### PR TITLE
Actually add the 'name' description of the plugin

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1356,9 +1356,12 @@ cdef Plugin createPlugin(VSPlugin *plugin, str namespace, const VSAPI *funcs, Co
     instance.funcs = funcs
     instance.injected_arg = None
     instance.namespace = namespace
-    
-    instance.__doc__ = list(core.get_plugins().values())[0]['name']
-    
+
+    for plugin_dict in core.get_plugins().values():
+        if plugin_dict['namespace'] == namespace:
+            instance.__doc__ = plugin_dict['name']
+            break
+
     return instance
 
 cdef class Function(object):


### PR DESCRIPTION
Previously it just took the description of the first plugin found.

Unfortunately, I couldn't find anything similar to a "namespace to identifier"/"get identifier from plugin"/"whatever" function in the public API (read: too lazy to look for thoroughly), so I did an extra loop through the available plugins. Otherwise, a simple `core.get_plugins()[identifier_string_or_something]['name']` would have been enough.