### PR TITLE
Allow scripts to know if they are running under vapoursynth

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1474,6 +1474,8 @@ cdef public api int vpy_evaluateScript(VPYScriptExport *se, const char *script, 
                     orig_path = os.getcwd()
                     os.chdir(os.path.dirname(abspath))
 
+            evaldict['__name__'] = "__vapoursynth__"
+            
             if se.errstr:
                 errstr = <bytes>se.errstr
                 se.errstr = NULL


### PR DESCRIPTION
Allows vapoursynth scripts to know if they are being run under vapoursynth, python or as a module.

This is based of the typical idiom that is used by python scripts when testing to see if itself is being executed directly or being imported from another script.

I find this useful as I tend to write scripts with functions so I can import them into bigger scripts but can also be run using the vsscript api like vspipe without modifying the code each time.

to use:

``` Python
if __name__ == "__vapoursynth__":
    #Script is being run under vapoursynth
    clip.set_output()
elif __name__ == "__main__":
    #Script has been called by Python
    print(clip)
```
