### PR TITLE
More detailed docs for the misc.Hysteresis filter

### DIFF
--- a/doc/plugins/misc.rst
+++ b/doc/plugins/misc.rst
@@ -28,6 +28,15 @@ Miscellaneous Filters is a random collection of filters that mostly are useful f
    :module: misc
    
    Grows the mask in *clipa* into the mask in *clipb*. This is an equivalent of the Avisynth function *mt_hysteresis*.
+   
+   Specifically, Hysteresis takes two bi-level masks *clipa* and *clipb* and generates another
+   bi-level mask clip. Both *clipa* and *clipb* must have the same dimensions and format, and the
+   output clip will also have that format.
+   If we treat the planes of the clips as representing 8-neighbourhood undirected 2D grid graphs,
+   for each of the connected components in *clipb*, the whole component is copied to the output plane
+   if and only if one of its pixels is also marked in the corresponding plane from *clipa*.
+   The argument *planes* controls which planes to process, with the default being all. Any unprocessed
+   planes will be copied from the corresponding plane in *clipa*.
     
 .. function:: SCDetect(clip clip[, float threshold=0.1])
    :module: misc


### PR DESCRIPTION
Even though the current docs for Hysteresis is very intuitive once you understand it,
it's not very clear to beginners. (I've left the current docs intact so that experienced
users don't need to read any further.)

I also surveyed existing docs for avs' masktools plugin, but unfortunately, there isn't
any better docs (at least without using figures). This version is the best I can think of,
and IMHO it specifies the behavior formally, but it does involves some graph theoretic
notations. I'm open to better ideas on how to specify the behavior of this filter.

Any suggests welcome.

Thanks.

Signed-off-by: akarin <i@akarin.info>