### PR TITLE
Add x86 directory to ASM search path.

### DIFF
--- a/wscript
+++ b/wscript
@@ -343,7 +343,9 @@ def build(bld):
     if bld.env.CORE == 'true':
         sources = search_paths([os.path.join('src', 'core'),
                                 os.path.join('src', 'core', 'asm'),
-                                os.path.join('src', 'core', 'asm', 'x86')])
+                                os.path.join('src', 'core', 'asm', 'x86'),
+                                os.path.join('src', 'core', 'asm', 'arm'),
+                                os.path.join('src', 'core', 'asm', 'ppc')])
 
         if bld.env.DEST_OS in ['win32', 'cygwin', 'msys', 'uwin'] and bld.env.AVISYNTH == 'true':
             sources += search_paths([os.path.join('src', 'avisynth')])


### PR DESCRIPTION
With the move to ARM, the new x86 asm directory was left out from the build process, resulting in a broken build.

This adds the directory back.

-- Adub
