### PR TITLE
Basic audio tone support

### DIFF
--- a/msvc_project/Core/Core.vcxproj
+++ b/msvc_project/Core/Core.vcxproj
@@ -182,6 +182,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\core\audiofilter.cpp" />
     <ClCompile Include="..\..\src\core\boxblurfilter.cpp" />
     <ClCompile Include="..\..\src\core\cachefilter.cpp" />
     <ClCompile Include="..\..\src\core\cpufeatures.cpp" />

--- a/msvc_project/Core/Core.vcxproj.filters
+++ b/msvc_project/Core/Core.vcxproj.filters
@@ -116,6 +116,8 @@
     </ClCompile>
     <ClCompile Include="..\..\src\core\kernel\x86\generic_avx2.cpp">
       <Filter>Source Files\kernel\x86</Filter>
+    <ClCompile Include="..\..\src\core\audiofilter.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/core/audiofilter.cpp
+++ b/src/core/audiofilter.cpp
@@ -1,0 +1,471 @@
+/*
+* Copyright (c) 2012-2016 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "VSHelper.h"
+#include "internalfilters.h"
+#include "filtershared.h"
+#include "time.h"
+
+//////////////////////////////////////////
+// Tone
+
+#define PI 3.1415926535897932384626433832795
+/**********************************************************
+ *                         TONE                           *
+ **********************************************************/
+class SampleGenerator {
+public:
+    SampleGenerator() {}
+    virtual float getValueAt(double where) { return 0.0f; }
+};
+
+class SineGenerator : public SampleGenerator {
+public:
+    SineGenerator() {}
+    float getValueAt(double where) { return (float)sin(PI * where * 2.0); }
+};
+
+
+class NoiseGenerator : public SampleGenerator {
+public:
+    NoiseGenerator() {
+        srand((unsigned)time(NULL));
+    }
+
+    float getValueAt(double where) { return (float)rand()*(2.0f / RAND_MAX) - 1.0f; }
+};
+
+class SquareGenerator : public SampleGenerator {
+public:
+    SquareGenerator() {}
+
+    float getValueAt(double where) {
+        if (where <= 0.5) {
+            return 1.0f;
+        }
+        else {
+            return -1.0f;
+        }
+    }
+};
+
+class TriangleGenerator : public SampleGenerator {
+public:
+    TriangleGenerator() {}
+
+    float getValueAt(double where) {
+        if (where <= 0.25) {
+            return (float)(where*4.0);
+        }
+        else if (where <= 0.75) {
+            return (float)((-4.0*(where - 0.50)));
+        }
+        else {
+            return (float)((4.0*(where - 1.00)));
+        }
+    }
+};
+
+class SawtoothGenerator : public SampleGenerator {
+public:
+    SawtoothGenerator() {}
+
+    float getValueAt(double where) {
+        return (float)(2.0*(where - 0.5));
+    }
+};
+
+__inline short Saturate_int16(float n) {
+    if (n <= -32768.0f) return -32768;
+    if (n >= 32767.0f) return  32767;
+    return (short)(n + 0.5f);
+}
+
+void convertFromFloat(float* inbuf, void* outbuf, char sample_type, int count) {
+    int i;
+
+    signed short* samples = (signed short*)outbuf;
+    for (i = 0; i < count; i++) {
+        samples[i] = Saturate_int16(inbuf[i] * 32768.0f);
+    }
+}
+
+class Tone {
+    SampleGenerator *s;
+    const float freq;            // Frequency in Hz
+    const float samplerate;      // Samples per second
+    const int ch;                 // Number of channels
+    const double add_per_sample;  // How much should we add per sample in seconds
+    const float level;
+
+public:
+
+    Tone(float _length, float _freq, int _samplerate, int _ch, float _level, const char *_type) :
+        freq(_freq), samplerate(_samplerate), ch(_ch), add_per_sample(_freq / _samplerate), level(_level) {
+
+        if (_type == NULL || !strcmp(_type, "Sine"))
+            s = new SineGenerator();
+        else if (!strcmp(_type, "Noise"))
+            s = new NoiseGenerator();
+        else if (!strcmp(_type, "Square"))
+            s = new SquareGenerator();
+        else if (!strcmp(_type, "Triangle"))
+            s = new TriangleGenerator();
+        else if (!strcmp(_type, "Sawtooth"))
+            s = new SawtoothGenerator();
+        else
+            s = new SampleGenerator();
+    }
+
+    void __stdcall GetAudio(void* buf, __int64 start, __int64 count) {
+
+        // Where in the cycle are we in?
+        const double cycle = (freq * start) / samplerate;
+        double period_place = cycle - floor(cycle);
+
+        short* samples = (short* )buf;
+
+        for (int i = 0; i < count; i++) {
+            float v = s->getValueAt(period_place) * level;
+            for (int o = 0; o < ch; o++) {
+                samples[o + i * ch] = Saturate_int16(v * 32768.0f);
+            }
+            period_place += add_per_sample;
+            if (period_place >= 1.0)
+                period_place -= floor(period_place);
+        }
+    }
+};
+
+typedef struct AudioDubData {
+    VSVideoInfo vi;
+    VSNodeRef *clip1;
+    VSNodeRef *clip2;
+    VSVideoInfo clip1info;
+    VSVideoInfo clip2info;
+} AudioDubData;
+
+typedef struct FadeInOutData {
+    VSVideoInfo vi;
+    VSNodeRef *clip1;
+    float fade_duration;
+};
+
+typedef struct MixAudioData {
+    VSVideoInfo vi;
+    VSNodeRef *clip1;
+    VSNodeRef *clip2;
+    size_t tempbuffer_size;
+    signed char *tempbuffer;
+} MixAudioData;
+
+typedef struct ToneData {
+    VSVideoInfo vi;
+    Tone *tone;
+} ToneData;
+
+static void VS_CC ToneGetAudio(VSCore *core, const VSAPI *vsapi, void *instanceData, void *lpBuffer, long lStart, long lSamples) {
+    ToneData *d = (ToneData *)instanceData;
+
+    d->tone->GetAudio(lpBuffer, lStart, lSamples);
+}
+
+static void VS_CC ToneInit(VSMap *in, VSMap *out, void **instanceData, VSNode *node, VSCore *core, const VSAPI *vsapi) {
+    ToneData *d = (ToneData *)* instanceData;
+
+    d->vi.hasAudio = true;
+    vsapi->setVideoInfo(&d->vi, 1, node);
+}
+
+static void VS_CC ToneFree(void *instanceData, VSCore *core, const VSAPI *vsapi) {
+    ToneData *d = (ToneData *)instanceData;
+
+    delete d->tone;
+}
+
+static void VS_CC ToneCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
+    ToneData *data = (ToneData*)malloc(sizeof(ToneData));
+    int err;
+    float length = 10.0;
+    float frequency = 440;
+    int samplerate = 48000L;
+    int64_t channels = 2;
+    const char *type = 0;
+    float level = 1.0;
+
+    VSNodeRef *node = vsapi->propGetNode(in, "clip", 0, &err);
+    if (!err) {
+        data->vi = *vsapi->getVideoInfo(node);
+        vsapi->freeNode(node);
+    }
+
+    length = vsapi->propGetFloat(in, "length", 0, &err);
+    if (err) {
+        length = 10.0;
+    }
+
+    samplerate = vsapi->propGetInt(in, "samplerate", 0, &err);
+    if (err) {
+        samplerate = 48000;
+    }
+
+    frequency = vsapi->propGetFloat(in, "frequency", 0, &err);
+    if (err) {
+        frequency = 440;
+    }
+
+    channels = vsapi->propGetInt(in, "channels", 0, &err);
+    if (err) {
+        channels = 2;
+    }
+
+    type = vsapi->propGetData(in, "type", 0, &err);
+    if (err) {
+        type = NULL;
+    }
+
+    level = vsapi->propGetFloat(in, "level", 0, &err);
+    if (err) {
+        level = 1.0;
+    }
+
+    data->vi.format = vsapi->getFormatPreset(pfAudioOnly, core);
+    data->vi.numFrames = 0;
+
+    data->vi.channels = channels;
+    data->vi.audio_samplerate = samplerate;
+    data->vi.numAudioSample = length * samplerate;
+
+    Tone *tone = new Tone(length, frequency, samplerate, channels, level, type);
+    data->tone = tone;
+
+    vsapi->createFilter(in, out, "Tone", ToneInit, NULL, ToneFree, ToneGetAudio, fmParallel, nfNoCache, data, core);
+}
+
+long clamp(long n, long min, long max)
+{
+    n = n > max ? max : n;
+    return n < min ? min : n;
+}
+
+static __int64 signed_saturated_add64(__int64 x, __int64 y) {
+    // determine the lower or upper bound of the result
+    __int64 ret = (x < 0) ? INT64_MIN : INT64_MAX;
+    // this is always well defined:
+    // if x < 0 this adds a positive value to INT64_MIN
+    // if x > 0 this subtracts a positive value from INT64_MAX
+    __int64 comp = ret - x;
+    // the codition is equivalent to
+    // ((x < 0) && (y > comp)) || ((x >=0) && (y <= comp))
+    if ((x < 0) == (y > comp)) ret = x + y;
+    return ret;
+}
+
+static void VS_CC MixAudioGetAudio(VSCore *core, const VSAPI *vsapi, void *instanceData, void *lpBuffer, long lStart, long lSamples) {
+    MixAudioData *d = (MixAudioData *)instanceData;
+
+    if (d->tempbuffer_size < lSamples)
+    {
+        if (d->tempbuffer_size)
+            delete[] d->tempbuffer;
+
+        d->tempbuffer = new signed char[(size_t)(lSamples * 4)];
+        d->tempbuffer_size = (int)lSamples;
+    }
+
+    vsapi->getAudio(d->clip1, lpBuffer, lStart, lSamples);
+    vsapi->getAudio(d->clip2, (void*)d->tempbuffer, lStart, lSamples);
+
+    short* samples = (short*)lpBuffer;
+    short* clip_samples = (short*)d->tempbuffer;
+    for (unsigned i = 0; i < unsigned(lSamples) * 2; ++i) {
+        samples[i] = (samples[i] / 2) + (clip_samples[i] / 2);
+    }
+}
+
+static void VS_CC MixAudioInit(VSMap *in, VSMap *out, void **instanceData, VSNode *node, VSCore *core, const VSAPI *vsapi) {
+    MixAudioData *d = (MixAudioData *)* instanceData;
+
+    d->vi.hasAudio = true;
+    vsapi->setVideoInfo(&d->vi, 1, node);
+}
+
+static void VS_CC MixAudioFree(void *instanceData, VSCore *core, const VSAPI *vsapi) {
+}
+
+static void VS_CC MixAudioCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
+    MixAudioData *data = (MixAudioData*)malloc(sizeof(MixAudioData));
+    int err;
+
+    VSNodeRef *node = vsapi->propGetNode(in, "clip", 0, &err);
+
+    if (!err) {
+        data->vi = *vsapi->getVideoInfo(node);
+        vsapi->freeNode(node);
+    }
+
+    VSNodeRef *clip1 = vsapi->propGetNode(in, "clip1", 0, &err);
+    VSNodeRef *clip2 = vsapi->propGetNode(in, "clip2", 0, &err);
+    VSVideoInfo clip1info = *vsapi->getVideoInfo(clip1);
+
+    data->clip1 = clip1;
+    data->clip2 = clip2;
+    data->tempbuffer = NULL;
+    data->tempbuffer_size = 0;
+
+    data->vi.numFrames = 0;
+    data->vi.format = vsapi->getFormatPreset(pfAudioOnly, core);
+    data->vi.numAudioSample = clip1info.audio_samplerate;
+
+    data->vi.audio_samplerate = clip1info.audio_samplerate;
+    data->vi.channels = clip1info.channels;
+
+    vsapi->createFilter(in, out, "MixAudio", MixAudioInit, NULL, MixAudioFree, MixAudioGetAudio, fmParallel, nfNoCache, data, core);
+}
+
+static void VS_CC FadeInOutInit(VSMap *in, VSMap *out, void **instanceData, VSNode *node, VSCore *core, const VSAPI *vsapi) {
+    FadeInOutData *d = (FadeInOutData *)* instanceData;
+
+    d->vi.hasAudio = true;
+    vsapi->setVideoInfo(&d->vi, 1, node);
+}
+
+static void VS_CC FadeInOutFree(void *instanceData, VSCore *core, const VSAPI *vsapi) {
+}
+
+static void VS_CC FadeInOutGetAudio(VSCore *core, const VSAPI *vsapi, void *instanceData, void *lpBuffer, long lStart, long lSamples) {
+    FadeInOutData *d = (FadeInOutData *)instanceData;
+    VSVideoInfo clip1info = *vsapi->getVideoInfo(d->clip1);
+
+    vsapi->getAudio(d->clip1, lpBuffer, lStart, lSamples);
+
+    int totalNumberOfSamples = clip1info.numAudioSample;
+    int samplesToFadeOut = d->fade_duration;
+    int notCovered = totalNumberOfSamples - (lStart + lSamples);
+
+    unsigned int j = 0;
+    short* samples = (short*)lpBuffer;
+
+    if (notCovered < samplesToFadeOut) { // Needs of fade out
+        int covered = totalNumberOfSamples - (samplesToFadeOut - notCovered);
+        for (unsigned int i = covered - lStart; i < lSamples; i++) {
+            for (int o = 0; o < clip1info.channels; o++) {
+                samples[o + i * clip1info.channels] = samples[o + i * clip1info.channels] - ((samples[o + i * clip1info.channels] / samplesToFadeOut) * (j + 1));
+            }
+            j++;
+        }
+    }
+    j = 0;
+
+    if (lStart < samplesToFadeOut) {
+        int covered = samplesToFadeOut - lStart;
+        if (covered > lSamples) {
+            covered = lSamples;
+        }
+        for (unsigned int i = 0; i < covered; i++) {
+            for (int o = 0; o < clip1info.channels; o++) {
+                samples[o + i * clip1info.channels] = samples[o + i * clip1info.channels] - ((samples[o + i * clip1info.channels] / samplesToFadeOut) * (samplesToFadeOut - j));
+            }
+            j++;
+        }
+    }
+}
+
+static void VS_CC FadeInOutCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
+    FadeInOutData *data = (FadeInOutData*)malloc(sizeof(FadeInOutData));
+    int err;
+
+    VSNodeRef *node = vsapi->propGetNode(in, "clip", 0, &err);
+    data = (FadeInOutData*)malloc(sizeof(FadeInOutData));
+
+    if (!err) {
+        data->vi = *vsapi->getVideoInfo(node);
+        vsapi->freeNode(node);
+    }
+
+    VSNodeRef *clip1 = vsapi->propGetNode(in, "clip1", 0, &err);
+    float num_frames = vsapi->propGetFloat(in, "num_frames", 0, &err);
+    VSVideoInfo clip1info = *vsapi->getVideoInfo(clip1);
+
+    data->clip1 = clip1;
+    data->fade_duration = num_frames;
+
+    data->vi.format = clip1info.format;
+    data->vi.numFrames = clip1info.numFrames;
+    data->vi.audio_samplerate = clip1info.audio_samplerate;
+    data->vi.channels = clip1info.channels;
+    data->vi.numAudioSample = clip1info.numAudioSample;
+
+    vsapi->createFilter(in, out, "FadeOut", FadeInOutInit, NULL, FadeInOutFree, FadeInOutGetAudio, fmParallel, nfNoCache, data, core);
+}
+
+static void VS_CC AudioDubInit(VSMap *in, VSMap *out, void **instanceData, VSNode *node, VSCore *core, const VSAPI *vsapi) {
+    AudioDubData *d = (AudioDubData *)* instanceData;
+
+    d->clip1info.hasAudio = true;
+    d->clip1info.audio_samplerate = d->clip2info.audio_samplerate;
+    d->clip1info.channels = d->clip2info.channels;
+
+    vsapi->setVideoInfo(&d->clip1info, 1, node);
+}
+
+static void VS_CC AudioDubFree(void *instanceData, VSCore *core, const VSAPI *vsapi) {
+}
+
+static void VS_CC AudioDubGetAudio(VSCore *core, const VSAPI *vsapi, void *instanceData, void *lpBuffer, long lStart, long lSamples) {
+    AudioDubData *d = (AudioDubData *)instanceData;
+
+    vsapi->getAudio(d->clip2, lpBuffer, lStart, lSamples);
+}
+
+static const VSFrameRef *VS_CC AudioDubGetFrame(int n, int activationReason, void **instanceData, void **frameData, VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi) {
+    AudioDubData *d = (AudioDubData *)* instanceData;
+
+    return vsapi->getFrame(n, d->clip1, NULL, 0);
+}
+
+static void VS_CC AudioDubCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
+    AudioDubData *data = (AudioDubData*)malloc(sizeof(AudioDubData));
+    int err;
+
+    VSNodeRef *clip1 = vsapi->propGetNode(in, "clip1", 0, &err);
+    VSNodeRef *clip2 = vsapi->propGetNode(in, "clip2", 0, &err);
+
+    data->vi = *vsapi->getVideoInfo(clip1);
+
+    VSVideoInfo clip1info = *vsapi->getVideoInfo(clip1);
+    VSVideoInfo clip2info = *vsapi->getVideoInfo(clip2);
+
+    data->clip1 = clip1;
+    data->clip1info = clip1info;
+    data->clip2 = clip2;
+    data->clip2info = clip2info;
+
+    data->vi.numAudioSample = clip2info.numAudioSample;
+
+    vsapi->createFilter(in, out, "AudioDub", AudioDubInit, AudioDubGetFrame, MixAudioFree, AudioDubGetAudio, fmParallel, nfNoCache, data, core);
+}
+
+void VS_CC audioInitialize(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin) {
+    registerFunc("Tone", "length:float:opt;frequency:float:opt;samplerate:int:opt;channels:int:opt;type:data:opt;level:float:opt", ToneCreate, 0, plugin);
+    registerFunc("MixAudio", "clip1:clip;clip2:clip;clip1_factor:float:opt;clip2_factor:float:opt", MixAudioCreate, 0, plugin);
+    registerFunc("FadeInOut", "clip1:clip;num_frames:float", FadeInOutCreate, 0, plugin);
+    registerFunc("AudioDub", "clip1:clip;clip2:clip", AudioDubCreate, 0, plugin);
+}

