### PR TITLE
Allow Script-Runners to control which environments are active and which not

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -565,7 +565,8 @@ Classes and Functions
    Once the method :method:`on_policy_registered` has been called, the policy is responsible for creating and managing environments.
 
    Special considerations have been made to ensure the functions of class cannot be abused. You cannot retrieve the current running policy youself.
-   The additional API-calls are only valid if the policy has been registered. Once the policy is unregistered, all additional API-calls will fail with a RuntimeError.
+   The additional API exposed by "on_policy_registered" is only valid if the policy has been registered.
+   Once the policy is unregistered, all calls to the additional API will fail with a RuntimeError.
 
    .. py:method:: on_policy_registered(special_api)
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -570,9 +570,7 @@ Classes and Functions
    .. py:method:: use
 
       Returns a context-manager that enables the given environment in the block enclosed in the with-statement and restores the environment to the one
-      defined before.
-
-      The following code is safe in all cases.
+      defined before the with-block has been encountered.
 
       .. code::
       

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -711,7 +711,7 @@ Classes and Functions
 
    Internal class that stores the context sensitive data that VapourSynth needs. It is an opaque object whose attributes you cannot access directly.
 
-   A normal user has now way of getting an instance of this object. You can only encounter EnvironmentData-objects if you work with EnvironmentPolicies.
+   A normal user has no way of getting an instance of this object. You can only encounter EnvironmentData-objects if you work with EnvironmentPolicies.
 
    This object is weak-referenciable meaning you can get a callback if the environment-data object is actually being freed (i.e. no other object holds an instance
    to the environment data.)

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -523,8 +523,23 @@ Classes and Functions
 
         env = vpy_current_environment()
         # sometime later
-        with env:
+        with env.use():
           # Do stuff inside this env.
+
+   .. warning::
+
+      Environment-objects obtained using the :function:`vpy_current_environment` can directly be used as
+      as a context manager. This can cuase undefined behaviour when used in combination with generators and/or
+      coroutines.
+
+      This context-manager maintains a thread-local environment-stack that is used to restore the previous environment.
+      This can cause issues if the frame is suspended inside the block.
+      
+      .. code::
+
+         env = vpy_current_environment()
+         with env:
+              yield
 
    .. py:function:: is_single()
 
@@ -544,12 +559,46 @@ Classes and Functions
 
       Has the environment been destroyed by the underlying application?
 
+   .. py:method:: copy
+
+      Creates a copy of the environment-object. It will not copy the environment itself.
+
+      Added: R50
+
+   .. py:method:: use
+
+      Returns a context-manager that enables the given environment in the block enclosed in the with-statement and restores the environment to the one
+      defined before.
+
+      The following code is safe in all cases.
+
+      .. code::
+      
+         env = vpy_current_environment()
+         with env.use():
+             with env.use():
+                 pass
+
+      Added: R50
+
 .. py:function:: vpy_current_environment()
+
+   Deprecated. Use :function:`get_current_environment` instead.
 
    Returns an Environment-object representing the environment the script is currently running in. It will raise an error if we are currently not inside any
    script-environment while vsscript is being used.
 
    This function is intended for Python-based editors using vsscript.
+   This function has been deprecated as this function has undefined behaviour when used together with generators or coroutines.
+
+.. py:function:: get_current_environment()
+
+   Returns an Environment-object representing the environment the script is currently running in. It will raise an error if we are currently not inside any
+   script-environment while vsscript is being used.
+
+   This function is intended for Python-based editors using vsscript.
+
+   Added: R50
 
 .. py:class:: EnvironmentPolicy
 
@@ -567,6 +616,8 @@ Classes and Functions
    Special considerations have been made to ensure the functions of class cannot be abused. You cannot retrieve the current running policy youself.
    The additional API exposed by "on_policy_registered" is only valid if the policy has been registered.
    Once the policy is unregistered, all calls to the additional API will fail with a RuntimeError.
+
+   Added: R50
 
    .. py:method:: on_policy_registered(special_api)
 
@@ -586,17 +637,12 @@ Classes and Functions
 
       :returns: An :class:`EnvironmentData`-object representing the currently active environment in the current context.
 
