### PR TITLE
Add a sensible default for _env_current_id()

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -63,6 +63,14 @@ cdef _env_current_id():
             # Reset the current environment as the current environment
             # has beeen freed.
             current = _environment_state.current = None
+    else:
+        # Default to zero as sometimes environment_id is assumed to be an int.
+        # In these cases we just pretend there is an VSScript-Environment and
+        # it's ID is zero.
+        #
+        # Please don't use this value to test, if we are running inside a
+        # VSScript environment or not, ok?
+        current = 0
     return current
 
 cdef _env_current_stack():


### PR DESCRIPTION
Don't trust a programmer to check for None if _using_vsscript is None. He will forget anyway.

Or in other words:
I did it again. I always either forget VSScript exists or that there is a world without VSScript.
~ Me, in some random discord server full of encoders