### PR TITLE
Fix crash on VideoNode.__add__ method

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -929,10 +929,10 @@ cdef class VideoNode(object):
         if d.error:
             raise Error(d.error)
             
-    def __add__(self, other):
-        if not isinstance(other, VideoNode):
-            raise TypeError('Only clips can be spliced')
-        return (<VideoNode>self).core.std.Splice(clips=[self, other])
+    def __add__(x, y):
+        if not isinstance(x, VideoNode) or not isinstance(y, VideoNode):
+            return NotImplemented
+        return (<VideoNode>x).core.std.Splice(clips=[x, y])
 
     def __mul__(a, b):
         if isinstance(a, VideoNode):


### PR DESCRIPTION
We've to check for both arguments since `__add__` is also one of those Cython special methods where the first argument is not guaranteed to be an instance of the class.
Also, `NotImplemented` is the appropriate return value for unsupported operand types.