### PR TITLE
Correct an attribute name in doc.

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -497,7 +497,7 @@ Classes and Functions
 
    Plugin is a class that represents a loaded plugin and its namespace.
    
-   .. py:attribute:: name
+   .. py:attribute:: namespace
 
       The namespace of the plugin.
 


### PR DESCRIPTION
Correct an attribute name of `class Plugin` from "name" to "namespace".