--- a/src/core/boxblurfilter.cpp
+++ b/src/core/boxblurfilter.cpp
@@ -280,7 +280,7 @@ static VSNodeRef *applyBoxBlurPlaneFiltering(VSPlugin *stdplugin, VSNodeRef *nod
     if (hblur) {
         VSMap *vtmp1 = vsapi->createMap();
         VSMap *vtmp2 = vsapi->createMap();
-        vsapi->createFilter(vtmp1, vtmp2, "BoxBlur", templateNodeInit<BoxBlurData>, boxBlurGetframe, templateNodeFree<BoxBlurData>, fmParallel, 0, new BoxBlurData{ node, hradius, hpasses }, core);
+        vsapi->createFilter(vtmp1, vtmp2, "BoxBlur", templateNodeInit<BoxBlurData>, boxBlurGetframe, templateNodeFree<BoxBlurData>, NULL, fmParallel, 0, new BoxBlurData{ node, hradius, hpasses }, core);
         node = vsapi->propGetNode(vtmp2, "clip", 0, nullptr);
         vsapi->freeMap(vtmp1);
         vsapi->freeMap(vtmp2);
@@ -294,7 +294,7 @@ static VSNodeRef *applyBoxBlurPlaneFiltering(VSPlugin *stdplugin, VSNodeRef *nod
         vsapi->clearMap(vtmp1);
         node = vsapi->propGetNode(vtmp2, "clip", 0, nullptr);
         vsapi->clearMap(vtmp2);
-        vsapi->createFilter(vtmp1, vtmp2, "BoxBlur", templateNodeInit<BoxBlurData>, boxBlurGetframe, templateNodeFree<BoxBlurData>, fmParallel, 0, new BoxBlurData{ node, vradius, vpasses }, core);
+        vsapi->createFilter(vtmp1, vtmp2, "BoxBlur", templateNodeInit<BoxBlurData>, boxBlurGetframe, templateNodeFree<BoxBlurData>, NULL, fmParallel, 0, new BoxBlurData{ node, vradius, vpasses }, core);
         vsapi->freeMap(vtmp1);
         vtmp1 = vsapi->invoke(stdplugin, "Transpose", vtmp2);
         vsapi->freeMap(vtmp2);

--- a/src/core/cachefilter.cpp
+++ b/src/core/cachefilter.cpp
@@ -239,7 +239,7 @@ static void VS_CC createCacheFilter(const VSMap *in, VSMap *out, void *userData,
     else
         c->cache.setMaxFrames(20 + c->numThreads);
 
-    vsapi->createFilter(in, out, ("Cache" + std::to_string(cacheId++)).c_str(), cacheInit, cacheGetframe, cacheFree, c->makeLinear ? fmUnorderedLinear : fmUnordered, nfNoCache | nfIsCache, c, core);
+    vsapi->createFilter(in, out, ("Cache" + std::to_string(cacheId++)).c_str(), cacheInit, cacheGetframe, cacheFree, NULL, c->makeLinear ? fmUnorderedLinear : fmUnordered, nfNoCache | nfIsCache, c, core);
 
     c->addCache();
 }

--- a/src/core/exprfilter.cpp
+++ b/src/core/exprfilter.cpp
@@ -3260,7 +3260,7 @@ static void VS_CC exprCreate(const VSMap *in, VSMap *out, void *userData, VSCore
         return;
     }
 
-    vsapi->createFilter(in, out, "Expr", exprInit, exprGetFrame, exprFree, fmParallel, 0, d.release(), core);
+    vsapi->createFilter(in, out, "Expr", exprInit, exprGetFrame, exprFree, NULL, fmParallel, 0, d.release(), core);
 }
 
 } // namespace

--- a/src/core/genericfilters.cpp
+++ b/src/core/genericfilters.cpp
@@ -590,7 +590,7 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
         return;
     }
 
