### PR TITLE
Add PEP8-compatibility for parameter-keyword-collisions

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -97,6 +97,9 @@ Another way to deal with such arguments is to place them in a dictionary::
 
    args = { "lambda": 1 }
    clip = core.plugin.Filter(clip, **args)
+   
+VapourSynth will also support the PEP8 convention of using a single trailing
+underscore to prevent collisions with python keywords.
 
 Windows File Paths (Strings With Backslashes)
 #############################################

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1800,6 +1800,9 @@ cdef class Function(object):
         for key in kwargs:
             if key[0] == '_':
                 nkey = key[1:]
+            # PEP8 tells us single_trailing_underscore_ for collisions with Python-keywords.
+            elif key[-1] == "_":
+                nkey = key[:-1]
             else:
                 nkey = key
             ndict[nkey] = kwargs[key]


### PR DESCRIPTION
PEP8 (https://www.python.org/dev/peps/pep-0008/#id36) tells us:
> `_single_leading_underscore`: weak "internal use" indicator.
> [...]
> `single_trailing_underscore_`: used by convention to avoid conflicts with Python keyword, e.g.
> ```py
>     Tkinter.Toplevel(master, class_='ClassName')
> ```

Code Formatters do take PEP8 into consideration.