### PR TITLE
Add easier way to register new formats.

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -442,6 +442,17 @@ Classes and Functions
 
       The number of planes the format has.
 
+   .. py:method:: replace(core=None, **kwargs)
+
+      Returns a new format with the given modifications.
+
+      The only supported attributes that can be replaced are `color_family`,
+      `sample_type`, `bits_per_sample`, `subsampling_w`, `subsampling_h`.
+
+      The optional `core`-parameter defines on which core the new format
+      should be registered. This is usually not needed and defaults
+      to the core of the current environment.
+
 .. py:class:: Plugin
 
    Plugin is a class that represents a loaded plugin and its namespace.

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -581,6 +581,9 @@ cdef class Format(object):
         vals.update(**kwargs)
         return core.register_format(**vals)
 
+    def __int__(self):
+        return self.id
+
     def __str__(self):
         return ('Format Descriptor\n'
                f'\tId: {self.id:d}\n'

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -566,6 +566,21 @@ cdef class Format(object):
     def __init__(self):
         raise Error('Class cannot be instantiated directly')
 
+    def _as_dict(self):
+        return {
+            'color_family': self.color_family,
+            'sample_type': self.sample_type,
+            'bits_per_sample': self.bits_per_sample,
+            'subsampling_w': self.subsampling_w,
+            'subsampling_h': self.subsampling_h
+        }
+
+    def replace(self, **kwargs):
+        core = kwargs.pop("core", None) or get_core()
+        vals = self._as_dict()
+        vals.update(**kwargs)
+        return core.register_format(**vals)
+
     def __str__(self):
         return ('Format Descriptor\n'
                f'\tId: {self.id:d}\n'


### PR DESCRIPTION
I thought, it would be awesome to have a method that can create a new Format based on a preexisting format.

Addtionionally:
* Implement `__int__` on `Format` to allow Format-objects to be passed into filters.