### PR TITLE
Add a function to list all outputs

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -172,6 +172,12 @@ Classes and Functions
 
    Sets a function to handle all debug output and fatal errors. The function should have the form *handler(level, message)*,
    where level corresponds to the vapoursynth.mt constants. Passing *None* restores the default handler, which prints to stderr.
+
+.. py:function:: get_outputs()
+
+   Return a read-only mapping of all outputs registered on the current node.
+
+   The mapping will automatically update when a new output is registered.
    
 .. py:function:: get_output([index = 0])
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -31,6 +31,7 @@ import traceback
 import gc
 import sys
 import inspect
+from types import MappingProxyType
 from collections.abc import Iterable, Mapping
 from fractions import Fraction
 
@@ -169,6 +170,10 @@ def clear_output(int index = 0):
 def clear_outputs():
     cdef dict outputs = _get_output_dict("clear_outputs")
     outputs.clear()
+
+def get_outputs():
+    cdef dict outputs = _get_output_dict("get_outputs")
+    return MappingProxyType(outputs)
 
 def get_output(int index = 0):
     return _get_output_dict("get_output")[index]


### PR DESCRIPTION
Add a function to get a read-only mapping of all outputs.

Since I am using a `mappingproxy`, the mapping will automatically update when the internal output-dictionary changes.