### PR TITLE
Fix missing return value of Func.__call__

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -631,9 +631,7 @@ cdef class Func(object):
             error = self.funcs.mapGetError(outm)
             if error:
                 raise Error(error.decode('utf-8'))
-            ret = mapToDict(outm, False, NULL, vsapi)
-            if not isinstance(ret, dict):
-                ret = {'val':ret}
+            return mapToDict(outm, True, NULL, vsapi)
         finally:
             vsapi.freeMap(outm)
             vsapi.freeMap(inm)


### PR DESCRIPTION
The return value was discarded and never returned.