### PR TITLE
use diagnostic pragma to silence GCC's -Wunused-but-set-variable warning...

### DIFF
--- a/src/filters/removegrain/removegrainvs.cpp
+++ b/src/filters/removegrain/removegrainvs.cpp
@@ -14,6 +14,8 @@ http://sam.zoy.org/wtfpl/COPYING for more details.
 
 *Tab=3***********************************************************************/
 
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+
 #include "shared.h"
 
 #ifdef VS_TARGET_CPU_X86


### PR DESCRIPTION
... in removegrainvs.cpp
