### PR TITLE
Add missing stddef header

### DIFF
--- a/src/core/simplefilters.c
+++ b/src/core/simplefilters.c
@@ -22,6 +22,7 @@
 #include "internalfilters.h"
 #include "filtershared.h"
 #include <stdlib.h>
+#include <stddef.h>
 #include <string.h>
 #include <stdio.h>
 #include <math.h>

--- a/src/core/transpose.c
+++ b/src/core/transpose.c
@@ -1,5 +1,6 @@
 #include "VSHelper.h"
 #include <stdint.h>
+#include <stddef.h>
 
 /* Add an offset in bytes to a typed pointer. */
 #define ADD_OFFSET(p, stride) ((p) + (stride) / (sizeof(*(p))))


### PR DESCRIPTION
ptrdiff_t added in e69e7859645388736cd6be6613670df6a1900024 requires
stddef.h at least with gcc.