### PR TITLE
Fix two warnings from gcc and clang

### DIFF
--- a/src/core/exprfilter.cpp
+++ b/src/core/exprfilter.cpp
@@ -473,7 +473,7 @@ static void VS_CC exprCreate(const VSMap *in, VSMap *out, void *userData, VSCore
                     || vi[0]->height != vi[i]->height)
                     throw std::runtime_error("All inputs must have the same number of planes and the same dimensions, subsampling included");
                 if ((vi[i]->format->bitsPerSample > 16 && vi[i]->format->sampleType == stInteger)
-                    || vi[i]->format->bitsPerSample != 32 && vi[i]->format->sampleType == stFloat)
+                    || (vi[i]->format->bitsPerSample != 32 && vi[i]->format->sampleType == stFloat))
                     throw std::runtime_error("Input clips must be 8-16 bit integer or 32 bit float format");
             }
         }

--- a/src/core/simplefilters.c
+++ b/src/core/simplefilters.c
@@ -2415,7 +2415,7 @@ static const VSFrameRef *VS_CC selectClipGetFrame(int n, int activationReason, v
         for (i = 0; i < d->numsrc; i++)
             vsapi->requestFrameFilter(n, d->src[i], frameCtx);
     } else if (activationReason == arAllFramesReady) {
-        int idx = (int) * frameData;
+        intptr_t idx = (intptr_t) * frameData;
 
         if (idx < 0) {
             int err;


### PR DESCRIPTION
gcc complained about the cast to int and clang complained about both.
