### PR TITLE
A faster concurrent VideoNode.frames-implementation (and using that to rewrite VideoNode.output)

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -356,16 +356,20 @@ Classes and Functions
       containing the *alpha* to output at the same time. Currently only vspipe
       takes *alpha* into consideration when outputting.
 
-   .. py:method:: output(fileobj[, y4m = False, prefetch = 0, progress_update = None])
+   .. py:method:: output(fileobj[, y4m = False, prefetch = 0, progress_update = None, backlog=-1])
  
       Write the whole clip to the specified file handle. It is possible to pipe to stdout by specifying *sys.stdout* as the file.
       YUV4MPEG2 headers will be added when *y4m* is true.
       The current progress can be reported by passing a callback function of the form *func(current_frame, total_frames)* to *progress_update*.
       The *prefetch* argument is only for debugging purposes and should never need to be changed.
+      The *backlog* argument is only for debugging purposes and should never need to be changed.
 
-   .. py:method:: frames()
+   .. py:method:: frames([prefetch=None, backlog=None])
 
-      Returns a generator iterator of all VideoFrames in the clip.
+      Returns a generator iterator of all VideoFrames in the clip. It will render multiple frames concurrently.
+      
+      The *prefetch* argument defines how many frames are rendered concurrently. Is only there for debugging purposes and should never need to be changed.
+      The *backlog* argument defines how many frames are buffered internally before they consumed. This argument is there to limit the memory this function uses storing frames.
 
 .. py:class:: AlphaOutputTuple
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1838,10 +1838,11 @@ def get_core(threads = None, add_cache = None):
     warnings.warn("get_core() is deprecated. Use \"vapoursynth.core\" instead.", DeprecationWarning)
     
     ret_core = _get_core()
-    if threads is not None:
-        ret_core.num_threads = threads
-    if add_cache is not None:
-        ret_core.add_cache = add_cache
+    if ret_core is not None:
+        if threads is not None:
+            ret_core.num_threads = threads
+        if add_cache is not None:
+            ret_core.add_cache = add_cache
     return ret_core
     
 cdef Core vsscript_get_core_internal(EnvironmentData env):

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1415,6 +1415,12 @@ cdef class VideoNode(object):
         _get_output_dict("set_output")[index] = clip
 
     def output(self, object fileobj not None, bint y4m = False, object progress_update = None, int prefetch = 0, int backlog = -1):
+        if (fileobj is sys.stdout or fileobj is sys.stderr) and hasattr(fileobj, "buffer"):
+            fileobj = fileobj.buffer
+
+        if progress_update is not None:
+            progress_update(0, len(self))
+
         if y4m:
             if self.format.color_family == GRAY:
                 y4mformat = 'mono'
@@ -1441,7 +1447,7 @@ cdef class VideoNode(object):
             if len(y4mformat) > 0:
                 y4mformat = 'C' + y4mformat + ' '
 
