### PR TITLE
vspipe: honor sys.exit() exit code (take 2 with new API)

### DIFF
--- a/doc/api/vsscript.h.rst
+++ b/doc/api/vsscript.h.rst
@@ -32,6 +32,8 @@ Functions_
 
    vsscript_getError_
 
+   vsscript_getExitCode_
+
    vsscript_getOutput_
 
    vsscript_clearOutput_
@@ -150,7 +152,7 @@ vsscript_evaluateScript
 
     Restores the working directory before returning.
 
-    Returns non-zero in case of errors. The error message can be retrieved with vsscript_getError_\ ().
+    Returns non-zero in case of errors. The error message can be retrieved with vsscript_getError_\ (). If the script calls *sys.exit(code)* the exit code can be retrieved with vsscript_getExitCode_\ ().
 
     
 vsscript_evaluateFile
@@ -206,6 +208,16 @@ vsscript_getError
     
     VSScript retains ownership of the pointer.
 
+
+vsscript_getExitCode
+--------------------
+
+.. c:function:: int vsscript_getExitCode(VSScript *handle)
+
+    Returns the exit code if the script calls *sys.exit(code)*, or 0, if the script fails for other reasons or calls *sys.exit(0)*.
+
+    It is okay to pass NULL.
+    
 
 vsscript_getOutput
 ------------------

--- a/include/VSScript.h
+++ b/include/VSScript.h
@@ -62,6 +62,7 @@ VS_API(int) vsscript_createScript(VSScript **handle);
 
 VS_API(void) vsscript_freeScript(VSScript *handle);
 VS_API(const char *) vsscript_getError(VSScript *handle);
+VS_API(int) vsscript_getExitCode(VSScript *handle);
 /* The node returned must be freed using freeNode() before calling vsscript_freeScript() */
 VS_API(VSNodeRef *) vsscript_getOutput(VSScript *handle, int index);
 /* Both nodes returned must be freed using freeNode() before calling vsscript_freeScript(), the alpha node pointer will only be set if an alpha clip has been set in the script */

--- a/include/VSScript4.h
+++ b/include/VSScript4.h
@@ -72,6 +72,9 @@ struct VSSCRIPTAPI {
     /* Returns NULL on success, otherwise an error message */
     const char *(VS_CC *getError)(VSScript *handle) VS_NOEXCEPT;
 
+    /* Returns 0 on success, otherwise the exit code */
+    int (VS_CC *getExitCode)(VSScript *handle) VS_NOEXCEPT;
+
     /*
     * The returned nodes must be freed using freeNode() before calling freeScript() since they may depend on data in the VSScript
     * environment. Returns NULL if no node was set as output in the script. Index 0 is used by default in scripts and other

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2797,6 +2797,13 @@ cdef int _vpy_evaluate(VSScript *se, bytes script, str filename, const VSScriptO
         with _vsscript_use_or_create_environment2(se.id, options).use():
             exec(code, pyenvdict, pyenvdict)
 
+    except SystemExit, e:
+        se.exitCode = e.code
+        errstr = 'Python exit with code ' + str(e.code) + '\n'
+        errstr = errstr.encode('utf-8')
+        Py_INCREF(errstr)
+        se.errstr = <void *>errstr
+        return 3
     except BaseException, e:
         errstr = 'Python exception: ' + str(e) + '\n\n' + traceback.format_exc()
         errstr = errstr.encode('utf-8')

--- a/src/cython/vsscript_internal.pxd
+++ b/src/cython/vsscript_internal.pxd
@@ -24,3 +24,4 @@ cdef extern from "src/vsscript/vsscript_internal.h" nogil:
         void *pyenvdict
         void *errstr
         int id
+        int exitCode

--- a/src/vspipe/vspipe.cpp
+++ b/src/vspipe/vspipe.cpp
@@ -943,9 +943,11 @@ int main(int argc, char **argv) {
     }
 
     if (vssapi->getError(se)) {
+        int code = vssapi->getExitCode(se);
+        if (code == 0) code = 1;
         fprintf(stderr, "Script evaluation failed:\n%s\n", vssapi->getError(se));
         vssapi->freeScript(se);
-        return 1;
+        return code;
     }
 
     VSNode *node = vssapi->getOutputNode(se, opts.outputIndex);

--- a/src/vsscript/vsscript.cpp
+++ b/src/vsscript/vsscript.cpp
@@ -197,6 +197,14 @@ VS_API(const char *) vsscript_getError(VSScript *handle) VS_NOEXCEPT {
         return "Invalid handle (NULL)";
 }
 
+VS_API(int) vsscript_getExitCode(VSScript *handle) VS_NOEXCEPT {
+    std::lock_guard<std::mutex> lock(vsscriptlock);
+    if (handle)
+        return handle->exitCode;
+    else
+        return 0;
+}
+
 VS_API(const VSAPI *) vsscript_getVSApi2(int version) VS_NOEXCEPT {
     std::lock_guard<std::mutex> lock(vsscriptlock);
     return vpy4_getVSAPI(version);
@@ -300,6 +308,7 @@ static VSSCRIPTAPI vsscript_api = {
     &evaluateBuffer,
     &evaluateFile,
     &vsscript_getError,
+    &vsscript_getExitCode,
     &getOutputNode,
     &getOutputAlphaNode,
     &getOptions,

--- a/src/vsscript/vsscript_internal.h
+++ b/src/vsscript/vsscript_internal.h
@@ -25,6 +25,7 @@ struct VSScript {
     void *pyenvdict;
     void *errstr;
     int id;
+    int exitCode;
 };
 
 #endif


### PR DESCRIPTION
Introduced a new VSScript API, bumped minor version number.
(Probably unnecessary for VSScript4 as it's unreleased yet, but perhaps we do want
to move the new API to the last entry to not break existing software that is using the
current API?)

New API:
```C++
VS_API(int) vsscript_getExitCode(VSScript *handle);
```

Discussion: I also thought about adding a way to differentiate between regular failures
and `sys.exit(0)` but I don't think it's necessary, as it's not clear what the vpy author
intends when calling `sys.exit(0)`, vspipe will fail (and return 1) anyway.

Fixes #437.