### PR TITLE
Add missing stddef.h includes for ptrdiff_t

### DIFF
--- a/src/core/simplefilters.c
+++ b/src/core/simplefilters.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <float.h>
+#include <stddef.h>
 #ifdef VS_TARGET_CPU_X86
 #include <emmintrin.h>
 #endif

--- a/src/core/transpose.c
+++ b/src/core/transpose.c
@@ -1,5 +1,6 @@
 #include "VSHelper.h"
 #include <stdint.h>
+#include <stddef.h>
 
 /* Add an offset in bytes to a typed pointer. */
 #define ADD_OFFSET(p, stride) ((p) + (stride) / (sizeof(*(p))))


### PR DESCRIPTION
Otherwise fails to build.

---

Not sure why, maybe a newer gcc or glibc with cleaner headers?