-            data = 'YUV4MPEG2 {y4mformat} W{width} H{height} F{fps_num}:{fps_den}Ip A0:0\n'.format(
+            data = 'YUV4MPEG2 {y4mformat} W{width} H{height} F{fps_num}:{fps_den} Ip A0:0\n'.format(
                 y4mformat=y4mformat,
                 width=self.width,
                 height=self.height,

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1448,12 +1448,12 @@ cdef class VideoNode(object):
                 fps_num=self.fps_num,
                 fps_den=self.fps_den
             )
-            stream.write(data.encode("ascii"))
+            fileobj.write(data.encode("ascii"))
 
         frame: vs.VideoFrame
         for idx, frame in enumerate(self.frames(prefetch, backlog)):
             if y4m:
-                stream.write(b"FRAME\n")
+                fileobj.write(b"FRAME\n")
 
             for planeno, plane in enumerate(frame.planes()):
                 # This is a quick fix.
@@ -1461,14 +1461,14 @@ cdef class VideoNode(object):
                 # copying the frame to a continous buffer
                 # if the stride does not match the width*bytes_per_sample.
                 if frame.get_stride(planeno) != plane.width*clip.format.bytes_per_sample:
-                    stream.write(bytes(plane))
+                    fileobj.write(bytes(plane))
                 else:
-                    stream.write(plane)
+                    fileobj.write(plane)
 
             if progress is not None:
                 progress(idx+1, len(clip))
 
-        stream.close()
+        fileobj.close()
 
     def __add__(x, y):
         if not isinstance(x, VideoNode) or not isinstance(y, VideoNode):

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -34,7 +34,7 @@ import inspect
 import weakref
 import atexit
 import contextlib
-from threading import local as ThreadLocal, Lock
+from threading import local as ThreadLocal, Lock, RLock
 from types import MappingProxyType
 from collections import namedtuple
 from collections.abc import Iterable, Mapping
@@ -1544,8 +1544,6 @@ cdef class VideoNode(object):
             backlog = prefetch*3
         elif backlog < prefetch:
             backlog = prefetch
-
-        from threading import RLock
 
         enum_fut = enumerate((self.get_frame_async(frameno) for frameno in range(len(self))))
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1447,7 +1447,7 @@ cdef class VideoNode(object):
             if len(y4mformat) > 0:
                 y4mformat = 'C' + y4mformat + ' '
 
-            data = 'YUV4MPEG2 {y4mformat} W{width} H{height} F{fps_num}:{fps_den} Ip A0:0 XLENGTH={length}\n'.format(
+            data = 'YUV4MPEG2 {y4mformat}W{width} H{height} F{fps_num}:{fps_den} Ip A0:0 XLENGTH={length}\n'.format(
                 y4mformat=y4mformat,
                 width=self.width,
                 height=self.height,

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1447,12 +1447,13 @@ cdef class VideoNode(object):
             if len(y4mformat) > 0:
                 y4mformat = 'C' + y4mformat + ' '
 
-            data = 'YUV4MPEG2 {y4mformat} W{width} H{height} F{fps_num}:{fps_den} Ip A0:0\n'.format(
+            data = 'YUV4MPEG2 {y4mformat} W{width} H{height} F{fps_num}:{fps_den} Ip A0:0 XLENGTH={length}\n'.format(
                 y4mformat=y4mformat,
                 width=self.width,
                 height=self.height,
                 fps_num=self.fps_num,
-                fps_den=self.fps_den
+                fps_den=self.fps_den,
+                length=len(self)
             )
             fileobj.write(data.encode("ascii"))
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1465,8 +1465,8 @@ cdef class VideoNode(object):
                 else:
                     fileobj.write(plane)
 
-            if progress is not None:
-                progress(idx+1, len(clip))
+            if progress_update is not None:
+                progress_update(idx+1, len(clip))
 
         fileobj.close()
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1468,7 +1468,8 @@ cdef class VideoNode(object):
             if progress_update is not None:
                 progress_update(idx+1, len(self))
 
-        fileobj.close()
+        if hasattr(fileobj, "flush"):
+            fileobj.flush()
 
     def __add__(x, y):
         if not isinstance(x, VideoNode) or not isinstance(y, VideoNode):

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1442,7 +1442,7 @@ cdef class VideoNode(object):
                 y4mformat = 'C' + y4mformat + ' '
 
             data = 'YUV4MPEG2 {y4mformat} W{width} H{height} F{fps_num}:{fps_den}Ip A0:0\n'.format(
-                y4mformat=y4mformat
+                y4mformat=y4mformat,
                 width=self.width,
                 height=self.height,
                 fps_num=self.fps_num,

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1620,6 +1620,7 @@ cdef class VideoNode(object):
 
         finally:
             finished = True
+            gc.collect()
             
     def __dir__(self):
         plugins = [plugin["namespace"] for plugin in self.core.get_plugins().values()]

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1460,13 +1460,13 @@ cdef class VideoNode(object):
                 # Calling bytes(VideoPlane) should make the buffer continuous by
                 # copying the frame to a continous buffer
                 # if the stride does not match the width*bytes_per_sample.
-                if frame.get_stride(planeno) != plane.width*clip.format.bytes_per_sample:
+                if frame.get_stride(planeno) != plane.width*self.format.bytes_per_sample:
                     fileobj.write(bytes(plane))
                 else:
                     fileobj.write(plane)
 
             if progress_update is not None:
-                progress_update(idx+1, len(clip))
+                progress_update(idx+1, len(self))
 
         fileobj.close()
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1837,8 +1837,7 @@ def get_core(threads = None, add_cache = None):
     import warnings
     warnings.warn("get_core() is deprecated. Use \"vapoursynth.core\" instead.", DeprecationWarning)
     
-    # ret_core = _get_core()
-    ret_core = core
+    ret_core = _get_core()
     if threads is not None:
         ret_core.num_threads = threads
     if add_cache is not None:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1546,7 +1546,6 @@ cdef class VideoNode(object):
             backlog = prefetch
 
         from threading import RLock
-        from concurrent.futures import Future
 
         enum_fut = enumerate((self.get_frame_async(frameno) for frameno in range(len(self))))
 
@@ -1597,7 +1596,6 @@ cdef class VideoNode(object):
         _refill()
 
         sidx = 0
-        fut: Future
         try:
             while (not finished) or (len(reorder)>0) or running>0:
                 if sidx not in reorder:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1416,11 +1416,11 @@ cdef class VideoNode(object):
 
     def output(self, object fileobj not None, bint y4m = False, object progress_update = None, int prefetch = 0, int backlog = -1):
         if y4m:
-            if self.format.color_family == vs.GRAY:
+            if self.format.color_family == GRAY:
                 y4mformat = 'mono'
                 if self.format.bits_per_sample > 8:
                     y4mformat = y4mformat + str(self.format.bits_per_sample)
-            elif self.format.color_family == vs.YUV:
+            elif self.format.color_family == YUV:
                 if self.format.subsampling_w == 1 and self.format.subsampling_h == 1:
                     y4mformat = '420'
                 elif self.format.subsampling_w == 1 and self.format.subsampling_h == 0:
@@ -1436,7 +1436,7 @@ cdef class VideoNode(object):
                 if self.format.bits_per_sample > 8:
                     y4mformat = y4mformat + 'p' + str(self.format.bits_per_sample)
             else:
-                raise ValueError("Can only use vs.GRAY and vs.YUV for V4M-Streams")
+                raise ValueError("Can only use GRAY and YUV for V4M-Streams")
 
             if len(y4mformat) > 0:
                 y4mformat = 'C' + y4mformat + ' '


### PR DESCRIPTION
The implementation consists of two parts:
- Reimplementing `VideoNode.frames()` render multiple frames concurrently and yielding the frames in order.
- Reimplementing `VideoNode.output()` using the reimplemented `VideoNode.frames()`-method.

This makes `VideoNode.output()` easier to implement and its performance is now solely tied to `VideoNode.frames()` which has more uses than the `output`-function itself.