### PR TITLE
Add MIME type for vpy scripts

### DIFF
--- a/data/vapoursynth.xml
+++ b/data/vapoursynth.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="text/x-vpy">
+    <sub-class-of type="text/x-python"/>
+    <comment>VapourSynth script</comment>
+    <glob pattern="*.vpy"/>
+  </mime-type>
+</mime-info>

--- a/wscript
+++ b/wscript
@@ -143,6 +143,12 @@ features = [
         'func': check_true
     },
     {
+        'name': '--mime',
+        'desc': 'MIME types definitions',
+        'default': 'disable',
+        'func': check_true
+    },
+    {
         'name': '--examples',
         'desc': 'SDK examples',
         'default': 'disable',
@@ -221,7 +227,8 @@ _INSTALL_DIRS_LIST = [
     ('libdir',      '${PREFIX}/lib',                    'library files'),
     ('plugindir',   '${LIBDIR}/vapoursynth',            'plugins'),
     ('datadir',     '${PREFIX}/share',                  'data files'),
-    ('docdir',      '${DATADIR}/doc/vapoursynth',       'documentation files')
+    ('docdir',      '${DATADIR}/doc/vapoursynth',       'documentation files'),
+    ('mimedir',     '${DATADIR}/mime/packages',         'mimetype definitions')
 ]
 
 def options(opt):

--- a/wscript_build.py
+++ b/wscript_build.py
@@ -122,6 +122,10 @@ def build(ctx):
             source = os.path.join('doc', 'conf.py'),
             install_path = ctx.env.DOCDIR)
 
+    def _install_mime():
+        ctx.install_files(ctx.env.MIMEDIR,
+                          [os.path.join('data', 'vapoursynth.xml')])
+
     if ctx.dependency_satisfied('vapoursynth'):
         _build_core()
 
@@ -135,3 +139,6 @@ def build(ctx):
 
     if ctx.dependency_satisfied('docs'):
         _build_docs()
+
+    if ctx.dependency_satisfied('mime'):
+        _install_mime()


### PR DESCRIPTION
Added a custom mimetype to make file association with editors possible on Linux. On Arch Linux, these go in /usr/share/mime/packages, I'm not sure about other distros. It is disabled by default.