-   .. py:method:: push_environment(env)
+   .. py:method:: set_environment(environment)
 
-      This method is called by the module to change the currently active environment. It should behave like a stack.
+      This method is called by the module to change the currently active environment.
 
-      :param id: The :class:`EnvironmentData` to enable in the current context.
-
-   .. py:method:: pop_environment()
-
-      This method is called by the module to remove the currently selected environment from the current context.
-
-      :returns: The :class:`EnvironmentData`-object that has just been popped or None if no ID was active.
+      :param environment: The :class:`EnvironmentData` to enable in the current context.
+      :returns: The environment that was enabled previously.
 
    .. py:method:: is_alive(environment)
 
@@ -606,6 +652,8 @@ Classes and Functions
 
    This class is intended to be used by custom Script-Runners and Editors. An instance of this class exposes an additional API.
    The methods are bound to a specific :class:`EnvironmentPolicy`-instance and will only work if the policy is currenty registered.
+
+   Added: R50
 
    .. py:method:: wrap_environment(environment)
 
@@ -630,6 +678,8 @@ Classes and Functions
    installed.
 
    If no policy is installed, the first environment-sensitive call will automatically register an internal policy.
+
+   Added: R50
    
    .. note::
 
@@ -642,11 +692,14 @@ Classes and Functions
       * Using :function:`clear_output`
       * Using :function:`clear_outputs`
       * Using :function:`vpy_current_environment`
+      * Using :function:`get_current_environment`
       * Accessing any attribute of :attribute:`core`
 
 .. py:function:: has_policy()
 
    This class is intended for subclassing by custom Script-Runners and Editors. This function checks if a :class:`EnvironmentPolicy` has been installed.
+
+   Added: R50
 
 .. py:attribute: _using_vsscript
 
@@ -662,6 +715,8 @@ Classes and Functions
 
    This object is weak-referenciable meaning you can get a callback if the environment-data object is actually being freed (i.e. no other object holds an instance
    to the environment data.)
+
+   Added: R50
 
 .. py:class:: Func
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -553,16 +553,19 @@ Classes and Functions
 
 .. py:class:: EnvironmentPolicy
 
-   This class is intended for subclassing by custom Script-Runners and Editors. The instance controls which environment is in which context. Each environment must be associated
-   with a unique ID (integer) that identifies which environment is in use. The exact meaning of "context" is defined by the concrete EnvironmentPolicy.
+   This class is intended for subclassing by custom Script-Runners and Editors.
+   Normal users don't need this class. Most methods implemented here have corresponding APIs in other parts of this module.
+   
+   An instance of this class controls which environment is in which context.
+   The exact meaning of "context" is defined by the concrete EnvironmentPolicy. A environment is represented by a :class:`EnvironemtnData`-object.
 
    To use this class, first create a subclass and then use :function:`register_policy` to get VapourSynth to use your policy. This must happen before vapoursynth is first
    used. VapourSynth will automatically register an internal policy if it needs one. The subclass must be weak-referenciable!
+   
+   Once the method :method:`on_policy_registered` has been called, the policy is responsible for creating and managing environments.
 
    Special considerations have been made to ensure the functions of class cannot be abused. You cannot retrieve the current running policy youself.
    The additional API-calls are only valid if the policy has been registered. Once the policy is unregistered, all additional API-calls will fail with a RuntimeError.
-   
-   Normal users don't need this class. Most methods implemented here have corresponding APIs in other parts of this module.
 
    .. py:method:: on_policy_registered(special_api)
 
@@ -590,7 +593,7 @@ Classes and Functions
 
    .. py:method:: pop_environment()
 
-      This method is called by the module to remove the currently selected core from the current context.
+      This method is called by the module to remove the currently selected environment from the current context.
 
       :returns: The :class:`EnvironmentData`-object that has just been popped or None if no ID was active.
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -534,6 +534,8 @@ Classes and Functions
 
       This context-manager maintains a thread-local environment-stack that is used to restore the previous environment.
       This can cause issues if the frame is suspended inside the block.
