### PR TITLE
Attempt to allocate frame buffers with large pages.

### DIFF
--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -279,6 +279,9 @@ static bool isWindowsLargePageBroken() {
         return false;
 
     static const bool supported = []() -> bool {
+        if (getenv("VS_NO_LARGE_PAGES"))
+            return false;
+
 #ifdef VS_TARGET_OS_WINDOWS
         HANDLE token = INVALID_HANDLE_VALUE;
         TOKEN_PRIVILEGES priv = {};

--- a/src/core/vscore.h
+++ b/src/core/vscore.h
@@ -333,6 +333,11 @@ public:
 
 class MemoryUse {
 private:
+    struct BlockHeader {
+        size_t size; // Size of memory allocation, minus header and padding.
+    };
+    static_assert(sizeof(BlockHeader) <= 16, "block header too large");
+
     std::atomic<size_t> used;
     size_t maxMemoryUse;
     bool freeOnZero;
@@ -341,6 +346,9 @@ private:
     size_t maxUnusedBufferSize;
     std::minstd_rand generator;
     std::mutex mutex;
+
+    void *allocateMemory(size_t bytes) const;
+    void freeMemory(void *ptr) const;
 public:
     void add(size_t bytes);
     void subtract(size_t bytes);
@@ -611,7 +619,7 @@ private:
     //number of filter instances plus one, freeing the core reduces it by one
     // the core will be freed once it reaches 0
     bool coreFreed;
-    std::atomic<int> numFilterInstances; 
+    std::atomic<int> numFilterInstances;
     std::atomic<int> numFunctionInstances;
 
     std::map<std::string, VSPlugin *> plugins;


### PR DESCRIPTION
This speeds up processing of 4K content.

Test script:

    import vapoursynth as vs

    core = vs.get_core()
    # Needed if memory thrashing occurs.
    # core.max_cache_size = 32 * 1024

    # XCPU = None

    c = core.std.BlankClip(width=3840, height=2160, length=1000, format=vs.YUV420P10)
    c = core.resize.Bilinear(c, format=vs.RGBS, matrix_in_s='2020ncl', transfer_in_s='709', primaries_in_s='2020',
                             matrix_s='rgb', transfer_s='linear', primaries_s='2020', dither_type='none', cpu_type=XCPU)
    c = core.resize.Bilinear(c, format=vs.YUV420P8, matrix_in_s='rgb', transfer_in_s='linear', primaries_in_s='709',
                             matrix_s='709', transfer_s='709', primaries_s='709', dither_type='ordered', cpu_type=XCPU)
    c.set_output()