-    vsapi->createFilter(in, out, d->filter_name, templateNodeInit<GenericData>, genericGetframe<op>, templateNodeFree<GenericData>, fmParallel, 0, d.get(), core);
+    vsapi->createFilter(in, out, d->filter_name, templateNodeInit<GenericData>, genericGetframe<op>, templateNodeFree<GenericData>, NULL, fmParallel, 0, d.get(), core);
     d.release();
 }
 
@@ -642,7 +642,7 @@ static void VS_CC invertCreate(const VSMap *in, VSMap *out, void *userData, VSCo
         return;
     }
 
-    vsapi->createFilter(in, out, d->name, templateNodeInit<InvertData>, singlePixelGetFrame<InvertData, InvertOp>, templateNodeFree<InvertData>, fmParallel, 0, d.get(), core);
+    vsapi->createFilter(in, out, d->name, templateNodeInit<InvertData>, singlePixelGetFrame<InvertData, InvertOp>, templateNodeFree<InvertData>, NULL, fmParallel, 0, d.get(), core);
     d.release();
 }
 
@@ -697,7 +697,7 @@ static void VS_CC limitCreate(const VSMap *in, VSMap *out, void *userData, VSCor
         return;
     }
 
-    vsapi->createFilter(in, out, d->name, templateNodeInit<LimitData>, singlePixelGetFrame<LimitData, LimitOp>, templateNodeFree<LimitData>, fmParallel, 0, d.get(), core);
+    vsapi->createFilter(in, out, d->name, templateNodeInit<LimitData>, singlePixelGetFrame<LimitData, LimitOp>, templateNodeFree<LimitData>, NULL, fmParallel, 0, d.get(), core);
     d.release();
 }
 