+
+      A similar problem also existed in previous VapourSynth versions!
       
       .. code::
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -594,11 +594,11 @@ Classes and Functions
 
       :returns: The environment ID that has just been popped or None if no ID was active.
 
-   .. py:method: is_alive(id)
+   .. py:method:: is_alive(id)
 
       Is the environment with the given ID alive?
 
-   .. py:method: get_core(id)
+   .. py:method:: get_core(id)
 
       :param id: The environment-id to retrieve the core from.
       :returns: the :class:`Core`-object that is associated with the given ID. Return None if there is no core associated with the ID.
@@ -607,22 +607,22 @@ Classes and Functions
 
          VapourSynth creates :class:`Core`-objects lazily! The fact that this method returns None does not indicate that the environment is not alive.
 
-   .. py:method: set_core(id, core_obj)
+   .. py:method:: set_core(id, core_obj)
 
       Sets the core-object for the given ID. Do nothing if the environment is not alive.
 
       :param id: The environment-id to associate the core with.
       :param core_obj: The :class:`Core`-instance that shall be associated with the given environment-id.
 
-   .. py:method: get_output_dict(id)
+   .. py:method:: get_output_dict(id)
 
       :returns: the dictionary containing the stored outputs of the given environment. The contents of the dictionary might be changed by the caller.
 
-.. py:class: EnvironmentPolicyAPI
+.. py:class:: EnvironmentPolicyAPI
 
    An instance of this class exposes an additional API. The methods are bound to a specific :class:`EnvironmentPolicy`-instance and will only work if the policy is currenty registered.
 
-   .. py:method: use_environment(id)
+   .. py:method:: use_environment(id)
 
       Creates a new :class:`Environment`-object bound to the passed environment-id.
 
@@ -630,11 +630,11 @@ Classes and Functions
 
          This function does not check if the id corresponds to a live environment as the caller is expected to know which environments are active.
 
-   .. py:method: unregister_policy()
+   .. py:method:: unregister_policy()
 
       Unregisters the policy it is bound to and allows another policy to be registered.
 
-.. py:function: register_policy(policy)
+.. py:function:: register_policy(policy)
 
    This class is intended for use by custom Script-Runners and Editors. It installs your custom :class:`EnvironmentPolicy`. This function only works if no other policy has been
    installed.
@@ -654,7 +654,7 @@ Classes and Functions
       * Using :function:`vpy_current_environment`
       * Accessing any attribute of :attribute:`core`
 
-.. py:function: has_policy()
+.. py:function:: has_policy()
 
    This class is intended for subclassing by custom Script-Runners and Editors. This function checks if a :class:`EnvironmentPolicy` has been installed.
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -701,7 +701,7 @@ Classes and Functions
 
    Added: R50
 
-.. py:attribute: _using_vsscript
+.. py:attribute:: _using_vsscript
 
    INTERNAL ATTRIBUTE. Deprecated (will be removed soon). This was the only way to find out if VSScript.h was calling this script.
    It now stores true if a custom policy is installed or VSScript.h is used. Use :function:`has_policy` instead.

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -518,7 +518,7 @@ Classes and Functions
    Some editors allow multiple vapoursynth-scripts to run in the same process, each of them comes with a different Core-instance and
    their own set of outputs. Each core-instance with their associated outputs represent their own environment.
 
-   At any given time, only one environment can be active at any given time (in the same context). This class allows introspection about
+   At any given time, only one environment can be active (in the same context). This class allows introspection about
    environments and allows to switch to them at will.
 
    .. code::

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -528,7 +528,7 @@ Classes and Functions
 
    .. warning::
 
-      Environment-objects obtained using the :function:`vpy_current_environment` can directly be used as
+      Environment-objects obtained using the :func:`vpy_current_environment` can directly be used as
       as a context manager. This can cuase undefined behaviour when used in combination with generators and/or
       coroutines.
 
@@ -583,7 +583,7 @@ Classes and Functions
 
 .. py:function:: vpy_current_environment()
 
