### PR TITLE
Add setup.py for portable installations

### DIFF
--- a/installer/MANIFEST.in
+++ b/installer/MANIFEST.in
@@ -1,0 +1,2 @@
+global-include *.dll portable.vs .keep VSPipe.exe
+global-exclude VapourSynth.dll

--- a/installer/make portable.bat
+++ b/installer/make portable.bat
@@ -1,4 +1,4 @@
-rem extract version string
+em extract version string
 for /F "tokens=2 delims='" %%a in ('findstr /C:"#define Version" vsinstaller.iss') do set v=%%a
 @echo %v%
 
@@ -20,7 +20,10 @@ copy ..\msvc_project\x64\Release\Vinverse.dll buildp64\vapoursynth64\coreplugins
 copy ..\msvc_project\x64\Release\VIVTC.dll buildp64\vapoursynth64\coreplugins
 copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.12.25810\x64\Microsoft.VC141.CRT\*" buildp64
 copy x64\plugins\* buildp64\vapoursynth64\coreplugins
+copy .\setup.py buildp64
+copy .\MANIFEST.in buildp64
 type nul >buildp64\portable.vs
+type nul >buildp64\vapoursynth64\plugins\.keep
 rm Compiled\vapoursynth64-portable-%v%.7z
 cd buildp64
 "C:\Program Files\7-Zip\7z.exe" a ..\Compiled\VapourSynth64-Portable-%v%.7z *
@@ -45,10 +48,12 @@ copy ..\msvc_project\Release\Vinverse.dll buildp32\vapoursynth32\coreplugins
 copy ..\msvc_project\Release\VIVTC.dll buildp32\vapoursynth32\coreplugins
 copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.12.25810\x86\Microsoft.VC141.CRT\*" buildp32
 copy x86\plugins\* buildp32\vapoursynth32\coreplugins
+copy .\setup.py buildp32
+copy .\MANIFEST.in buildp32
 type nul >buildp32\portable.vs
+type nul >buildp64\vapoursynth32\plugins\.keep
 rm Compiled\vapoursynth32-portable-%v%.7z
 cd buildp32
 "C:\Program Files\7-Zip\7z.exe" a ..\Compiled\VapourSynth32-Portable-%v%.7z *
 cd ..
 rmdir /s /q buildp32
-

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -84,7 +84,7 @@ setup(
             if p.endswith(".dll")
         ]),
 
-        ("Lib\\site-packages\\%s\\coreplugins"%plugin_subdir, [
+        ("Lib\\site-packages\\%s\\plugins"%plugin_subdir, [
             os.path.join(plugin_dir, 'plugins', p)
             for p in os.listdir(os.path.join(plugin_dir, 'plugins'))
             if p.endswith(".dll") or p.endswith(".keep")

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -69,8 +69,7 @@ setup(
             os.path.join(build_dir, p)
             for p in os.listdir(build_dir)
             if p.endswith("140.dll") or \
-               p.endswith(".vs") or \
-               (p.startswith("vs") and p.endswith(".dll"))
+               p.endswith(".vs")
         ]),
 
         ("Scripts", [

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -1,0 +1,94 @@
+CURRENT_RELEASE = "43"
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+from platform import architecture
+from codecs import open
+
+import os
+from os import listdir, path
+
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+    class bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+
+        def get_tag(self):
+            python, abi, plat = _bdist_wheel.get_tag(self)
+            # We don't contain any python source
+            python, abi = 'py2.py3', 'none'
+            return python, abi, plat
+except ImportError:
+    bdist_wheel = None
+
+
+is_win = (architecture()[1] == "WindowsPE")
+is_64 = (architecture()[0] == "64bit")
+here = path.abspath(path.dirname(__file__))
+
+if not is_win:
+    raise OSError("VapourSynth Portable is currently only supported on Windows Systems.")
+
+if not os.path.exists(os.path.join(here, "VapourSynth.dll")):
+    if is_64:
+        subdir = "buildp64"
+    else:
+        subdir = "buildp32"
+    build_dir = os.path.join(here, subdir)
+
+    if not os.path.exists(os.path.join(build_dir, "VapourSynth.dll")):
+        raise OSError("Failed to detect VapourSynth-portable build directory.")
+else:
+    subdir = "."
+    build_dir = here
+
+if is_64:
+    plugin_subdir = 'vapoursynth64'
+else:
+    plugin_subdir = 'vapoursynth32'
+plugin_dir = os.path.join(subdir, plugin_subdir)
+
+setup(
+    name = "VapourSynth-portable",
+    version=CURRENT_RELEASE,
+    description = "A frameserver for the 21st century",
+    url = "http://www.vapoursynth.com/",
+    download_url = "https://github.com/vapoursynth/vapoursynth",
+    author = "Fredrik Mellbin",
+    author_email = "fredrik.mellbin@gmail.com",
+
+    cmdclass={'bdist_wheel': bdist_wheel},
+
+    packages=[],
+    install_requires=["vapoursynth==" + CURRENT_RELEASE],
+    setup_requires=["vapoursynth==" + CURRENT_RELEASE],
+    data_files = [
+        ("Lib\\site-packages", [
+            os.path.join(build_dir, p)
+            for p in os.listdir(build_dir)
+            if p.endswith("140.dll") or \
+               p.endswith(".vs") or \
+               (p.startswith("vs") and p.endswith(".dll"))
+        ]),
+
+        ("Scripts", [
+            os.path.join(build_dir, "VSPipe.exe"),
+            os.path.join(build_dir, "VSScript.dll"),
+            os.path.join(build_dir, "portable.vs")
+        ]),
+
+        ("Lib\\site-packages\\%s\\coreplugins"%plugin_subdir, [
+            os.path.join(plugin_dir, 'coreplugins', p)
+            for p in os.listdir(os.path.join(plugin_dir, 'coreplugins'))
+            if p.endswith(".dll")
+        ]),
+
+        ("Lib\\site-packages\\%s\\coreplugins"%plugin_subdir, [
+            os.path.join(plugin_dir, 'plugins', p)
+            for p in os.listdir(os.path.join(plugin_dir, 'plugins'))
+            if p.endswith(".dll") or p.endswith(".keep")
+        ])
+    ]
+)


### PR DESCRIPTION
# What is this about?
The current setup.py only installs the `vapoursynth.pyd` and `VapourSynth.dll` neccessary for working with the pre-existing VapourSynth installation.

This PR adds a setup.py for portable installations, copying the neccessary files for portable installations into the Python-directory.

# What do I need to know
This setup.py **will** require the matching vapoursynth-installation installed via `setup.py` (of VapourSynth itself) or via `PyPI`. The installation of this package will attempt to redownload and install the package prior to installation of the portable edition if it hasn't been installed beforehand.

As such, the source-distribution and binary-wheels will not include the `VapourSynth.dll` itself as it is included in its requirement.

# Where do the files come from?
There are essentially two modes of this `setup.py`-file:
1. It finds the directory `buildp64` (or `buildp32` on 32bit-Systems) created by `make portable.bat` and uses its directory structure to copy the files to the correct destination.
2. It finds the file `VapourSynth.dll` and assumes it was included in the portable .7z-file and takes the files from the extracted portable directory.

# What is included?
Currently, all plugins provded in `vapoursynth(32|64)/coreplugins` are included as well as the files required to run `VSPipe.exe`.

`VapourSynth` itself is not included.
