### PR TITLE
fix 'dark image' bug in imwri

### DIFF
--- a/src/filters/imwri/imwri.cpp
+++ b/src/filters/imwri/imwri.cpp
@@ -367,6 +367,8 @@ static const VSFrameRef *VS_CC writeGetFrame(int n, int activationReason, void *
                 writeImageHelper<uint8_t>(frame, alphaFrame, isGray, image, width, height, fi->bitsPerSample, vsapi);
             }
 
+            image.strip();
+
             image.write(filename);
 
             vsapi->freeFrame(alphaFrame);


### PR DESCRIPTION
This PR fixes bug i reported back in Dec 2019 (https://github.com/vapoursynth/vapoursynth/issues/519)

thanks to @motbob for finding out the cause of this bug. (https://github.com/vapoursynth/vapoursynth/issues/519#issuecomment-691735413)

## About bug

apparently, metadata corruption by `imagemagick`(`Magick++`) is causing this. this has nothing to do with vapoursynth itself, I tested it out using `Magick++` and it produced the same faulty output as VS.

## Solution

the solution is to strip the metadata before writing the file in ` vapoursynth/src/filters/imwri/imwri.cpp `.
```cpp
image.strip();
```

## Results

python script:
```py
import vapoursynth as vs

core = vs.core
core.std.LoadPlugin('/usr/local/lib/libffms2.so')
clip = core.ffms2.Source(source="video.mp4")

clip = core.resize.Spline36(clip, format=vs.RGB24, matrix_in_s='709',transfer_in_s='709',primaries_in_s='709',
                            prefer_props=True)

print(core.text.CoreInfo(clip))

frames = [0, 10, 20, 30]


for f in frames:
    print(f)
    clip.get_frame(f)
    clip = core.imwri.Write(clip, "PNG64", "source_compare_%d.png",overwrite=True)
```

Running the following will produce 3 images corresponding to given frames.

The example given here is **Frame 10** taken from [this](https://www.pexels.com/video/time-lapse-of-busy-street-857267/) video.

R52 (darker blacks compared to original):
![](https://i.imgur.com/4uu2FSP.png)

This PR:
![](https://i.imgur.com/khxlFv5.png)

One way to compare is to open these images in separate tabs and switch between them. the difference should be obvious.

## Refs

* https://www.imagemagick.org/Magick++/Image++.html


