### PR TITLE
Two things

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -519,6 +519,47 @@ Classes and Functions
    
       Refers to the *Plugin*-instance which registered this function.
    
+.. py:class:: Environment
+
+   This class represents an environment.
+
+   It is a context-manager allowing you to switch to this environment at will.
+   But it is faster than using the equivalent evaluate_script-function as it does not
+   impose additional exception handling.
+
+   .. code::
+
+        env = vpy_current_environment()
+        # sometime later
+        with env:
+          # Do stuff inside this env.
+
+   .. py:function:: is_single()
+
+      Returns True if the script is _not_ running inside a vsscript-Environment.
+      If it is running inside a vsscript-Environment, it returns False.
+
+   .. py:attribute:: env_id
+
+      Return -1 if the script is not running inside a vsscript-Environment.
+      Otherwise, it will return the current environment-id.
+
+   .. py:attribute:: single
+
+      See is_single()
+
+   .. py:attribute:: alive
+
+      Has the environment been destroyed by the underlying application?
+
+.. py:function:: vpy_current_environment()
+
+   Returns an Environment-object representing the environment the script is currently running in. It will raise an error if we are currently not inside any
+   script-environment while vsscript is being used.
+
+   This function is intended for Python-based editors using vsscript.
+
+
 .. py:class:: Func
 
    Func is a simple wrapper class for VapourSynth VSFunc objects.

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1774,7 +1774,7 @@ cdef void __stdcall publicFunction(const VSMap *inm, VSMap *outm, void *userData
                 vsapi.setError(outm, emsg)
 
 
-cdef class VapourSynthEnvironment(object):
+cdef class Environment(object):
     cdef readonly int env_id
     cdef readonly int ensure_existing_core
 
@@ -1832,13 +1832,13 @@ cdef class VapourSynthEnvironment(object):
 
     def __repr__(self):
         if self.single:
-            return "<VapourSynthEnvironment (default)>"
+            return "<Environment (default)>"
 
-        return f"<VapourSynthEnvironment {self.env_id} ({('active' if self.active else 'alive') if self.alive else 'dead'})>"
+        return f"<Environment {self.env_id} ({('active' if self.active else 'alive') if self.alive else 'dead'})>"
 
 
-cdef VapourSynthEnvironment use_environment(int id, int ensure_existing_core=False):
-    cdef VapourSynthEnvironment instance = VapourSynthEnvironment.__new__(VapourSynthEnvironment)
+cdef Environment use_environment(int id, int ensure_existing_core=False):
+    cdef Environment instance = Environment.__new__(Environment)
     instance.env_id = id
     instance.ensure_existing_core = ensure_existing_core
     return instance

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1830,6 +1830,14 @@ cdef class Environment(object):
         global _environment_id_stack, _environment_id
         _environment_id = _environment_id_stack.pop()
 
+    def __eq__(self, other):
+        if not isinstance(other, Environment):
+            return False
+        if self.single:
+            return False
+
+        return other.env_id == self.env_id
+
     def __repr__(self):
         if self.single:
             return "<Environment (default)>"


### PR DESCRIPTION
**Allow the script-authors more control over the script-envs.** (until commit 3019e55)
This is achieved by:
1. Switch the environment at will (assuming it has not been freed)
2. Query information about the environment.
3. Allow scripts to detect changed environments by comparing Environment instances.
The functions make sure that you cannot switch to freed script-environments.

**Based on this a fix of #390** (commit 3e20384)
This introduces some changes:

* `_environment_id` changed to  `_env_current_id()`
  * If the script-environment is freed `_env_current_id()` will always return `None` until this stack-level is left.
* `_environment_id_stack` changed to `_env_current_stack()`
* thread-local _environment_state. It stores two variables:
  * `_environment_state.current` (accessed via `_env_current_id()`)
  * `_environment_state.stack` (accessed via `_env_current_stack()`)
* `createFuncPython` may now encounter a `_env_current_id=None`.
  * In this case, it as almost always a use after free.