-   Deprecated. Use :function:`get_current_environment` instead.
+   Deprecated. Use :func:`get_current_environment` instead.
 
    Returns an Environment-object representing the environment the script is currently running in. It will raise an error if we are currently not inside any
    script-environment while vsscript is being used.
@@ -608,10 +608,10 @@ Classes and Functions
    An instance of this class controls which environment is in which context.
    The exact meaning of "context" is defined by the concrete EnvironmentPolicy. A environment is represented by a :class:`EnvironemtnData`-object.
 
-   To use this class, first create a subclass and then use :function:`register_policy` to get VapourSynth to use your policy. This must happen before vapoursynth is first
+   To use this class, first create a subclass and then use :func:`register_policy` to get VapourSynth to use your policy. This must happen before vapoursynth is first
    used. VapourSynth will automatically register an internal policy if it needs one. The subclass must be weak-referenciable!
    
-   Once the method :method:`on_policy_registered` has been called, the policy is responsible for creating and managing environments.
+   Once the method :meth:`on_policy_registered` has been called, the policy is responsible for creating and managing environments.
 
    Special considerations have been made to ensure the functions of class cannot be abused. You cannot retrieve the current running policy youself.
    The additional API exposed by "on_policy_registered" is only valid if the policy has been registered.
@@ -674,7 +674,7 @@ Classes and Functions
 
 .. py:function:: register_policy(policy)
 
-   This class is intended for use by custom Script-Runners and Editors. It installs your custom :class:`EnvironmentPolicy`. This function only works if no other policy has been
+   This function is intended for use by custom Script-Runners and Editors. It installs your custom :class:`EnvironmentPolicy`. This function only works if no other policy has been
    installed.
 
    If no policy is installed, the first environment-sensitive call will automatically register an internal policy.
@@ -686,25 +686,25 @@ Classes and Functions
       This must be done before VapourSynth is used in any way. Here is a non-exhaustive list that automatically register a policy:
 
       * Using "vsscript_init" in "VSScript.h"
-      * Using :function:`get_core`
-      * Using :function:`get_outputs`
-      * Using :function:`get_output`
-      * Using :function:`clear_output`
-      * Using :function:`clear_outputs`
-      * Using :function:`vpy_current_environment`
-      * Using :function:`get_current_environment`
-      * Accessing any attribute of :attribute:`core`
+      * Using :func:`get_core`
+      * Using :func:`get_outputs`
+      * Using :func:`get_output`
+      * Using :func:`clear_output`
+      * Using :func:`clear_outputs`
+      * Using :func:`vpy_current_environment`
+      * Using :func:`get_current_environment`
+      * Accessing any attribute of :attr:`core`
 
 .. py:function:: has_policy()
 
-   This class is intended for subclassing by custom Script-Runners and Editors. This function checks if a :class:`EnvironmentPolicy` has been installed.
+   This function is intended for subclassing by custom Script-Runners and Editors. This function checks if a :class:`EnvironmentPolicy` has been installed.
 
    Added: R50
 
 .. py:attribute:: _using_vsscript
 
    INTERNAL ATTRIBUTE. Deprecated (will be removed soon). This was the only way to find out if VSScript.h was calling this script.
-   It now stores true if a custom policy is installed or VSScript.h is used. Use :function:`has_policy` instead.
+   It now stores true if a custom policy is installed or VSScript.h is used. Use :func:`has_policy` instead.
 
 
 .. py:class:: EnvironmentData

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -578,19 +578,19 @@ Classes and Functions
    
    .. py:method:: get_current_environment()
 
-      This method is called by the wrapper to detect which core is currently running in the current context.
+      This method is called by the module to detect which environment is currently running in the current context.
 
       :returns: An :class:`EnvironmentData`-object representing the currently active environment in the current context.
 
    .. py:method:: push_environment(env)
 
-      This method is called by the wrapper to change the currently active core. It should behave like a stack.
+      This method is called by the module to change the currently active environment. It should behave like a stack.
 
       :param id: The :class:`EnvironmentData` to enable in the current context.
 
    .. py:method:: pop_environment()
 
