### PR TITLE
core: api4 consistent format names

### DIFF
--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -1497,18 +1497,20 @@ bool VSCore::getVideoFormatName(const VSVideoFormat &format, char *buffer) noexc
     if (!isValidVideoFormat(format.colorFamily, format.sampleType, format.bitsPerSample, format.subSamplingW, format.subSamplingH))
         return false;
 
-    const char *sampleTypeStr = "";
+    char suffix[16];
     if (format.sampleType == stFloat)
-        sampleTypeStr = (format.bitsPerSample == 32) ? "S" : "H";
+        strcpy(suffix, (format.bitsPerSample == 32) ? "S" : "H");
+    else
+        sprintf(suffix, "%d", (format.colorFamily == cfRGB ? 3:1) * format.bitsPerSample);
 
     const char *yuvName = nullptr;
 
     switch (format.colorFamily) {
         case cfGray:
-            snprintf(buffer, 32, "Gray%s%d", sampleTypeStr, format.bitsPerSample);
+            snprintf(buffer, 32, "Gray%s", suffix);
             break;
         case cfRGB:
-            snprintf(buffer, 32, "RGB%s%d", sampleTypeStr, format.bitsPerSample * 3);
+            snprintf(buffer, 32, "RGB%s", suffix);
             break;
         case cfYUV:
             if (format.subSamplingW == 1 && format.subSamplingH == 1)
@@ -1524,9 +1526,9 @@ bool VSCore::getVideoFormatName(const VSVideoFormat &format, char *buffer) noexc
             else if (format.subSamplingW == 0 && format.subSamplingH == 1)
                 yuvName = "440";
             if (yuvName)
-                snprintf(buffer, 32, "YUV%sP%s%d", yuvName, sampleTypeStr, format.bitsPerSample);
+                snprintf(buffer, 32, "YUV%sP%s", yuvName, suffix);
             else
-                snprintf(buffer, 32, "YUVssw%dssh%dP%s%d", format.subSamplingW, format.subSamplingH, sampleTypeStr, format.bitsPerSample);
+                snprintf(buffer, 32, "YUVssw%dssh%dP%s", format.subSamplingW, format.subSamplingH, suffix);
             break;
         case cfUndefined:
             snprintf(buffer, 32, "Undefined");

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -1145,18 +1145,20 @@ const vs3::VSVideoFormat *VSCore::queryVideoFormat3(vs3::VSColorFamily colorFami
     if (name) {
         strcpy(f.name, name);
     } else {
-        const char *sampleTypeStr = "";
+        char suffix[16];
         if (sampleType == stFloat)
-            sampleTypeStr = (bitsPerSample == 32) ? "S" : "H";
+            strcpy(suffix, (bitsPerSample == 32) ? "S" : "H");
+        else
+            sprintf(suffix, "%d", (colorFamily == vs3::cmRGB ? 3:1) * bitsPerSample);
 
         const char *yuvName = nullptr;
 
         switch (colorFamily) {
         case vs3::cmGray:
-            snprintf(f.name, sizeof(f.name), "Gray%s%d", sampleTypeStr, bitsPerSample);
+            snprintf(f.name, sizeof(f.name), "Gray%s", suffix);
             break;
         case vs3::cmRGB:
-            snprintf(f.name, sizeof(f.name), "RGB%s%d", sampleTypeStr, bitsPerSample * 3);
+            snprintf(f.name, sizeof(f.name), "RGB%s", suffix);
             break;
         case vs3::cmYUV:
             if (subSamplingW == 1 && subSamplingH == 1)
@@ -1172,12 +1174,12 @@ const vs3::VSVideoFormat *VSCore::queryVideoFormat3(vs3::VSColorFamily colorFami
             else if (subSamplingW == 0 && subSamplingH == 1)
                 yuvName = "440";
             if (yuvName)
-                snprintf(f.name, sizeof(f.name), "YUV%sP%s%d", yuvName, sampleTypeStr, bitsPerSample);
+                snprintf(f.name, sizeof(f.name), "YUV%sP%s", yuvName, suffix);
             else
-                snprintf(f.name, sizeof(f.name), "YUVssw%dssh%dP%s%d", subSamplingW, subSamplingH, sampleTypeStr, bitsPerSample);
+                snprintf(f.name, sizeof(f.name), "YUVssw%dssh%dP%s", subSamplingW, subSamplingH, suffix);
             break;
         case vs3::cmYCoCg:
-            snprintf(f.name, sizeof(f.name), "YCoCgssw%dssh%dP%s%d", subSamplingW, subSamplingH, sampleTypeStr, bitsPerSample);
+            snprintf(f.name, sizeof(f.name), "YCoCgssw%dssh%dP%s", subSamplingW, subSamplingH, suffix);
             break;
         default:;
         }


### PR DESCRIPTION
There is a behavior change between v4 and v3 regarding format names:
|  v3  |  v4 |
|-----|----|
|  RGBH  | RGBH48 |
|  RGBS  |  RGBS96 |
| YUV444PH | YUV444PH16 |
| YUV444PS  | YUV444PS32 |

The v4 name does not carry more information as "H"/"S" already unambiguously specifies the length of the components. Furthermore, it confuses downstream tool that parses `vspipe -i` output.

This PR restores the v3 format names.