### PR TITLE
Move vapoursynth manpage to section 3 (libs)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -215,7 +215,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'vapoursynth', 'VapourSynth Documentation',
-     ['Fredrik Mellbin'], 1),
+     ['Fredrik Mellbin'], 3),
     ('vspipe', 'vspipe', 'pipe output of a VapourSynth script',
      ['Fredrik Mellbin'], 1)
 ]


### PR DESCRIPTION
Section 1 is for executable programs and commands.