-      This method is called by the wrapper to remove the currently selected core from the current context.
+      This method is called by the module to remove the currently selected core from the current context.
 
       :returns: The :class:`EnvironmentData`-object that has just been popped or None if no ID was active.
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -571,7 +571,7 @@ Classes and Functions
 
       :param special_api: This is a :class:`EnvironmentPolicyAPI`-object that exposes additional API
 
-   .. py:method: on_policy_cleared()
+   .. py:method:: on_policy_cleared()
 
       This method is called once the python-process exits or when unregister_policy is called by the environment-policy. This allows the policy to free the resources
       used by the policy.

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -515,9 +515,11 @@ Classes and Functions
 
    This class represents an environment.
 
-   It is a context-manager allowing you to switch to this environment at will.
-   But it is faster than using the equivalent evaluate_script-function as it does not
-   impose additional exception handling.
+   Some editors allow multiple vapoursynth-scripts to run in the same process, each of them comes with a different Core-instance and
+   their own set of outputs. Each core-instance with their associated outputs represent their own environment.
+
+   At any given time, only one environment can be active at any given time (in the same context). This class allows introspection about
+   environments and allows to switch to them at will.
 
    .. code::
 
@@ -605,8 +607,8 @@ Classes and Functions
    This class is intended for subclassing by custom Script-Runners and Editors.
    Normal users don't need this class. Most methods implemented here have corresponding APIs in other parts of this module.
    
-   An instance of this class controls which environment is in which context.
-   The exact meaning of "context" is defined by the concrete EnvironmentPolicy. A environment is represented by a :class:`EnvironemtnData`-object.
+   An instance of this class controls which environment is activated in a the current context.
+   The exact meaning of "context" is defined by the concrete EnvironmentPolicy. A environment is represented by a :class:`EnvironmentData`-object.
 
    To use this class, first create a subclass and then use :func:`register_policy` to get VapourSynth to use your policy. This must happen before vapoursynth is first
    used. VapourSynth will automatically register an internal policy if it needs one. The subclass must be weak-referenciable!

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -607,7 +607,7 @@ Classes and Functions
    This class is intended for subclassing by custom Script-Runners and Editors.
    Normal users don't need this class. Most methods implemented here have corresponding APIs in other parts of this module.
    
-   An instance of this class controls which environment is activated in a the current context.
+   An instance of this class controls which environment is activated in the current context.
    The exact meaning of "context" is defined by the concrete EnvironmentPolicy. A environment is represented by a :class:`EnvironmentData`-object.
 
    To use this class, first create a subclass and then use :func:`register_policy` to get VapourSynth to use your policy. This must happen before vapoursynth is first

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -561,7 +561,13 @@ Classes and Functions
 
       Has the environment been destroyed by the underlying application?
 
-   .. py:method:: use()
+   .. py:method:: copy
+
+      Creates a copy of the environment-object.
+
+      Added: R50
+
+   .. py:method:: use
 
       Returns a context-manager that enables the given environment in the block enclosed in the with-statement and restores the environment to the one
       defined before the with-block has been encountered.

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -596,7 +596,7 @@ Classes and Functions
 
    .. py:method:: is_alive(environment)
 
-      Is the current environment policy still active and managed by the policy.
+      Is the current environment still active and managed by the policy.
 
 .. py:class:: EnvironmentPolicyAPI
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -521,7 +521,7 @@ Classes and Functions
 
    .. code::
 
-        env = vpy_current_environment()
+        env = get_current_environment()
         # sometime later
         with env.use():
           # Do stuff inside this env.

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -561,13 +561,7 @@ Classes and Functions
 
       Has the environment been destroyed by the underlying application?
 
