### PR TITLE
VDecimate: use the input frame count when parsing the ovr

### DIFF
--- a/src/filters/vivtc/vivtc.c
+++ b/src/filters/vivtc/vivtc.c
@@ -1048,7 +1048,7 @@ static void VS_CC vdecimateInit(VSMap *in, VSMap *out, void **instanceData, VSNo
         char err[80];
 
         vdm->ovr = NULL;
-        if (vdecimateLoadOVR(vdm->ovrfile, &vdm->ovr, vdm->cycle, vdm->vi.numFrames, err)) {
+        if (vdecimateLoadOVR(vdm->ovrfile, &vdm->ovr, vdm->cycle, vdm->inputNumFrames, err)) {
             free(vdm->bdiffs);
             free(vdm->vmi);
             vsapi->freeNode(vdm->node);


### PR DESCRIPTION
A silly bug that showed up when I tried to use it with an ovr from the real world.
