### PR TITLE
CI: run all tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -70,4 +70,4 @@ jobs:
         pip install .
 
     - name: Run test
-      run: python -m unittest discover -s test
+      run: python -m unittest discover -s test -p "*test.py"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,4 +60,4 @@ jobs:
         pip install .
 
     - name: Run test
-      run: python -m unittest discover -s test
+      run: python -m unittest discover -s test -p "*test.py"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,4 +69,4 @@ jobs:
         popd
 
     - name: Run test
-      run: python -m unittest discover -s test
+      run: python -m unittest discover -s test -p "*test.py"


### PR DESCRIPTION
Without adding `-p "*test.py"`, it will only run tests in test/test.py.

Though it makes the CI runs slower (the test step will uses 2.5 minutes with github's default runner), I think it's worth the time (for example, my PR #693 would certainly benefit from running the expr tests.)

Signed-off-by: akarin <i@akarin.info>