### PR TITLE
Use VAPOURSYNTH_API_VERSION from the header file

### DIFF
--- a/src/cython/vapoursynth.pxd
+++ b/src/cython/vapoursynth.pxd
@@ -21,6 +21,11 @@
 from libc.stdint cimport uint8_t, uint32_t, int64_t, uintptr_t
 
 cdef extern from "include/VapourSynth.h" nogil:
+    enum:
+        VAPOURSYNTH_API_MAJOR
+        VAPOURSYNTH_API_MINOR
+        VAPOURSYNTH_API_VERSION
+
     ctypedef struct VSFrameRef:
         pass
     ctypedef struct VSNodeRef:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -48,7 +48,6 @@ _stored_output = {}
 _core = None
 _message_handler = None
 cdef const VSAPI *_vsapi = NULL
-cdef int _api_version = 0x30004
 
 
 # Create an empty list whose instance will represent a not passed value.
@@ -134,7 +133,7 @@ cdef void __stdcall message_handler_wrapper(int msgType, const char *msg, void *
 def set_message_handler(handler_func):
     cdef const VSAPI *funcs
     global _message_handler
-    funcs = getVapourSynthAPI(_api_version)
+    funcs = getVapourSynthAPI(VAPOURSYNTH_API_VERSION)
     if funcs == NULL:
         raise Error('Failed to obtain VapourSynth API pointer. Is the Python module and loaded core library mismatched?')
     if handler_func is None:
@@ -1391,7 +1390,7 @@ cdef class Core(object):
 
 cdef Core createCore():
     cdef Core instance = Core.__new__(Core)
-    instance.funcs = getVapourSynthAPI(_api_version)
+    instance.funcs = getVapourSynthAPI(VAPOURSYNTH_API_VERSION)
     if instance.funcs == NULL:
         raise Error('Failed to obtain VapourSynth API pointer. System does not support SSE2 or is the Python module and loaded core library mismatched?')
     instance.core = instance.funcs.createCore(0)
@@ -1849,7 +1848,7 @@ cdef public api VSCore *vpy_getCore(VPYScriptExport *se) nogil:
 cdef public api const VSAPI *vpy_getVSApi() nogil:
     global _vsapi
     if _vsapi == NULL:
-        _vsapi = getVapourSynthAPI(_api_version)
+        _vsapi = getVapourSynthAPI(VAPOURSYNTH_API_VERSION)
     return _vsapi
 
 cdef public api int vpy_getVariable(VPYScriptExport *se, const char *name, VSMap *dst) nogil:


### PR DESCRIPTION
This adds literally no new functionality to the python module; it basically just help to keep track of the version API in a simpler manner.