### PR TITLE
VFM: Fix value of VFMMatch property

### DIFF
--- a/src/filters/vivtc/vivtc.c
+++ b/src/filters/vivtc/vivtc.c
@@ -726,7 +726,7 @@ static const VSFrameRef *VS_CC vfmGetFrame(int n, int activationReason, void **i
         for (i = 0; i < 5; i++)
             vsapi->propSetInt(m, "VFMMics", mics[fxo[i]], paAppend);
         vsapi->propSetInt(m, "_Combed", mics[match] >= vfm->mi, paReplace);
-        vsapi->propSetInt(m, "VFMMatch", fxo[match], paReplace);
+        vsapi->propSetInt(m, "VFMMatch", match, paReplace);
         vsapi->propSetInt(m, "VFMSceneChange", sc, paReplace);
         return dst2;
     }


### PR DESCRIPTION
It was reporting the matches used for the two interlaced frames
in a cycle as "0" whether the field parameter was 0 or 1 (order=1
in both cases). TFM reports "n" when field is 0 and "p" when field
is 1.
