### PR TITLE
[Discussion wanted] Add an __all__-Attribute

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -44,6 +44,14 @@ try:
 except ImportError as e:
     typing = None
 
+__all__ = [
+  "core", "get_core",
+  "get_output", "get_outputs", "clear_output", "clear_outputs",
+  
+  "VideoFrame", "VideoNode",
+  "Format"
+]
+    
 __version__ = namedtuple("VapourSynthVersion", "release_major release_minor")(50, 0)
 __api_version__ = namedtuple("VapourSynthAPIVersion", "api_major api_minor")(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR)
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -58,6 +58,7 @@ __all__ = [
     'YUV422P8', 'YUV422P9', 'YUV440P8', 'YUV444P10',
     'YUV444P12', 'YUV444P14', 'YUV444P16', 'YUV444P8',
     'YUV444P9', 'YUV444PH', 'YUV444PS', 
+  'NONE',
   'FLOAT', 'INTEGER',
   
   'get_output', 'get_outputs',

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -45,11 +45,25 @@ except ImportError as e:
     typing = None
 
 __all__ = [
-  "core", "get_core",
-  "get_output", "get_outputs", "clear_output", "clear_outputs",
+  'COMPAT',
+    'COMPATBGR32', 'COMPATYUY2',
+  'GRAY',
+    'GRAY16', 'GRAY8', 'GRAYH', 'GRAYS', 
+  'RGB',
+    'RGB24', 'RGB27', 'RGB30', 'RGB48', 'RGBH', 'RGBS',
+  'YCOCG', 'YUV',
+    'YUV410P8', 'YUV411P8', 'YUV420P10', 'YUV420P12',
+    'YUV420P14', 'YUV420P16', 'YUV420P8', 'YUV420P9',
+    'YUV422P10', 'YUV422P12', 'YUV422P14', 'YUV422P16',
+    'YUV422P8', 'YUV422P9', 'YUV440P8', 'YUV444P10',
+    'YUV444P12', 'YUV444P14', 'YUV444P16', 'YUV444P8',
+    'YUV444P9', 'YUV444PH', 'YUV444PS', 
+  'FLOAT', 'INTEGER',
   
-  "VideoFrame", "VideoNode",
-  "Format"
+  'get_output', 'get_outputs',
+  'clear_output', 'clear_outputs',
+  
+  'core', 
 ]
     
 __version__ = namedtuple("VapourSynthVersion", "release_major release_minor")(50, 0)


### PR DESCRIPTION
If you do `from vapoursynth import *`, the `__all__` attribute defines what gets actually included.

P.S. **Please don't merge it just yet.** Maybe others have additional ideas what should be included by when *-importing the python module.