### PR TITLE
misc.Hysteresis: fix incorrect mask for floating point U/V planes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+r54:
+fixed misc.Hysteresis handling of floating point U/V planes (AkarinVS)
+
 r53:
 updated visual studio 2019 runtime version
 updated to python 3.9 for windows

--- a/src/filters/misc/miscfilters.cpp
+++ b/src/filters/misc/miscfilters.cpp
@@ -721,7 +721,6 @@ struct HysteresisData {
     VSNodeRef * node1, *node2;
     bool process[3];
     uint16_t peak;
-    float lower[3], upper[3];
     size_t labelSize;
 };
 
@@ -745,8 +744,8 @@ static void process_frame_hysteresis(const VSFrameRef * src1, const VSFrameRef *
                 lower = 0;
                 upper = d->peak;
             } else {
-                lower = d->lower[plane];
-                upper = d->upper[plane];
+                lower = 0.f;
+                upper = 1.f;
             }
 
             std::fill_n(dstp, stride * height, lower);
@@ -848,16 +847,6 @@ static void VS_CC hysteresisCreate(const VSMap *in, VSMap *out, void *userData, 
 
         if (vi->format->sampleType == stInteger) {
             d->peak = (1 << vi->format->bitsPerSample) - 1;
-        } else {
-            for (int plane = 0; plane < vi->format->numPlanes; plane++) {
-                if (plane == 0 || vi->format->colorFamily == cmRGB) {
-                    d->lower[plane] = 0.f;
-                    d->upper[plane] = 1.f;
-                } else {
-                    d->lower[plane] = -0.5f;
-                    d->upper[plane] = 0.5f;
-                }
-            }
         }
 
         d->labelSize = vi->width * vi->height;


### PR DESCRIPTION
For all planes, the mask's range should be 0~1, regardless of
color spaces.

Update #681.

Signed-off-by: akarin <i@akarin.info>