@@ -758,7 +758,7 @@ static void VS_CC binarizeCreate(const VSMap *in, VSMap *out, void *userData, VS
         return;
     }
 
-    vsapi->createFilter(in, out, d->name, templateNodeInit<BinarizeData>, singlePixelGetFrame<BinarizeData, BinarizeOp>, templateNodeFree<BinarizeData>, fmParallel, 0, d.get(), core);
+    vsapi->createFilter(in, out, d->name, templateNodeInit<BinarizeData>, singlePixelGetFrame<BinarizeData, BinarizeOp>, templateNodeFree<BinarizeData>, NULL, fmParallel, 0, d.get(), core);
     d.release();
 }
 
@@ -924,11 +924,11 @@ static void VS_CC levelsCreate(const VSMap *in, VSMap *out, void *userData, VSCo
     }
 
     if (d->vi->format->bytesPerSample == 1)
-        vsapi->createFilter(in, out, d->name, templateNodeInit<LevelsData>, levelsGetframe<uint8_t>, templateNodeFree<LevelsData>, fmParallel, 0, d.get(), core);
+        vsapi->createFilter(in, out, d->name, templateNodeInit<LevelsData>, levelsGetframe<uint8_t>, templateNodeFree<LevelsData>, NULL, fmParallel, 0, d.get(), core);
     else if (d->vi->format->bytesPerSample == 2)
