### PR TITLE
imwri: convert <8-bit depth images to 8-bit

### DIFF
--- a/src/filters/imwri/imwri.cpp
+++ b/src/filters/imwri/imwri.cpp
@@ -592,6 +592,22 @@ static void readImageHelper(VSFrameRef *frame, VSFrameRef *alphaFrame, bool isGr
     }
 }
 
+static void readSampleTypeDepth(const ReadData *d, const Magick::Image &image, VSSampleType &st, int &depth) {
+        st = stInteger;
+        depth = static_cast<int>(image.depth());
+        if (depth == 32)
+                st = stFloat;
+
+        if (d->floatOutput || image.attribute("quantum:format") == "floating-point") {
+                depth = 32;
+                st = stFloat;
+        }
+
+        // VapourSynth does not support <8-bit integer types.
+        if (depth < 8)
+                depth = 8;
+}
+
 static const VSFrameRef *VS_CC readGetFrame(int n, int activationReason, void **instanceData, void **frameData, VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi) {
     ReadData *d = static_cast<ReadData *>(*instanceData);
 
@@ -623,15 +639,9 @@ static const VSFrameRef *VS_CC readGetFrame(int n, int activationReason, void **
             int height = static_cast<int>(image.rows());
             size_t channels = image.channels();
 
-            VSSampleType st = stInteger;
-            int depth = static_cast<int>(image.depth());
-            if (depth == 32)
-                st = stFloat;
-
-            if (d->floatOutput || image.attribute("quantum:format") == "floating-point") {
-                depth = 32;
-                st = stFloat;
-            }
+            VSSampleType st;
+            int depth;
+            readSampleTypeDepth(d, image, st, depth);
 
             if (d->vi[0].format && (cf != d->vi[0].format->colorFamily || depth != d->vi[0].format->bitsPerSample)) {
                 std::string err = "Read: Format mismatch for frame " + std::to_string(n) + ", is ";
@@ -787,15 +797,9 @@ static void VS_CC readCreate(const VSMap *in, VSMap *out, void *userData, VSCore
     try {
         Magick::Image image(d->fileListMode ? d->filenames[0] : specialPrintf(d->filenames[0], d->firstNum));
 
-        VSSampleType st = stInteger;
-        int depth = image.depth();
-        if (depth == 32)
-            st = stFloat;
-
-        if (d->floatOutput || image.attribute("quantum:format") == "floating-point") {
-            depth = 32;
-            st = stFloat;
-        }
+        VSSampleType st;
+        int depth;
+        readSampleTypeDepth(d.get(), image, st, depth);
 
         if (!d->mismatch || d->vi[0].numFrames == 1) {
             d->vi[0].height = static_cast<int>(image.rows());


### PR DESCRIPTION
As registerFormat returns nullptr when depth < 8, it used to treat all such
images as dynamic format, and confuse all downstream tools/filters.

As a test case, we can use the 4-bit PGM image on http://davis.lbl.gov/Manuals/NETPBM/doc/pgm.html.

Given this `test.vpy` script:
```
with open('feep.pgm', 'w') as f:
    f.write('''P2
# feep.pgm
24 7
15
0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
0  3  3  3  3  0  0  7  7  7  7  0  0 11 11 11 11  0  0 15 15 15 15  0
0  3  0  0  0  0  0  7  0  0  0  0  0 11  0  0  0  0  0 15  0  0 15  0
0  3  3  3  0  0  0  7  7  7  0  0  0 11 11 11  0  0  0 15 15 15 15  0
0  3  0  0  0  0  0  7  0  0  0  0  0 11  0  0  0  0  0 15  0  0  0  0
0  3  0  0  0  0  0  7  7  7  7  0  0 11 11 11 11  0  0 15  0  0  0  0
0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
''')

from vapoursynth import core
clip = core.imwri.Read('feep.pgm')
clip.set_output()
```

Prior to this change:
```
$ vspipe --info test.vpy -
Width: 24
Height: 7
Frames: 1
FPS: 30/1 (30.000 fps)
Format Name: Variable
```

After this change:
```
$ vspipe --info test.vpy -
Width: 24
Height: 7
Frames: 1
FPS: 30/1 (30.000 fps)
Format Name: Gray8
Color Family: Gray
Alpha: No
Sample Type: Integer
Bits: 8
SubSampling W: 0
SubSampling H: 0
```

Note: this also matches behavior of `lsmas.LWLibavSource`, which will also return a Gray8 clip for this 4-bit grayscale image.

Signed-off-by: akarin <i@akarin.info>