### PR TITLE
Improve setup.py to use system vapoursynth.dll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ ltmain.sh
 missing
 vspipe
 *.pc
+
+dist/
+.eggs
+*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ vspipe
 dist/
 .eggs
 *.egg-info/
+
+zimg/
+AviSynthPlus

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ recursive-include test *
 recursive-include src/cython *.pyx *.pxd
 recursive-include include *.h *.asm
 recursive-exclude include/cython *
+
+global-exclude *.dll

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include COPYING.LGPLv2.1
+
+recursive-include test *
+recursive-include src/cython *.pyx *.pxd
+recursive-include include *.h *.asm
+recursive-exclude include/cython *

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ if is_win:
 
         return value
 
-    library_dirs.append(join(query(winreg.HKEY_LOCAL_MACHINE, REGISTRY_PATH, REGISTRY_KEY), "sdk", lib_suffix))
+    base_dir = query(winreg.HKEY_LOCAL_MACHINE, REGISTRY_PATH, REGISTRY_KEY)
+    library_dirs.append(base_dir)
+    library_dirs.append(join(base_dir, "sdk", lib_suffix))
 
 
 setup(
@@ -48,7 +50,7 @@ setup(
     author = "Fredrik Mellbin",
     author_email = "fredrik.mellbin@gmail.com",
     license = "LGPL 2.1 or later",
-    version = "1.0.0",
+    version = "39",
     long_description = "A portable replacement for Avisynth",
     platforms = "All",
     ext_modules = [Extension("vapoursynth", [join("src", "cython", "vapoursynth.pyx")],

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
                              library_dirs = library_dirs,
                              include_dirs = [curdir, join("src", "cython")],
                              cython_c_in_temp = 1)],
-    setup_requires=[
+    install_requires=[
         'setuptools>=36.0',
         "Cython",
     ]

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
                              library_dirs = library_dirs,
                              include_dirs = [curdir, join("src", "cython")],
                              cython_c_in_temp = 1)],
-    install_requires=[
+    setup_requires=[
         'setuptools>=36.0',
         "Cython",
     ]

--- a/setup.py
+++ b/setup.py
@@ -36,10 +36,14 @@ if is_win:
                 winreg.CloseKey(reg_key)
 
         return value
-
-    base_dir = query(winreg.HKEY_LOCAL_MACHINE, REGISTRY_PATH, REGISTRY_KEY)
-    library_dirs.append(base_dir)
-    library_dirs.append(join(base_dir, "sdk", lib_suffix))
+    
+    try:
+        base_dir = query(winreg.HKEY_LOCAL_MACHINE, REGISTRY_PATH, REGISTRY_KEY)
+    except (IOError, FileNotFoundError):
+        pass
+    else:
+        library_dirs.append(base_dir)
+        library_dirs.append(join(base_dir, "sdk", lib_suffix))
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
                              include_dirs = [curdir, join("src", "cython")],
                              cython_c_in_temp = 1)],
     setup_requires=[
-        'setuptools>=18.0',
+        'setuptools>=36.0',
         "Cython",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
 from platform import architecture
-from os import curdir, pardir
+from os import curdir
 from os.path import join
-from distutils.core import setup
-from Cython.Distutils import Extension, build_ext
+from setuptools import setup, Extension
 
 is_win = (architecture()[1] == "WindowsPE")
 is_64 = (architecture()[0] == "64bit")
@@ -13,8 +12,33 @@ library_dirs = [curdir, "build"]
 if is_win:
     if is_64:
         library_dirs.append(join("msvc_project", "x64", "Release"))
+        lib_suffix = "lib64"
     else:
         library_dirs.append(join("msvc_project", "Release"))
+        lib_suffix = "lib32"
+
+    #
+    # This code detects the library directory by querying the Windows Registry
+    # for the current VapourSynth directory location.
+    #
+
+    import winreg
+    REGISTRY_PATH = r"SOFTWARE\VapourSynth"
+    REGISTRY_KEY = r"Path"
+
+    def query(hkey, path, key):
+        reg_key = None
+        try:
+            reg_key = winreg.OpenKey(hkey, path, 0, winreg.KEY_READ)
+            value, _ = winreg.QueryValueEx(reg_key, key)
+        finally:
+            if reg_key is not None:
+                winreg.CloseKey(reg_key)
+
+        return value
+
+    library_dirs.append(join(query(winreg.HKEY_LOCAL_MACHINE, REGISTRY_PATH, REGISTRY_KEY), "sdk", lib_suffix))
+
 
 setup(
     name = "VapourSynth",
@@ -27,10 +51,13 @@ setup(
     version = "1.0.0",
     long_description = "A portable replacement for Avisynth",
     platforms = "All",
-    cmdclass = {'build_ext': build_ext},
     ext_modules = [Extension("vapoursynth", [join("src", "cython", "vapoursynth.pyx")],
                              libraries = ["vapoursynth"],
                              library_dirs = library_dirs,
                              include_dirs = [curdir, join("src", "cython")],
-                             cython_c_in_temp = 1)]
+                             cython_c_in_temp = 1)],
+    setup_requires=[
+        'setuptools>=18.0',
+        "Cython",
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from platform import architecture
-from shutils import which
+from shutil import which
 from os import curdir
 from os.path import join, exists
 from setuptools import setup, Extension

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 
 from platform import architecture
+from shutils import which
 from os import curdir
-from os.path import join
+from os.path import join, exists
 from setuptools import setup, Extension
 
 is_win = (architecture()[1] == "WindowsPE")
 is_64 = (architecture()[0] == "64bit")
+
+extra_data = {}
 
 library_dirs = [curdir, "build"]
 if is_win:
@@ -45,7 +48,18 @@ if is_win:
         library_dirs.append(base_dir)
         library_dirs.append(join(base_dir, "sdk", lib_suffix))
 
-
+    for path in library_dirs:
+        dll_path = join(path, "VapourSynth.dll")
+        if exists(dll_path):
+            break
+    else:
+        dll_path = which("VapourSynth.dll")
+        if not which("VapourSynth.dll"):
+            print("Warning: Couldn't detect VapourSynth. Installation may fail.")
+            
+    if dll_path:
+        extra_data["package_data"] = [(r"Lib\site-packages", [dll_path])]
+        
 setup(
     name = "VapourSynth",
     description = "A frameserver for the 21st century",
@@ -65,5 +79,7 @@ setup(
     setup_requires=[
         'setuptools>=36.0',
         "Cython",
-    ]
+    ],
+    
+    **extra_data
 )


### PR DESCRIPTION
This Pull-Request improves the setup.py file to allow it to install via pip.

# How does it accomplish this?
This pull-request actually solves a related problem: Allowing the setup.py to detect the vapoursynth.dll installed by the installer.

The setup.py routine now try to locate the vapoursynth.dll using three ways:
1. vapoursynth.dll and vapoursynth.lib from `Release` or `x64/Release`
2. vapoursynth.dll and vapoursynth.lib from PATH
3. vapoursynth.dll and vapoursynth.lib located in the Registry

The located vapoursynth.dll-file will be copied to Lib\\site-packages during the installation and shipped in binary distributions of this package.

On linux there are no changes and no additional files except the module (and meta-data about the package) itself will be copied into site-packages. Linux based binary-distributions will not contain a vapoursynth.so file.

# Dependencies
This PR introduces a dependency to setuptools. Since setuptools is packaged with current python versions, this will likely not prove to be a problem.

Installing from source needs Visual Studio 2015. Alternatively you can install vapoursynth inside the Native VS2017 build shell of the desired architecture.

# Python distributions
The setup.py allows binary and source distributions to be compiled and uploaded to pypi. This section will address the state of both commands.

## Source distributions `sdist`
Using `python setup.py sdist`, a source distribution will be created that will create a `.tar.gz` (or using `--format=zip` a zip-file) containing the neccessary files to install the vapoursynth package by compiling.

This package will neither ship with a vapoursynth.lib nor with a vapoursynth.dll or any other compiled file.

## Wheels `bdist_wheel`
Using `python setup.py bdist_wheel`, you can create a binary distribution that can be installed without the compiling anything.

The wheel will ship with their own compiled version of `vapoursynth.dll`

Since no compilation is being done here, the pip-bug below does not apply when installing vapoursynth using a wheel.

## Instalation path
The setup will install both the vapoursynth.dll as well as the compiled cython module directly into site-packages. `pip` will remove both files when updating or removing the package.

## Release considerations
The `setup.py` file now contains the current release-number as its _major_ version. This allows packages dependent on VapourSynth to specify the minimum required version of vapoursynth inside their setup.py file. Make sure the version remains up-to-date to allow users to update and specify their vapoursynth installation using `pip`

Additionaly, the source distribution for vapoursynth as well as binary distributions for Windows x64, Windows x32, Linux x64 and Linux x32 should be uploaded to pypi.

# Where to go from here.
Since we can expect pip to be installed on all Windows systems, we can change the module-installation routine in the Windows installer to instead install a binary-wheel created by setup.py using the pip installation of the package. The binary-wheel can be included by the installer.

# Known Problems
Python 3.6 changed the way I/O is handled on Windows causing a bug on non-english Windows installations which is fixed here https://github.com/pypa/pip/pull/4486
Until this fix is shipped with a new release of pip,  change the code-page for the current command shell to UTF-8 by executing `chcp 65001`.  This is not neccessary when installing using a binary distribution.

# Afterword
Since I cannot foresee all build-environments this thing is possibly gonna run on, additional testing may be helpful.

# Additional things added in this PR
Added zimg and AviSynth+ to the .gitignore-file

# References to other issues
Implements #283 