### PR TITLE
Fix Broken Python Data Export

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -690,9 +690,11 @@ cdef class VideoFrame(object):
             raise IndexError('Specified plane index out of range')
         cdef const uint8_t *d = self.funcs.getReadPtr(self.constf, plane)
         stride = self.get_stride(plane) // self.format.bytes_per_sample
+        width = self.width
         height = self.height
         if plane is not 0:
             height >>= self.format.subsampling_h
+            width >>= self.format.subsampling_w
         array = None
         if self.format.sample_type == stInteger:
             if self.format.bytes_per_sample == 1:
@@ -704,7 +706,7 @@ cdef class VideoFrame(object):
         elif self.format.sample_type == stFloat:
             array = <float[:height, :stride]> (<float*>d)
         if array is not None:
-            return array[:height, :self.width]
+            return array[:height, :width]
         return None
 
     def get_write_ptr(self, int plane):
@@ -722,9 +724,11 @@ cdef class VideoFrame(object):
             raise IndexError('Specified plane index out of range')
         cdef uint8_t *d = self.funcs.getWritePtr(self.f, plane)
         stride = self.get_stride(plane) // self.format.bytes_per_sample
+        width = self.width
         height = self.height
         if plane is not 0:
             height >>= self.format.subsampling_h
+            width >>= self.format.subsampling_w
         array = None
         if self.format.sample_type == stInteger:
             if self.format.bytes_per_sample == 1:
@@ -736,7 +740,7 @@ cdef class VideoFrame(object):
         elif self.format.sample_type == stFloat:
             array = <float[:height, :stride]> (<float*>d)
         if array is not None:
-            return array[:height, :self.width]
+            return array[:height, :width]
         return None
 
     def get_stride(self, int plane):


### PR DESCRIPTION
After doing some more testing on the get_read/write_array functions I discovered that they were not correctly representing the layout in memory.

Changes:

Accessing pixel at (X,Y) is now accessed by `array[y,x]` not `array[x,y]` (the pixels in each row are contiguous in memory whereas the column data is strided)

The functions now return a slice of the view and now doesn't expose the padded values from the stride. This shouldn't introduce a copy.
