### PR TITLE
Be more friendly to Python autocompletion engines

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1655,8 +1655,16 @@ cdef Core vsscript_get_core_internal(int environment_id):
         _cores[environment_id] = createCore()
     return _cores[environment_id]
     
-cdef class _CoreProxy(object):
+class CoreMeta(type):
+    def __new__(cls, name, bases, dct):
+        core = get_core()
+        for plugin in core.get_plugins().values():
+            name = plugin['namespace']
+            dct[name] = core.__getattr__(name)
 
+        return super(CoreMeta, cls).__new__(cls, name, bases, dct)
+
+class _CoreProxy(metaclass=CoreMeta):
     def __init__(self):
         raise Error('Class cannot be instantiated directly')
     

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1783,12 +1783,6 @@ cdef class Function(object):
     cdef readonly str name
     cdef readonly str signature
     
-    @property
-    def __signature__(self):
-        if typing is None:
-            return None
-        return construct_signature(self.signature, injected=self.plugin.injected_arg)
-
     def __init__(self):
         raise Error('Class cannot be instantiated directly')
 
@@ -1869,7 +1863,9 @@ cdef class Function(object):
         return retdict
 
 cdef Function createFunction(str name, str signature, Plugin plugin, const VSAPI *funcs):
-    cdef Function instance = Function.__new__(Function)
+    dct = {'__signature__': construct_signature(signature, injected=plugin.injected_arg)}
+    t = type('Function', (Function,), dct)
+    cdef Function instance = t.__new__(t)
     instance.name = name
     instance.signature = signature
     instance.plugin = plugin

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -36,6 +36,7 @@ from types import MappingProxyType
 from collections import namedtuple
 from collections.abc import Iterable, Mapping
 from fractions import Fraction
+from warnings import warn
 
 # Ensure that the import doesn't fail
 # if typing is not available on the python installation.
@@ -1868,7 +1869,7 @@ cdef Function createFunction(str name, str signature, Plugin plugin, const VSAPI
         try:
             dct['__signature__'] = construct_signature(signature, injected=plugin.injected_arg)
         except ValueError as e:
-            print("Constructing signature for {}.{}() failed: {}".format(plugin.namespace, name, str(e)))
+            warn('Constructing signature for {}.{}() failed: {}'.format(plugin.namespace, name, str(e)))
     t = type('Function', (Function,), dct)
     cdef Function instance = t.__new__(t)
     instance.name = name

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1867,10 +1867,16 @@ cdef Function createFunction(str name, str signature, Plugin plugin, const VSAPI
     dct = {'__signature__': None}
     if typing is not None:
         try:
-            dct['__signature__'] = construct_signature(signature, injected=plugin.injected_arg)
+            sign = construct_signature(signature, injected=plugin.injected_arg)
+            annotations = dict(sign.parameters)
+            annotations['return'] = sign.return_annotation
+
+            dct['__signature__'] = sign
+            dct['__annotations__'] = annotations
         except ValueError as e:
             warn('Constructing signature for {}.{}() failed: {}'.format(plugin.namespace, name, str(e)))
     t = type('Function', (Function,), dct)
+
     cdef Function instance = t.__new__(t)
     instance.name = name
     instance.signature = signature

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -189,7 +189,7 @@ def _construct_parameter(signature):
     elif type == "float":
         type = float
     elif type == "data":
-        type = typing.Union[str, bytes, bytearray]
+        type = typing.AnyStr
     else:
         raise ValueError("Couldn't determine type")
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1865,7 +1865,10 @@ cdef class Function(object):
 cdef Function createFunction(str name, str signature, Plugin plugin, const VSAPI *funcs):
     dct = {'__signature__': None}
     if typing is not None:
-        dct['__signature__'] = construct_signature(signature, injected=plugin.injected_arg)
+        try:
+            dct['__signature__'] = construct_signature(signature, injected=plugin.injected_arg)
+        except ValueError as e:
+            print("Constructing signature for {}.{}() failed: {}".format(plugin.namespace, name, str(e)))
     t = type('Function', (Function,), dct)
     cdef Function instance = t.__new__(t)
     instance.name = name

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1863,7 +1863,9 @@ cdef class Function(object):
         return retdict
 
 cdef Function createFunction(str name, str signature, Plugin plugin, const VSAPI *funcs):
-    dct = {'__signature__': construct_signature(signature, injected=plugin.injected_arg)}
+    dct = {'__signature__': None}
+    if typing is not None:
+        dct['__signature__'] = construct_signature(signature, injected=plugin.injected_arg)
     t = type('Function', (Function,), dct)
     cdef Function instance = t.__new__(t)
     instance.name = name


### PR DESCRIPTION
#### Problem
Microsoft's engine doesn't list any plugins at all for core object (`_CoreProxy`). Jedi list the plugins, but doesn't list functions.
#### Reason
Microsoft's engines examines objects in a static way via dict of the type. Jedi does the same, but also calls type's `__dir__()` — that's why it's able to list plugins. No one triggers `__getattr__()` or `__getattribute__()` to get actual object for given plugin to list it's attributes. This behavior is intended since engines aims to execute less code. 
#### Solution
Fetch all the plugins objects from core and add them to `_CoreProxy` as if they were attributes defined in source. Metaclasses is the right mechanism for that.
#### Result
Both autocompletion engines lists the plugins, and Jedi lists functions inside plugins.
#### Testing code
```
import jedi
from vapoursynth import core

script = jedi.Interpreter('core.', [locals()])
print(script.completions())
```