-   .. py:method:: copy
-
-      Creates a copy of the environment-object. It will not copy the environment itself.
-
-      Added: R50
-
-   .. py:method:: use
+   .. py:method:: use()
 
       Returns a context-manager that enables the given environment in the block enclosed in the with-statement and restores the environment to the one
       defined before the with-block has been encountered.

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -63,7 +63,7 @@ setup(
 
     packages=[],
     install_requires=["vapoursynth==" + CURRENT_RELEASE],
-    # setup_requires=["vapoursynth==" + CURRENT_RELEASE],
+    setup_requires=["vapoursynth==" + CURRENT_RELEASE],
     data_files = [
         ("Lib\\site-packages", [
             os.path.join(build_dir, p)

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -63,7 +63,7 @@ setup(
 
     packages=[],
     install_requires=["vapoursynth==" + CURRENT_RELEASE],
-    setup_requires=["vapoursynth==" + CURRENT_RELEASE],
+    # setup_requires=["vapoursynth==" + CURRENT_RELEASE],
     data_files = [
         ("Lib\\site-packages", [
             os.path.join(build_dir, p)

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -266,7 +266,7 @@ cdef class Environment(object):
     cdef _get_stack(self):
         if not self.use_stack:
             raise RuntimeError("You cannot directly use the environment as a context-manager. Use Environment.use instead.")
-        _tl_env_stack.stack = getattr(_tl_env_stack, "stack", )
+        _tl_env_stack.stack = getattr(_tl_env_stack, "stack", [])
         return _tl_env_stack.stack
 
     def __enter__(self):
@@ -1453,8 +1453,6 @@ cdef class VideoNode(object):
             
             clip = AlphaOutputTuple(self, alpha)
 
-        if self.core is not :
-            raise EnvironmentError("Trying to attach a clip to the wrong output node.")
         _get_output_dict("set_output")[index] = clip
 
     def output(self, object fileobj not None, bint y4m = False, object progress_update = None, int prefetch = 0):

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -266,7 +266,7 @@ cdef class Environment(object):
     cdef _get_stack(self):
         if not self.use_stack:
             raise RuntimeError("You cannot directly use the environment as a context-manager. Use Environment.use instead.")
-        _tl_env_stack.stack = getattr(_tl_env_stack, "stack", [])
+        _tl_env_stack.stack = getattr(_tl_env_stack, "stack", )
         return _tl_env_stack.stack
 
     def __enter__(self):
@@ -1453,6 +1453,8 @@ cdef class VideoNode(object):
             
             clip = AlphaOutputTuple(self, alpha)
 
+        if self.core is not :
+            raise EnvironmentError("Trying to attach a clip to the wrong output node.")
         _get_output_dict("set_output")[index] = clip
 
     def output(self, object fileobj not None, bint y4m = False, object progress_update = None, int prefetch = 0):

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -253,7 +253,7 @@ cdef class Environment(object):
             return -1
         return id(self.env)
 
-    cdef EnvironmentData get_env():
+    cdef EnvironmentData get_env(self):
         return self.env()
 
     @property
@@ -262,6 +262,12 @@ cdef class Environment(object):
         if env is None:
             return None
         return get_policy().get_current_environment() is env
+
+    def copy(self):
+        cdef Environment env = Environment.__new__(Environment)
+        env.env = self.env
+        env.use_stack = False
+        return env
 
     def use(self):
         env = self.get_env()

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -121,7 +121,9 @@ def register_policy(policy):
     if _policy is not None:
         raise RuntimeError("There is already a policy registered.")
     _policy = policy
-    _policy.on_policy_registered(lambda id: use_environment(id))
+    _policy.on_policy_registered({
+        "use_environment": lambda id: use_environment(id)
+    })
 
     if not isinstance(policy, StandaloneEnvironmentPolicy):
         # Older script had to use this flag to determine if it ran in

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2336,7 +2336,7 @@ cdef public api int vpy_getVariable(VPYScriptExport *se, const char *name, VSMap
             try:
                 dname = name.decode('utf-8')
                 read_var = { dname:evaldict[dname]}
-                core = vsscript_get_core_internal(se.id)
+                core = vsscript_get_core_internal(_get_vsscript_policy().get_environment(se.id))
                 dictToMap(read_var, dst, core.core, vpy_getVSApi())
                 return 0
             except:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -52,6 +52,8 @@ cdef class EnvironmentData(object):
     cdef object core
     cdef dict outputs
 
+    cdef object __weakref__
+
     def __init__(self):
         raise RuntimeError("Cannot directly instantiate this class.")
 


### PR DESCRIPTION
This PR allows Script-Hosts to implement their own management of VapourSynth-environments.

# Rationale
## Shortcomings of the current Thread-Local Approach
VSScript allows for multiple concurrent script environments to be alive at the same time. This lead to [concurrency problems](https://github.com/vapoursynth/vapoursynth/issues/390) as multiple environments fought over the which one is active. The solution was to move this value into a thread-local variable.

This introduced problems when vapoursynth users actually tried to use Multi-Threaded applications inside vsscript. In addition, a implementation-detail of vsscript was leaking into the code: The environment-id. Most of the vapoursynth wrapper does not need to know the actual environment id, they just need a pointer to the environment they are attached
to.

## Event-loops

Event-loops have existed in the Python-World [for a long time](https://twistedmatrix.com/trac/). With the introduction of [`asyncio`](https://docs.python.org/3/library/asyncio.html) the actual use of event-loops in python became wide-spread.

Until 3.7, Python lacked the ability to use Task-local-variables. The module [`contextvars`](https://docs.python.org/3/library/contextvars.html) implemented a library that allowed framework-authors to influence which context is active at any given callback. This is used in asyncio to implement Task-local variables.

VapourSynth is not aware of `contextvars` and thus will use thread-local storage.

## Custom Script-Runners

People who want to write their own script-runners (vsedit) usually better what concurrency requirements they actually have. There is no way for those to influence how the vapoursynth module manages which environment is actually active.

# Proposal

This proposal changes three things:
* This PR encapsulates the variables that are intrinsic to a script-environment into its own structure.
  Instead of the environment-id (which is an integer), it uses this object to control which environment the callbacks are attached to.
* It introduces a `EnvironmentPolicy`, a class that can be used to control how the vapoursynth module manages which is actually active any any given time.
* Changes to the `Environment` API that had some issues with undefined behaviour.

## Encapsulation of the Script-Environment state.

Right now, an environment of the module has two attribues: The currenct `Core` instance and the outputs attached to it. These were stored in four global variables. Two of those variables were only used if the VapourSynth module is running in standalone-mode and the other to were only used if vsscript was active. It depends on an exposed private variable `_using_vsscript`, which set of variables is actually used.

The change encapsulates these two variables into its own `EnvironmentData`-class and changes how the callback-functions refer to these variables.

## EnvironmentPolicy-Instances

A host-application can now implement an EnvironmentPolicy-class and make vapoursynth use it to manage which environment is active at any time. This gets passed special API-methods that allow it to create new environments at will.

Special considerations have been made so that the currently policy does not leak to the user. This prevents the user to access Policy-instances and mess with its internals.

### Lifecycle of an EnvironmentPolicy

```
Host-Application                            vapoursynth.pyx
       |                                           |
       | -------register_policy(my_policy)-------> |
       | <--my_policy.on_policy_registered(API)--- |
       |                                           |
       .                                           .
       .                                           .
       .                                           .
       |                                           |
       | <-----my_policy.on_policy_cleared()------ |
       |  (Called at-exit or when the policy is    |
       |   deactivated)                            |
       |                                           |
```

### A special API for EnvironmentPolicies

During the registration of a policy, a special object is passed to the policy, that allow it to create new environments at will and pass them to client code as well. This object is bound to the policy and all methods on it will fail once the policy is disabled.

The methods are as follows:

* `EnvironmentPolicyAPI.unregister_policy() -> NoReturn` unregisters the policy. Will cause all subsequent calls to this object to fail.
* `EnvironmentPolicyAPI.wrap_environment(EnvironmentData) -> Environment` wraps an environment into a wrapper object that can be passed
  to other parts of the application.
* `EnvironmentPolicyAPI.create_environment() -> EnvironmentData` creates a new environment. No further initialiation is neccessary.

### Entering an environment at will

VapourSynth will ask the policy every time it wants to request the current environment.
To do that, the `EnvironmentPolicy.get_current_environment() -> Optional[EnvironmentData]` is called. If this function returns `None`,
the module assumes no environment is active and will fail with a corresponding error.

VapourSynth has its own callbacks. These callbacks are attached to a specific environment that needs to be enabled while running
the callbacks. In order to do this, the module will call the function
`EnvironmentPolicy.set_environment(EnvironmentData) -> Optional[EnvironmentData]`.
This will activate the environment for the given callback and return the previously active environment-object.

```
Host-Application                            vapoursynth.pyx                                 User Script
       |                                           |                                             |
       |                                           | <---------Script does a FrameEval---------- |
       | <---my_policy.get_current_environment---- |                                             |
       | -------(The active environment X)-------> |                                             |
       |                                           |                                             |
       |                     (Create a Func object and pass it to the filter)                    |
       |                         [attach the EnvironmentData for X to it]                        |
       |                                           |                                             |
       |                                           | ------------FrameEval-Clip----------------->|
       .                                           .                                             .
       .                                           .                                             .
       .                       (Some time later, the new environment is Y)                       .
       .                                           .                                             .
       .                                           .                                             .
       |                                           |                                             |
       |                                           |                                             |
       |                                 Enter the environment X                                 |
       | <-----my_policy.set_environment(X)------- |                                             |
       | ------(The previous environment Y)------> | (Y is stored on the stack frame)            |
       |                                           |                                             |
       |                                           | -------------Run the callback-------------> |
       |                                           | <------------------------------------------ |
       |                                           |                                             |
       | <-----my_policy.set_environment(Y)------- |                                             |
       | ------(The previous environment X)------> | (X is ignored)                              |
       |                                 Exit the environment X                                  |
       |                                           |                                             |
```

### Changes to the Environment-API

Unfortunately, this proved to be incompatible to the old way this was done (Having its own stack inside a thread-local). A second API has been introduced to fix this problem. Users of the old API will still use a thread-local stack and a warning is printed to the console that undefined behaviour can occur in certain cases.

The undefined behaviour occurs when using the context-manager inside coroutines and generators (since the frame it runs in might be suspended and resumed in another thread/context) or if the functions __enter__ and __exit__ are called manually.

This PR does not introduce this problem!

Environment-objects now come in two variants:
* The old-style retrieved via `vpy_current_environment()`. Calling `vpy_current_environment()` will now emit a Python deprecation warning. These can be used directly as context managers, storing their state externally thus causing potential bugs due to unexpected codeflow inside the python script. `Environment.use()` however behaves just as expected.
* The new-style retrieved via `get_current_environment()`.
  Instances of new-style-environments must use the `Environment.use()`-context-manager.

### Predefined EnvrionmentPolicy-objects

VapourSynth comes with two EnvironmentPolicy instances:

* `StandaloneEnvironmentPolicy`, which only has one `EnvironmentData`-object. Any call to `set_environment` is ignored.
* `VSScriptEnvironmentPolicy`, which implements the `VPYScriptExport.id` to `EnvironmentData`-mapping as well everything that is needed so that vapoursynth still acts like it used to be.

### Examples

This example implements a `EnvironmentPolicy` that acts like the `StandaloneEnvironmentPolicy`. However this class has a `reset_core()`-function that disables the currently active environment and starts a new one.

```py
import vapoursynth as vs
from vapoursynth import core

class ReplacableEnvironmentPolicy(vs.EnvironmentPolicy):
    def __init__(self):
        self._current = None
        self._api = None
    def on_policy_registered(self, special_api):
        self._api = special_api
        self.reset_core()
    def on_policy_cleared(self):
        self._current = None
    def get_current_environment(self):
        return self._current
    def set_environment(self, env):
        if env is not self._current:
            raise RuntimeError("The chosen environment is dead.")
    def is_alive(self, env):
        return env is self._current

    def reset_core(self):
        # THIS IS A CUSTOM METHOD
        self._current = self._api.create_environment()

policy = ReplacableEnvironmentPolicy()
vs.register_policy(policy)


e1 = vs.get_current_environment()
print(e1 == vs.get_current_environment())

policy.reset_core()   # Enable a new environment globally.

print(e1 == vs.get_current_environment())
```

The output will be:
```
True
False
```