### PR TITLE
Let VideoProps behave like a dict

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -784,7 +784,7 @@ cdef class VideoProps(object):
         if 0 < len(args) < 2:
             args = args[0]
             if not isinstance(args, dict):
-                args = dict(args[0])
+                args = dict(args)
         elif len(args) > 1:
             raise TypeError("update takes 1 positional argument but %d was given" % len(args))
         else:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -23,12 +23,14 @@ from cython cimport view
 from libc.stdint cimport intptr_t, uint16_t, uint32_t
 from cpython.ref cimport Py_INCREF, Py_DECREF
 import os
+import abc
 import ctypes
 import threading
 import traceback
 import gc
 import sys
 import inspect
+from collections.abc import Mapping
 
 # Ensure that the import doesn't fail
 # if typing is not available on the python installation.
@@ -615,8 +617,14 @@ cdef class VideoProps(object):
 
     def __dealloc__(self):
         self.funcs.freeFrame(self.constf)
+        
+    def __contains__(self, name):
+        cdef const VSMap *m = self.funcs.getFramePropsRO(self.constf)
+        cdef bytes b = name.encode('utf-8')
+        cdef int numelem = self.funcs.propNumElements(m, b)
+        return numelem > 0
 
-    def __getattr__(self, name):
+    def __getitem__(self, name):
         cdef const VSMap *m = self.funcs.getFramePropsRO(self.constf)
         cdef bytes b = name.encode('utf-8')
         cdef list ol = []
@@ -657,7 +665,7 @@ cdef class VideoProps(object):
         else:
             return ol
 
-    def __setattr__(self, name, value):
+    def __setitem__(self, name, value):
         if self.readonly:
             raise Error('Cannot delete properties of a read only object')
         cdef VSMap *m = self.funcs.getFramePropsRW(self.f)
@@ -706,20 +714,109 @@ cdef class VideoProps(object):
             self.__delattr__(name)
             raise
 
-    def __delattr__(self, name):
+    def __delitem__(self, name):
         if self.readonly:
             raise Error('Cannot delete properties of a read only object')
         cdef VSMap *m = self.funcs.getFramePropsRW(self.f)
         cdef bytes b = name.encode('utf-8')
         self.funcs.propDeleteKey(m, b)
+        
+    def __setattr__(self, name, value):
+        self[name] = value
+        
+    def __delattr__(self, name):
+        del self[name]
+    
+    # Only the methods __getattr__ and keys are required for the support of
+    #     >>> dict(frame.props)
+    # this can be shown at Objects/dictobject.c:static int dict_merge(PyObject *, PyObject *, int)
+    # in the generic code path.
+    
+    def __getattr__(self, name):
+        try:
+           return self[name]
+        except KeyError as e:
+           raise AttributeError from e
 
-    def __dir__(self):
+    def keys(self):
         cdef const VSMap *m = self.funcs.getFramePropsRO(self.constf)
         cdef int numkeys = self.funcs.propNumKeys(m)
-        attrs = []
         for i in range(numkeys):
-            attrs.append(self.funcs.propGetKey(m, i).decode('utf-8'))
-        return attrs
+            yield self.funcs.propGetKey(m, i).decode('utf-8')
+            
+    def values(self):
+        for key in self.keys():
+            yield self[key]
+            
+    def items(self):
+        yield from zip(self.keys(), self.values())
+        
+    def get(self, key, default=None):
+        if key in self:
+            return self[key]
+        return default
+        
+    def pop(self, key, default=None):
+        if key in self:
+            value = self[key]
+            del self[key]
+            return value
+        return default
+        
+    def popitem(self):
+        if len(self) <= 0:
+            raise KeyError
+        key = next(self.keys())
+        return (key, self.pop(key))
+        
+    def setdefault(self, key, default=0):
+        """
+        Behaves like the dict.setdefault function but since setting None is not supported,
+        it will default to zero.
+        """
+        if key not in self:
+            self[key] = default
+        return self[key]
+        
+    def update(self, *args, **kwargs):
+        # This code converts the positional argument into a dict which we then can update
+        # with the kwargs.
+        if 0 < len(args) < 2:
+            args = args[0]
+            if not isinstance(args, dict):
+                args = dict(args[0])
+        elif len(args) > 1:
+            raise TypeError("update takes 1 positional argument but %d was given" % len(args))
+        else:
+            args = {}
+            
+        args.update(kwargs)
+        
+        for k, v in args.items():
+            self[k] = v
+            
+    def clear(self):
+        for _ in range(len(self)):
+            self.popitem()
+            
+    def copy(self):
+        """
+        We can't copy VideoFrames directly, so we're just gonna return a real dictionary.
+        """
+        return dict(self)
+        
+    def __iter__(self):
+        yield from self.keys()
+        
+    def __len__(self):
+        cdef const VSMap *m = self.funcs.getFramePropsRO(self.constf)
+        return self.funcs.propNumKeys(m)
+            
+    def __dir__(self):
+        return super(VideoProps, self).__dir__() + list(self.keys())
+        
+    def __repr__(self):
+        return "<vapoursynth.VideoProps %r>" % dict(self)
 
 cdef VideoProps createVideoProps(VideoFrame f):
     cdef VideoProps instance = VideoProps.__new__(VideoProps)