-        vsapi->createFilter(in, out, d->name, templateNodeInit<LevelsData>, levelsGetframe<uint16_t>, templateNodeFree<LevelsData>, fmParallel, 0, d.get(), core);
+        vsapi->createFilter(in, out, d->name, templateNodeInit<LevelsData>, levelsGetframe<uint16_t>, templateNodeFree<LevelsData>, NULL, fmParallel, 0, d.get(), core);
     else
-        vsapi->createFilter(in, out, d->name, templateNodeInit<LevelsData>, levelsGetframeF<float>, templateNodeFree<LevelsData>, fmParallel, 0, d.get(), core);
+        vsapi->createFilter(in, out, d->name, templateNodeInit<LevelsData>, levelsGetframeF<float>, templateNodeFree<LevelsData>, NULL, fmParallel, 0, d.get(), core);
     d.release();
 }
 

--- a/src/core/internalfilters.h
+++ b/src/core/internalfilters.h
@@ -38,5 +38,6 @@ void VS_CC genericInitialize(VSConfigPlugin configFunc, VSRegisterFunction regis
 void VS_CC lutInitialize(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin);
 void VS_CC boxBlurInitialize(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin);
 void VS_CC resizeInitialize(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin);
+void VS_CC audioInitialize(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin);
 
 #endif // INTERNALFILTERS_H

--- a/src/core/lutfilters.cpp
+++ b/src/core/lutfilters.cpp
@@ -184,7 +184,7 @@ static void lutCreateHelper(const VSMap *in, VSMap *out, VSFuncRef *func, std::u
         }
     }
 
