### PR TITLE
Fix assert in setFilterError.

### DIFF
--- a/src/core/vsapi.cpp
+++ b/src/core/vsapi.cpp
@@ -192,7 +192,7 @@ static const char *VS_CC getError(const VSMap *map) {
 }
 
 static void VS_CC setFilterError(const char *errorMessage, VSFrameContext *context) {
-    assert(errorMessage && errorMessage);
+    assert(errorMessage && context);
     context->ctx->setError(errorMessage);
 }
 


### PR DESCRIPTION
I assume the assert in setFilterError was not supposed to have errorMessage on both sides of the and.
