### PR TITLE
vsscript: fix vsscript_freeScript SIGSEGV when the script fails compilation

### DIFF
--- a/src/cython/vapoursynth.pxd
+++ b/src/cython/vapoursynth.pxd
@@ -17,6 +17,7 @@
 # License along with VapourSynth; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
+#cython: language_level=3
 
 from libc.stdint cimport uint8_t, uint32_t, int64_t, uint64_t, uintptr_t
 from libc.stddef cimport ptrdiff_t

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -3054,8 +3054,13 @@ cdef public api void vpy_clearEnvironment(VSScript *se) nogil:
         pyenvdict.clear()
         vpy4_clearLogHandler(se)
         try:
-             _get_vsscript_policy().get_environment(se.id).outputs.clear()
-             _get_vsscript_policy().get_environment(se.id).core = None
+            # Environment is lazily created at the time of exec'ing a script,
+            # if the process errors out before that (e.g. fails compiling),
+            # the environment might be None.
+            env = _get_vsscript_policy().get_environment(se.id)
+            if env is not None:
+                env.outputs.clear()
+                env.core = None
         except:
             pass
         gc.collect()


### PR DESCRIPTION
Cython fails to insert appropriate checks for None here.

We're at it, also silence a Cython warning about unspecified language_level.

To reproduce the crash, simply run `vspipe -i test.vpy -` with a `test.vpy` that contains a syntax error.