### PR TITLE
Better reflection and improved compatibility with older VS-Wrapper versions regarding outputs.

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -188,7 +188,7 @@ Classes and Functions
 .. py:function:: get_output([index = 0])
 
    Get a previously set output node. Throws an error if the index hasn't been
-   set.
+   set. Will return an AlphaOutputNode when *alpha* was passed to *VideoNode.set_output*.
 
 .. py:function:: clear_output([index = 0])
 
@@ -362,6 +362,19 @@ Classes and Functions
       YUV4MPEG2 headers will be added when *y4m* is true.
       The current progress can be reported by passing a callback function of the form *func(current_frame, total_frames)* to *progress_update*.
       The *prefetch* argument is only for debugging purposes and should never need to be changed.
+      
+      
+.. py:class:: AlphaOutputNode
+
+      This class is returned by get_output. If a *alpha* was passed to set_output, *get_output* will return an object of this type.
+      
+      .. py:attribute:: clip
+      
+         A VideoNode-instance containing the color planes.
+         
+      .. py:attribute:: alpha
+      
+         A VideoNode-instance containing the alpha planes.
       
 .. py:class:: VideoFrame
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -188,7 +188,7 @@ Classes and Functions
 .. py:function:: get_output([index = 0])
 
    Get a previously set output node. Throws an error if the index hasn't been
-   set. Will return an AlphaOutputNode when *alpha* was passed to *VideoNode.set_output*.
+   set. Will return an AlphaOutputTuple when *alpha* was passed to *VideoNode.set_output*.
 
 .. py:function:: clear_output([index = 0])
 
@@ -364,7 +364,7 @@ Classes and Functions
       The *prefetch* argument is only for debugging purposes and should never need to be changed.
       
       
-.. py:class:: AlphaOutputNode
+.. py:class:: AlphaOutputTuple
 
       This class is returned by get_output. If a *alpha* was passed to set_output, *get_output* will return an object of this type.
       

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -32,6 +32,7 @@ import gc
 import sys
 import inspect
 from types import MappingProxyType
+from collections import namedtuple
 from collections.abc import Iterable, Mapping
 from fractions import Fraction
 
@@ -56,6 +57,8 @@ cdef const VSAPI *_vsapi = NULL
 
 # Create an empty list whose instance will represent a not passed value.
 _EMPTY = []
+
+AlphaOutputNode = namedtuple("AlphaOutputNode", "clip alpha")
 
 def _construct_parameter(signature):
     name,type,*opt = signature.split(":")
@@ -1144,7 +1147,8 @@ cdef class VideoNode(object):
 
     def set_output(self, int index = 0, VideoNode alpha = None):
         cdef const VSFormat *aformat = NULL
-        if (alpha is not None):
+        clip = self
+        if alpha is not None:
             if (self.vi.width != alpha.vi.width) or (self.vi.height != alpha.vi.height):
                 raise Error('Alpha clip dimensions must match the main video')
             if (self.num_frames != alpha.num_frames):
@@ -1154,8 +1158,10 @@ cdef class VideoNode(object):
                     raise Error('Alpha clip format must match the main video')
             elif (self.vi.format) or (alpha.vi.format):
                 raise Error('Format must be either known or unknown for both alpha and main clip')
+            
+            clip = AlphaOutputNode(self, alpha)
 
-        _get_output_dict("set_output")[index] = (self, alpha)
+        _get_output_dict("set_output")[index] = clip
 
     def output(self, object fileobj not None, bint y4m = False, object progress_update = None, int prefetch = 0):
         if prefetch < 1:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -58,7 +58,7 @@ cdef const VSAPI *_vsapi = NULL
 # Create an empty list whose instance will represent a not passed value.
 _EMPTY = []
 
-AlphaOutputNode = namedtuple("AlphaOutputNode", "clip alpha")
+AlphaOutputTuple = namedtuple("AlphaOutputTuple", "clip alpha")
 
 def _construct_parameter(signature):
     name,type,*opt = signature.split(":")
@@ -1159,7 +1159,7 @@ cdef class VideoNode(object):
             elif (self.vi.format) or (alpha.vi.format):
                 raise Error('Format must be either known or unknown for both alpha and main clip')
             
-            clip = AlphaOutputNode(self, alpha)
+            clip = AlphaOutputTuple(self, alpha)
 
         _get_output_dict("set_output")[index] = clip
 


### PR DESCRIPTION
I think it is a bad idea to always store `(clip, alpha)`-tuples, even if `alpha` is not passed to `set_output`.

This is a breaking change and I think we make it compatible again. 