@@ -733,6 +830,10 @@ cdef VideoProps createVideoProps(VideoFrame f):
         instance.f = <VSFrameRef *>instance.constf
     return instance
 
+# Make sure the VideoProps-Object quacks like a Mapping.
+Mapping.register(VideoProps)
+
+    
 cdef class VideoFrame(object):
     cdef const VSFrameRef *constf
     cdef VSFrameRef *f


### PR DESCRIPTION
vapoursynth.VideoProps now behaves like a dictionary while keeping backwards compatibility.

There are two changes worth documenting:

1. The default-parameter of VideoProps.setdefault will be zero by default instead of None as the FrameProp-Structure does not support None-Types
2. VideoProps.copy will return a PyDict-Object instead a copy of itself.

Let's paste examples here (pasted from multiple IPython sessions):
Also serves as a simple test :P

```python
In [1]: import vapoursynth; c=vapoursynth.get_core(); bc = c.std.BlankClip(); f=bc.get_frame(0); f2=f.copy()

In [3]: dict(f2.props)
Out[3]: {'_DurationDen': 24, '_DurationNum': 1}

In [4]: f2.props._DurationDen
Out[4]: 24

In [5]: f2.props['_DurationNum']
Out[5]: 1

In [6]: f2.props['_DurationNum'] = 2

In [6]: del f2.props['_DurationDen']

In [7]: f2.props
Out[7]: <vapoursynth.VideoProps {'_DurationNum': 1}>

In [7]: dict(f2.props)
Out[7]: {'_DurationDen': 24, '_DurationNum': 2}

In [8]: f2.props.get("_Matrix")

In [9]: f2.props.get("_Matrix", "709")
Out[9]: '709'

In [10]: f2.props.keys()
Out[10]: <generator at 0x12d11c06598>

In [11]: tuple(f2.props.keys())
Out[11]: ('_DurationDen', '_DurationNum')

In [12]: tuple(f2.props.values())
Out[12]: (24, 2)

In [13]: tuple(f2.props.items())
Out[13]: (('_DurationDen', 24), ('_DurationNum', 2))

In [14]: tuple(f2.props)
Out[14]: ('_DurationDen', '_DurationNum')

In [15]: del f2.props._DurationDen

In [16]: f2.props._DurationDen = 24

In [20]: f2.props
Out[20]: <vapoursynth.VideoProps {'_DurationDen': 24, '_DurationNum': 2}>

In [22]: f2.props.setdefault('_DurationDen', 12)
Out[22]: 24

In [23]: f2.props.setdefault('_DurationDen2', 12)
Out[23]: 12

In [25]: f2.props
Out[25]: <vapoursynth.VideoProps {'_DurationDen': 24, '_DurationDen2': 12, '_DurationNum': 2}>

In [27]: f2.props.clear()

In [29]: f2.props
Out[29]: <vapoursynth.VideoProps {}>

In [2]: f2.props.clear()

In [3]: f2.props.update(f.props)

In [5]: f2.props
Out[5]: <vapoursynth.VideoProps {'_DurationDen': 24, '_DurationNum': 1}>

In [10]: len(f2.props)
Out[10]: 2
```