### PR TITLE
G++ gives this error since GCC version 4.1:

### DIFF
--- a/src/core/vscore.h
+++ b/src/core/vscore.h
@@ -499,7 +499,7 @@ private:
     void startInternal(const PFrameContext &context);
     void spawnThread();
     static void runTasks(VSThreadPool *owner, std::atomic<bool> &stop);
-    static bool VSThreadPool::taskCmp(const PFrameContext &a, const PFrameContext &b);
+    static bool taskCmp(const PFrameContext &a, const PFrameContext &b);
 public:
     VSThreadPool(VSCore *core, int threads);
     ~VSThreadPool();


### PR DESCRIPTION
In file included from src/core/cachefilter.h:24:0,
                 from src/core/cachefilter.cpp:21:
src/core/vscore.h:502:17: error: extra qualification 'VSThreadPool::' on member 'taskCmp' [-fpermissive]