### PR TITLE
doc: update avfs URL

### DIFF
--- a/doc/avfs.rst
+++ b/doc/avfs.rst
@@ -1,7 +1,7 @@
 AVFS (AV FileSystem)
 ====================
 
-AV FileSystem is based on `AVFS <http://www.turtlewar.org/avfs/>`_ and shares most of its
+AV FileSystem is based on `AVFS <https://turtlewar.org/avfs/>`_ and shares most of its
 source code and functionality. This package has several uses. It can easily make
 a script file openable by any application, as it appears like a real,
 uncompressed avi file. It can also be used to bridge the 32/64 bit gap, since a


### PR DESCRIPTION
http://www.turtlewar.org no longer works, and should be updated to https://turtlewar.org/.

Signed-off-by: akarin <i@akarin.info>