### PR TITLE
Update github action - remove deprecated set-env

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,9 +38,10 @@ jobs:
     - name: Set neccessary environment variables
       run: |
         PYTHON_BASE_PATH=$(command -v python | xargs dirname)/..
-        echo "::set-env name=LD_LIBRARY_PATH::$LD_LIBRARY_PATH:$PYTHON_BASE_PATH/lib"
-        echo "::set-env name=LIBRARY_PATH::$LIBRARY_PATH:$PYTHON_BASE_PATH/lib"
-        echo "::set-env name=PKG_CONFIG_PATH::$PYTHON_BASE_PATH/lib/pkgconfig"
+      env:
+        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$PYTHON_BASE_PATH/lib
+        LIBRARY_PATH: $LIBRARY_PATH:$PYTHON_BASE_PATH/lib
+        PKG_CONFIG_PATH: $PYTHON_BASE_PATH/lib/pkgconfig
 
     - name: configure
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,9 +47,10 @@ jobs:
     - name: Set neccessary environment variables
       run: |
         PYTHON_BASE_PATH=$(command -v python | xargs dirname)/..
-        echo "::set-env name=LD_LIBRARY_PATH::$LD_LIBRARY_PATH:$PYTHON_BASE_PATH/lib"
-        echo "::set-env name=LIBRARY_PATH::$LIBRARY_PATH:$PYTHON_BASE_PATH/lib"
-        echo "::set-env name=PKG_CONFIG_PATH::$PYTHON_BASE_PATH/lib/pkgconfig"
+      env:
+        LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$PYTHON_BASE_PATH/lib
+        LIBRARY_PATH: $LIBRARY_PATH:$PYTHON_BASE_PATH/lib
+        PKG_CONFIG_PATH: $PYTHON_BASE_PATH/lib/pkgconfig
 
     - name: configure
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
   
     - name: Clone Dependencies
       run: |


### PR DESCRIPTION
Linux still has an issue, but I'm not 100% how to fix it:
```
checking for PYTHON3... no
checking for PYTHON3... no
configure: error: Package requirements (python-3.9) were not met:

No package 'python-3.9' found
```

Win + mac are ok now.