### PR TITLE
Fixing exception in construct_signature

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -111,7 +111,7 @@ def construct_signature(signature, injected=None):
     )
     
     if injected:
-        params[0] = params[0].replace(default=injected)
+        del params[0]
     
     return inspect.Signature(tuple(params), return_annotation=vapoursynth.VideoNode)
     


### PR DESCRIPTION
Fixes an exception when a clip is injected in cases where there are more than one required parameter.

To reproduce the exception (R37):

```python
>>> from vapoursynth import core
>>> core.std.BlankClip().text.Text.__signature__
Traceback (most recent call last):
  File "<pyshell#2>", line 1, in <module>
    core.std.BlankClip().text.Text.__signature__
  File "src\cython\vapoursynth.pyx", line 1529, in vapoursynth.Function.__signature__.__get__ (src\cython\vapoursynth.c:31983)
  File "src\cython\vapoursynth.pyx", line 117, in vapoursynth.construct_signature (src\cython\vapoursynth.c:4752)
  File "C:\Users\stuxc\AppData\Local\Programs\Python\Python36\lib\inspect.py", line 2713, in __init__
    raise ValueError(msg)
ValueError: non-default argument follows default argument
```

This solution works by removing the first argument when an injected clip is present.

PS:
Unfortunately, the VS2017-Installer crashed while installing refusing to perform the install the installer again. 