### PR TITLE
Use a Fraction instance for the FPS

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1217,12 +1217,7 @@ cdef class VideoNode(object):
 
         s += '\tNum Frames: ' + str(self.num_frames) + '\n'
 
-        if not self.fps_num or not self.fps_den:
-            s += '\tFPS Num: dynamic\n'
-            s += '\tFPS Den: dynamic\n'
-        else:
-            s += '\tFPS Num: ' + str(self.fps_num) + '\n'
-            s += '\tFPS Den: ' + str(self.fps_den) + '\n'
+        s += <str>f"\tFPS: {self.fps or 'dynamic'}\n"
 
         if self.flags:
             s += '\tFlags:'

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -30,6 +30,7 @@ import gc
 import sys
 import inspect
 from collections.abc import Mapping
+from fractions import Fraction
 
 # Ensure that the import doesn't fail
 # if typing is not available on the python installation.
@@ -986,6 +987,7 @@ cdef class VideoNode(object):
     cdef readonly int num_frames
     cdef readonly int64_t fps_num
     cdef readonly int64_t fps_den
+    cdef readonly object fps
     cdef readonly int flags
 
     cdef object __weakref__
@@ -1253,6 +1255,11 @@ cdef VideoNode createVideoNode(VSNodeRef *node, const VSAPI *funcs, Core core):
     instance.num_frames = instance.vi.numFrames
     instance.fps_num = <int64_t>instance.vi.fpsNum
     instance.fps_den = <int64_t>instance.vi.fpsDen
+    if instance.vi.fpsDen:
+        instance.fps = Fraction(
+            <int64_t> instance.vi.fpsNum, <int64_t> instance.vi.fpsDen)
+    else:
+        instance.fps = Fraction(0, 1)
     instance.flags = instance.vi.flags
     return instance
 


### PR DESCRIPTION
The idea into this is to deprecate/remove the `fps_num`/`fps_den` attributes of `VideoNode` and use this instead. If anyone needs the FPS values at the C level or something they could simply get them from the `vi` member.

Btw, you're free to ignore the 2nd commit if it's not that representative as a string for the `__str__` method.