### PR TITLE
Remove limit on LibASS for Karaoke FX

### DIFF
--- a/src/filters/subtext/toutf8.c
+++ b/src/filters/subtext/toutf8.c
@@ -161,14 +161,6 @@ char *convertToUtf8(const char *file_name, const char *charset, int64_t *file_si
         return NULL;
     }
 
-    if (*file_size > 50 * 1024 * 1024) {
-        snprintf(error, error_size, "subtitle file size of %" PRId64 " bytes is unreasonably large.", *file_size);
-
-        fclose(f);
-
-        return NULL;
-    }
-
     if (fseeko(f, 0, SEEK_SET)) {
         snprintf(error, error_size, "failed to seek back to the beginning of the subtitle file: %s.", strerror(errno));
 


### PR DESCRIPTION
In a land far far away in a Kingdom ruled by Queen Merkel there was a drug called karaoke-fx. Using equipment like NyuFX people could create this drug. However, like all proper drugs, its effects diminish with prolonged use and as such needed more and more of this drug. This commit allows to enter ASS-Files larger than 50MiB.

A program should not assume sane users.