### PR TITLE
Make sure Python Versions older than 3.5 still work after #263

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -29,6 +29,9 @@ import traceback
 import gc
 import sys
 import inspect
+
+# Ensure that the import doesn't fail
+# if typing is not available on the python installation.
 try:
     import typing
 except ImportError as e:


### PR DESCRIPTION
Additionally I refactored out the shared code in the `VideoNode.set_output`, `get_output`, `clear_output` and `clear_outputs`.

I can remove it, if you want.