### PR TITLE
Add proxy object for the Core class.

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1388,6 +1388,7 @@ cdef class Core(object):
         s += '\tAdd Cache: ' + str(self.add_cache) + '\n'
         s += '\tAccept Lowercase: ' + str(self.accept_lowercase) + '\n'
         return s
+        
 
 cdef Core createCore():
     cdef Core instance = Core.__new__(Core)
@@ -1424,6 +1425,31 @@ def get_core(threads = None, add_cache = None, accept_lowercase = None):
         if accept_lowercase is not None:
             ret_core.accept_lowercase = accept_lowercase
     return ret_core
+        
+cdef class _CoreProxy(object):
+
+    def __init__(self):
+        raise Error('Class cannot be instantiated directly')
+    
+    @property
+    def core(self):
+        return get_core()
+        
+    def __dir__(self):
+        d = dir(self.core)
+        if 'core' not in d:
+            d += ['core']
+            
+        return d
+        
+    def __getattr__(self, name):
+        return getattr(self.core, name)
+        
+    def __setattr__(self, name, value):
+        setattr(self.core, name, value)
+    
+core = _CoreProxy.__new__(_CoreProxy)
+    
 
 cdef object vsscript_get_core_internal(int environment_id):
     global _cores

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1388,7 +1388,6 @@ cdef class Core(object):
         s += '\tAdd Cache: ' + str(self.add_cache) + '\n'
         s += '\tAccept Lowercase: ' + str(self.accept_lowercase) + '\n'
         return s
-        
 
 cdef Core createCore():
     cdef Core instance = Core.__new__(Core)
@@ -1425,7 +1424,13 @@ def get_core(threads = None, add_cache = None, accept_lowercase = None):
         if accept_lowercase is not None:
             ret_core.accept_lowercase = accept_lowercase
     return ret_core
-        
+    
+cdef object vsscript_get_core_internal(int environment_id):
+    global _cores
+    if not environment_id in _cores:
+        _cores[environment_id] = createCore()
+    return _cores[environment_id]
+    
 cdef class _CoreProxy(object):
 
     def __init__(self):
@@ -1450,12 +1455,6 @@ cdef class _CoreProxy(object):
     
 core = _CoreProxy.__new__(_CoreProxy)
     
-
-cdef object vsscript_get_core_internal(int environment_id):
-    global _cores
-    if not environment_id in _cores:
-        _cores[environment_id] = createCore()
-    return _cores[environment_id]
 
 cdef class Plugin(object):
     cdef Core core


### PR DESCRIPTION
At the moment, most VapourSynth Libraries are currently required to do essentially this:

```python
import vapoursynth

def useful_function(arg1=240):
    core = vapoursynth.get_core()
    return core.std.BlankClip(length=arg1)
```

This change reduces the redundancy of calling `get_core` for every function by adding a simple proxy-object which will resolve the current Core-instance on attribute access.

The code above would change into

```python
from vapoursynth import core

def useful_function(arg1=240):
    return core.std.BlankClip(length=arg1)
```