### PR TITLE
Plugin autoloading for Linux

### DIFF
--- a/src/core/vscore.h
+++ b/src/core/vscore.h
@@ -470,7 +470,7 @@ private:
     QMutex cacheLock;
 
     void registerFormats();
-    bool loadAllPluginsInPath(const QString &path);
+    bool loadAllPluginsInPath(const QString &path, const QString &filter);
 public:
     VSThreadPool *threadPool;
     MemoryUse *memory;


### PR DESCRIPTION
Read ~/.config/vapoursynth/vapoursynth.conf or
/etc/xdg/vapoursynth/vapoursynth.conf.

The default config file would look like this:
AutoloadSystemPluginDir=true
AutoloadUserPluginDir=true

; set at 'waf configure'
SystemPluginDir=$plugindir
; empty, thus not used
UserPluginDir=
