### PR TITLE
Export Frame Data to Python

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -20,7 +20,7 @@
 cimport vapoursynth
 cimport cython.parallel
 from cython cimport view
-from libc.stdint cimport intptr_t, uint16_t, uint32_t, uint64_t
+from libc.stdint cimport intptr_t, uint16_t, uint32_t
 from cpython.ref cimport Py_INCREF, Py_DECREF
 import os
 import ctypes
@@ -700,8 +700,8 @@ cdef class VideoFrame(object):
                 return <uint16_t[:width, :height]> (<uint16_t*>d)
             elif self.format.bytes_per_sample == 4:
                 return <uint32_t[:width, :height]> (<uint32_t*>d)
-            elif self.format.bytes_per_sample == 8:
-                return <uint64_t[:width, :height]> (<uint64_t*>d)
+        elif self.format.sample_type == stFloat:
+            return <float[:width, :height]> (<float*>d)
         return None
 
     def get_write_ptr(self, int plane):
@@ -730,8 +730,8 @@ cdef class VideoFrame(object):
                 return <uint16_t[:width, :height]> (<uint16_t*>d)
             elif self.format.bytes_per_sample == 4:
                 return <uint32_t[:width, :height]> (<uint32_t*>d)
-            elif self.format.bytes_per_sample == 8:
-                return <uint64_t[:width, :height]> (<uint64_t*>d)
+        elif self.format.sample_type == stFloat:
+            return <float[:width, :height]> (<float*>d)
         return None
 
     def get_stride(self, int plane):


### PR DESCRIPTION
get_read_frame and get_write_frame exports frame data in a Python
friendly way. A nice clean solution to #14 that doesn't require any new dependencies.

Uses Cython's [Typed Memoryviews](http://docs.cython.org/src/userguide/memoryviews.html) which usesthe  [PEP3118](http://legacy.python.org/dev/peps/pep-3118/) buffer protocol. This
allows the functions to be used as inputs into other libraries which
supports the buffer protocol, for example numpy without a memory copy.

Example:

``` python
import vapoursynth as vs
import numpy as np
core = vs.get_core()
clip = core.std.BlankClip(color=[128,0,0])
fr = clip.get_frame(0)
mem = fr.get_read_frame(0)
#Access pixel x,y = mem[x,y] or mem[x][y]
p = mem[0,0] #p = 128 mem[0][0] also works
#create numpy array using mem as the data
import numpy as np
np.asarray(mem)

#Make clip Bright Red
def mod_frame(n, f):
    fout = f.copy()
    data = fout.get_write_frame(0)
    for x, row in enumerate(data):
        for y, value in enumerate(row):
            data[x,y] = 255
    return fout

out = core.std.ModifyFrame(clip,clip, selector=mod_frame)
out.set_output()
```
