### PR TITLE
Array arguments also support passing non-arrays.

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -410,7 +410,7 @@ def _construct_parameter(signature):
 
     # Make the type a sequence.
     if array:
-        type = typing.Sequence[type]
+        type = typing.Union[type, typing.Sequence[type]]
 
     # Mark an optional type
     if opt:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -406,7 +406,7 @@ def _construct_parameter(signature):
     elif type == "data":
         type = typing.Union[str, bytes, bytearray]
     else:
-        raise ValueError("Couldn't determine type")
+        type = typing.Any
 
     # Make the type a sequence.
     if array:


### PR DESCRIPTION
This breaks type-checkers using the stubs provided by vsrepo PR.

This PR fixes this.