-    vsapi->createFilter(in, out, "Lut", lutInit, lutGetframe<T, U>, lutFree, fmParallel, 0, d.release(), core);
+    vsapi->createFilter(in, out, "Lut", lutInit, lutGetframe<T, U>, lutFree, NULL, fmParallel, 0, d.release(), core);
 }
 
 static void VS_CC lutCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
@@ -439,7 +439,7 @@ static void lut2CreateHelper(const VSMap *in, VSMap *out, VSFuncRef *func, std::
         }
     }
 
-    vsapi->createFilter(in, out, "Lut2", lut2Init, lut2Getframe<T, U, V>, lut2Free, fmParallel, 0, d.release(), core);
+    vsapi->createFilter(in, out, "Lut2", lut2Init, lut2Getframe<T, U, V>, lut2Free, NULL, fmParallel, 0, d.release(), core);
 }
 
 static void VS_CC lut2Create(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {

--- a/src/core/mergefilters.c
+++ b/src/core/mergefilters.c
@@ -212,7 +212,7 @@ static void VS_CC preMultiplyCreate(const VSMap *in, VSMap *out, void *userData,
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "PreMultiply", preMultiplyInit, preMultiplyGetFrame, preMultiplyFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "PreMultiply", preMultiplyInit, preMultiplyGetFrame, preMultiplyFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -393,7 +393,7 @@ static void VS_CC mergeCreate(const VSMap *in, VSMap *out, void *userData, VSCor
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "Merge", mergeInit, mergeGetFrame, mergeFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "Merge", mergeInit, mergeGetFrame, mergeFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -628,7 +628,7 @@ static void VS_CC maskedMergeCreate(const VSMap *in, VSMap *out, void *userData,
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "MaskedMerge", maskedMergeInit, maskedMergeGetFrame, maskedMergeFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "MaskedMerge", maskedMergeInit, maskedMergeGetFrame, maskedMergeFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -783,7 +783,7 @@ static void VS_CC makeDiffCreate(const VSMap *in, VSMap *out, void *userData, VS
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "MakeDiff", makeDiffInit, makeDiffGetFrame, makeDiffFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "MakeDiff", makeDiffInit, makeDiffGetFrame, makeDiffFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -937,7 +937,7 @@ static void VS_CC mergeDiffCreate(const VSMap *in, VSMap *out, void *userData, V
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "MergeDiff", mergeDiffInit, mergeDiffGetFrame, mergeDiffFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "MergeDiff", mergeDiffInit, mergeDiffGetFrame, mergeDiffFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////

--- a/src/core/simplefilters.c
+++ b/src/core/simplefilters.c
@@ -245,7 +245,7 @@ static void VS_CC cropAbsCreate(const VSMap *in, VSMap *out, void *userData, VSC
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "Crop", cropInit, cropGetframe, singleClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "Crop", cropInit, cropGetframe, singleClipFree, NULL, fmParallel, 0, data, core);
 }
 
 static void VS_CC cropRelCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
@@ -283,7 +283,7 @@ static void VS_CC cropRelCreate(const VSMap *in, VSMap *out, void *userData, VSC
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "Crop", cropInit, cropGetframe, singleClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "Crop", cropInit, cropGetframe, singleClipFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -483,7 +483,7 @@ static void VS_CC addBordersCreate(const VSMap *in, VSMap *out, void *userData, 
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "AddBorders", addBordersInit, addBordersGetframe, singleClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "AddBorders", addBordersInit, addBordersGetframe, singleClipFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -665,7 +665,7 @@ static void VS_CC shufflePlanesCreate(const VSMap *in, VSMap *out, void *userDat
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "ShufflePlanes", shufflePlanesInit, shufflePlanesGetframe, shufflePlanesFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "ShufflePlanes", shufflePlanesInit, shufflePlanesGetframe, shufflePlanesFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -772,7 +772,7 @@ static void VS_CC separateFieldsCreate(const VSMap *in, VSMap *out, void *userDa
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "SeparateFields", separateFieldsInit, separateFieldsGetframe, singleClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "SeparateFields", separateFieldsInit, separateFieldsGetframe, singleClipFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -885,7 +885,7 @@ static void VS_CC doubleWeaveCreate(const VSMap *in, VSMap *out, void *userData,
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "DoubleWeave", doubleWeaveInit, doubleWeaveGetframe, singleClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "DoubleWeave", doubleWeaveInit, doubleWeaveGetframe, singleClipFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -926,7 +926,7 @@ static void VS_CC flipVerticalCreate(const VSMap *in, VSMap *out, void *userData
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "FlipVertical", singleClipInit, flipVerticalGetframe, singleClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "FlipVertical", singleClipInit, flipVerticalGetframe, singleClipFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -1026,7 +1026,7 @@ static void VS_CC flipHorizontalCreate(const VSMap *in, VSMap *out, void *userDa
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, d.flip ? "Turn180" : "FlipHorizontal", singleClipInit, flipHorizontalGetframe, singleClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, d.flip ? "Turn180" : "FlipHorizontal", singleClipInit, flipHorizontalGetframe, singleClipFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -1150,7 +1150,7 @@ static void VS_CC stackCreate(const VSMap *in, VSMap *out, void *userData, VSCor
         data = malloc(sizeof(d));
         *data = d;
 
-        vsapi->createFilter(in, out, d.vertical ? "StackVertical" : "StackHorizontal", stackInit, stackGetframe, stackFree, fmParallel, 0, data, core);
+        vsapi->createFilter(in, out, d.vertical ? "StackVertical" : "StackHorizontal", stackInit, stackGetframe, stackFree, NULL, fmParallel, 0, data, core);
     }
 }
 
@@ -1338,7 +1338,7 @@ static void VS_CC blankClipCreate(const VSMap *in, VSMap *out, void *userData, V
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "BlankClip", blankClipInit, blankClipGetframe, blankClipFree, d.keep ? fmUnordered : fmParallel, nfNoCache, data, core);
+    vsapi->createFilter(in, out, "BlankClip", blankClipInit, blankClipGetframe, blankClipFree, NULL, d.keep ? fmUnordered : fmParallel, nfNoCache, data, core);
 }
 
 //////////////////////////////////////////
@@ -1417,7 +1417,7 @@ static void VS_CC assumeFPSCreate(const VSMap *in, VSMap *out, void *userData, V
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "AssumeFPS", assumeFPSInit, assumeFPSGetframe, singleClipFree, fmParallel, nfNoCache, data, core);
+    vsapi->createFilter(in, out, "AssumeFPS", assumeFPSInit, assumeFPSGetframe, singleClipFree, NULL, fmParallel, nfNoCache, data, core);
 }
 
 //////////////////////////////////////////
@@ -1587,7 +1587,7 @@ static void VS_CC frameEvalCreate(const VSMap *in, VSMap *out, void *userData, V
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "FrameEval", frameEvalInit, d.numpropsrc ? frameEvalGetFrameWithProps : frameEvalGetFrameNoProps, frameEvalFree, d.numpropsrc ? fmParallelRequests : fmUnordered, 0, data, core);
+    vsapi->createFilter(in, out, "FrameEval", frameEvalInit, d.numpropsrc ? frameEvalGetFrameWithProps : frameEvalGetFrameNoProps, frameEvalFree, NULL, d.numpropsrc ? fmParallelRequests : fmUnordered, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -1689,7 +1689,7 @@ static void VS_CC modifyFrameCreate(const VSMap *in, VSMap *out, void *userData,
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "ModifyFrame", modifyFrameInit, modifyFrameGetFrame, modifyFrameFree, fmParallelRequests, 0, data, core);
+    vsapi->createFilter(in, out, "ModifyFrame", modifyFrameInit, modifyFrameGetFrame, modifyFrameFree, NULL, fmParallelRequests, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -1788,7 +1788,7 @@ static void VS_CC transposeCreate(const VSMap *in, VSMap *out, void *userData, V
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "Transpose", transposeInit, transposeGetFrame, transposeFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "Transpose", transposeInit, transposeGetFrame, transposeFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -1938,7 +1938,7 @@ static void VS_CC pemVerifierCreate(const VSMap *in, VSMap *out, void *userData,
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "PEMVerifier", pemVerifierInit, pemVerifierGetFrame, pemVerifierFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "PEMVerifier", pemVerifierInit, pemVerifierGetFrame, pemVerifierFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -2134,7 +2134,7 @@ static void VS_CC planeStatsCreate(const VSMap *in, VSMap *out, void *userData, 
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "PlaneStats", planeStatsInit, planeStatsGetFrame, planeStatsFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "PlaneStats", planeStatsInit, planeStatsGetFrame, planeStatsFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -2203,7 +2203,7 @@ static void VS_CC clipToPropCreate(const VSMap *in, VSMap *out, void *userData, 
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "ClipToProp", clipToPropInit, clipToPropGetFrame, clipToPropFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "ClipToProp", clipToPropInit, clipToPropGetFrame, clipToPropFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -2300,7 +2300,7 @@ static void VS_CC propToClipCreate(const VSMap *in, VSMap *out, void *userData, 
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "PropToClip", propToClipInit, propToClipGetFrame, propToClipFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "PropToClip", propToClipInit, propToClipGetFrame, propToClipFree, NULL, fmParallel, 0, data, core);
 }
 
 //////////////////////////////////////////
@@ -2432,7 +2432,7 @@ static void VS_CC setFramePropCreate(const VSMap *in, VSMap *out, void *userData
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "SetFrameProp", setFramePropInit, setFramePropGetFrame, setFramePropFree, fmParallel, nfNoCache, data, core);
+    vsapi->createFilter(in, out, "SetFrameProp", setFramePropInit, setFramePropGetFrame, setFramePropFree, NULL, fmParallel, nfNoCache, data, core);
 }
 
 //////////////////////////////////////////
@@ -2477,7 +2477,7 @@ static void VS_CC setFieldBasedCreate(const VSMap *in, VSMap *out, void *userDat
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "SetFieldBased", singleClipInit, setFieldBasedGetFrame, singleClipFree, fmParallel, nfNoCache, data, core);
+    vsapi->createFilter(in, out, "SetFieldBased", singleClipInit, setFieldBasedGetFrame, singleClipFree, NULL, fmParallel, nfNoCache, data, core);
 }
 
 static void VS_CC setMaxCpu(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {

--- a/src/core/textfilter.cpp
+++ b/src/core/textfilter.cpp
@@ -702,7 +702,7 @@ static void VS_CC textCreate(const VSMap *in, VSMap *out, void *userData, VSCore
 
     data = new TextData(d);
 
-    vsapi->createFilter(in, out, d.instanceName.c_str(), textInit, textGetFrame, textFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, d.instanceName.c_str(), textInit, textGetFrame, textFree, NULL, fmParallel, 0, data, core);
 }
 
 

--- a/src/core/vscore.h
+++ b/src/core/vscore.h
@@ -478,6 +478,7 @@ private:
     std::string name;
     VSFilterInit init;
     VSFilterGetFrame filterGetFrame;
+    VSFilterGetAudio filterGetAudio;
     VSFilterFree free;
     VSFilterMode filterMode;
 
@@ -485,6 +486,7 @@ private:
     VSCore *core;
     int flags;
     bool hasVi;
+    bool hasAu;
     std::vector<VSVideoInfo> vi;
 
     // for keeping track of when a filter is busy in the exclusive section and with which frame
@@ -499,7 +501,7 @@ private:
 
     PVideoFrame getFrameInternal(int n, int activationReason, VSFrameContext &frameCtx);
 public:
-    VSNode(const VSMap *in, VSMap *out, const std::string &name, VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, VSFilterMode filterMode, int flags, void *instanceData, int apiMajor, VSCore *core);
+    VSNode(const VSMap *in, VSMap *out, const std::string &name, VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, VSFilterGetAudio getAudio, VSFilterMode filterMode, int flags, void *instanceData, int apiMajor, VSCore *core);
 
     ~VSNode();
 
@@ -508,6 +510,7 @@ public:
     }
 
     void getFrame(const PFrameContext &ct);
+    void getAudio(void *lpBuffer, long lStart, long lSamples);
 
     const VSVideoInfo &getVideoInfo(int index);
 
@@ -664,7 +667,7 @@ public:
     bool isValidFormatPointer(const VSFormat *f);
 
     void loadPlugin(const std::string &filename, const std::string &forcedNamespace = std::string(), const std::string &forcedId = std::string(), bool altSearchPath = false);
-    void createFilter(const VSMap *in, VSMap *out, const std::string &name, VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, VSFilterMode filterMode, int flags, void *instanceData, int apiMajor);
+    void createFilter(const VSMap *in, VSMap *out, const std::string &name, VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, VSFilterGetAudio getAudio, VSFilterMode filterMode, int flags, void *instanceData, int apiMajor);
 
     int getCpuLevel() const;
     int setCpuLevel(int cpu);

--- a/src/core/vsresize.cpp
+++ b/src/core/vsresize.cpp
@@ -934,7 +934,7 @@ public:
     static void create(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
         try {
             vszimg *x = new vszimg{ in, userData, core, vsapi };
-            vsapi->createFilter(in, out, "format", vszimg_init, vszimg_get_frame, vszimg_free, fmParallel, 0, x, core);
+            vsapi->createFilter(in, out, "format", vszimg_init, vszimg_get_frame, vszimg_free, NULL, fmParallel, 0, x, core);
         } catch (const vszimgxx::zerror &e) {
             std::string errmsg = std::string{ "Resize error " } + std::to_string(e.code) + ": " + e.msg;
             vsapi->setError(out, errmsg.c_str());


### PR DESCRIPTION
This PR lays the foundation for audio support.

For this first step, we wanted to be able to hear a sound when playing a vpy on virtual dub on Windows.
VSVFW has been modify to declare an audio track
Vapoursynth has been modify to have a `GetAudio` function for each filter.
`Tone` is a function to produce a sounds of a certain frequency over a certain length. Output is always 16 bits.
`MixAudio` mixes to audio tracks
`FadeInOut` fades an audio track at the beginning and at the end
`AudioDub` adds an audio tracks to a video track

Here is a test script to try it out:

```
from vapoursynth import core

c=C=261.6255653006
D=d=293.6647679174
E=e=329.6275569129
F=f=349.2282314330
G=g=391.9954359817
A=a=440.00000000001
B=b=493.8833012561

def note(len, freq):
	return core.std.FadeInOut(core.std.Tone(length=len,frequency=freq,channels=2,level=1.0,samplerate=48000), 500)


video = core.std.BlankClip(length=42)
audio = note(0.25, A) + note(0.25, B) + note(0.25, C) + note(0.25, D) + note(0.25, E) + note(0.25, F) + note(0.25, G)

track = core.std.AudioDub(video, audio);

track.set_output()
```

This is obviously still a work in progress and may be used by someone to build a more robust audio support for VapourSynth.