### PR TITLE
Fix compilation and standards compliance

### DIFF
--- a/src/core/genericfilters.cpp
+++ b/src/core/genericfilters.cpp
@@ -903,41 +903,41 @@ static void VS_CC levelsCreate(const VSMap *in, VSMap *out, void *userData, VSCo
 
 //////////////////////////
 
-void VS_CC generic2Initialize(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin) {
+void VS_CC genericInitialize(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin) {
     //configFunc("com.vapoursynth.std", "std", "VapourSynth Core Functions", VAPOURSYNTH_API_VERSION, 1, plugin);
 
-    registerFunc("Minimum2",
+    registerFunc("Minimum",
             "clip:clip;"
             "planes:int[]:opt;"
             "threshold:float:opt;"
             "coordinates:int[]:opt;"
             , genericCreate<GenericMinimum>, const_cast<char *>("Minimum"), plugin);
 
-    registerFunc("Maximum2",
+    registerFunc("Maximum",
             "clip:clip;"
             "planes:int[]:opt;"
             "threshold:float:opt;"
             "coordinates:int[]:opt;"
             , genericCreate<GenericMaximum>, const_cast<char *>("Maximum"), plugin);
 
-    registerFunc("Median2",
+    registerFunc("Median",
             "clip:clip;"
             "planes:int[]:opt;"
             , genericCreate<GenericMedian>, const_cast<char *>("Median"), plugin);
 
-    registerFunc("Deflate2",
+    registerFunc("Deflate",
             "clip:clip;"
             "planes:int[]:opt;"
             "threshold:float:opt;"
             , genericCreate<GenericDeflate>, const_cast<char *>("Deflate"), plugin);
 
-    registerFunc("Inflate2",
+    registerFunc("Inflate",
             "clip:clip;"
             "planes:int[]:opt;"
             "threshold:float:opt;"
             , genericCreate<GenericInflate>, const_cast<char *>("Inflate"), plugin);
 
-    registerFunc("Convolution2",
+    registerFunc("Convolution",
             "clip:clip;"
             "matrix:float[];"
             "bias:float:opt;"
@@ -947,31 +947,31 @@ void VS_CC generic2Initialize(VSConfigPlugin configFunc, VSRegisterFunction regi
             "mode:data:opt;"
             , genericCreate<GenericConvolution>, const_cast<char *>("Convolution"), plugin);
 
-    registerFunc("Prewitt2",
+    registerFunc("Prewitt",
             "clip:clip;"
             "planes:int[]:opt;"
             "scale:float:opt;"
             , genericCreate<GenericPrewitt>, const_cast<char *>("Prewitt"), plugin);
 
-    registerFunc("Sobel2",
+    registerFunc("Sobel",
             "clip:clip;"
             "planes:int[]:opt;"
             "scale:float:opt;"
             , genericCreate<GenericSobel>, const_cast<char *>("Sobel"), plugin);
 
-    registerFunc("Invert2",
+    registerFunc("Invert",
         "clip:clip;"
         "planes:int[]:opt;"
         , invertCreate, nullptr, plugin);
 
-    registerFunc("Limiter2",
+    registerFunc("Limiter",
         "clip:clip;"
         "min:float[]:opt;"
         "max:float[]:opt;"
         "planes:int[]:opt;"
         , limitCreate, nullptr, plugin);
 
-    registerFunc("Binarize2",
+    registerFunc("Binarize",
         "clip:clip;"
         "threshold:float[]:opt;"
         "v0:float[]:opt;"
@@ -979,7 +979,7 @@ void VS_CC generic2Initialize(VSConfigPlugin configFunc, VSRegisterFunction regi
         "planes:int[]:opt;"
         , binarizeCreate, nullptr, plugin);
 
-    registerFunc("Levels2",
+    registerFunc("Levels",
         "clip:clip;"
         "min_in:float[]:opt;"
         "max_in:float[]:opt;"

--- a/src/core/kernel/generic.cpp
+++ b/src/core/kernel/generic.cpp
@@ -34,7 +34,7 @@ T *line_ptr(T *ptr, unsigned i, ptrdiff_t stride)
 
 template <class T, bool Sobel>
 struct PrewittSobelOp {
-    typedef T T;
+    typedef T Ty;
 
     float scale;
 
@@ -62,7 +62,7 @@ struct PrewittSobelOp {
 
 template <class T, bool Max>
 struct MinMaxOp {
-    typedef T T;
+    typedef T Ty;
 
     typename std::conditional<std::is_integral<T>::value, int32_t, float>::type threshold;
     uint8_t stencil[8];
@@ -103,7 +103,7 @@ struct MinMaxOp {
 
 template <class T>
 struct MedianOp {
-    typedef T T;
+    typedef T Ty;
 
     explicit MedianOp(const vs_generic_params &) {}
 
@@ -148,7 +148,7 @@ struct MedianOp {
 
 template <class T, bool Inflate>
 struct DeflateInflateOp {
-    typedef T T;
+    typedef T Ty;
 
     typename std::conditional<std::is_integral<T>::value, int32_t, float>::type threshold;
 
@@ -175,7 +175,7 @@ struct DeflateInflateOp {
 
 template <class T>
 struct ConvolutionOp {
-    typedef T T;
+    typedef T Ty;
 
     std::array<typename std::conditional<std::is_integral<T>::value, int16_t, float>::type, 9> coeffs;
     float div;
@@ -217,7 +217,7 @@ struct ConvolutionOp {
 template <class Traits>
 void filter_plane_3x3(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const vs_generic_params &params, unsigned width, unsigned height)
 {
-    typedef typename Traits::T T;
+    typedef typename Traits::Ty T;
 
     Traits traits{ params };
     uint16_t maxval = params.maxval;


### PR DESCRIPTION
Template parameters [cannot be redeclared within their scope](https://timsong-cpp.github.io/cppwp/n4659/temp.local#6), which is enforced by (at least) Clang, causing compilation to fail.

This PR also includes #476 because linking failed without it. My [templates branch](https://github.com/Noctem/vapoursynth/tree/templates) has only my commit if you want them separated.

Let me know if you want a different name than `Ty` (or any other changes).

