### PR TITLE
core: fix wrapping for nfMakeLinear source filters

### DIFF
--- a/src/core/vscore.h
+++ b/src/core/vscore.h
@@ -844,15 +844,10 @@ private:
 
     // api3
     vs3::VSVideoInfo v3vi;
-    vs3::VSFilterGetFrame makeLinearFilterGetFrame = nullptr;
-    void *makeLinearinstanceData;
-    int makeLinearThreshold = 0;
-    int makeLinearLastFrame = -1;
 
     void registerCache(bool add);
     PVSFrame getCachedFrameInternal(int n);
     PVSFrame getFrameInternal(int n, int activationReason, VSFrameContext *frameCtx);
-    static const VSFrame *VS_CC makeLinearGetFrameWrapper(int n, int activationReason, void *instanceData, void **frameData, VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi);
 public:
     VSNode(const VSMap *in, VSMap *out, const std::string &name, vs3::VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, VSFilterMode filterMode, int flags, void *instanceData, int apiMajor, VSCore *core); // V3 compatibility
     VSNode(const std::string &name, const VSVideoInfo *vi, VSFilterGetFrame getFrame, VSFilterFree free, VSFilterMode filterMode, const VSFilterDependency *dependencies, int numDeps, void *instanceData, int apiMajor, VSCore *core);


### PR DESCRIPTION
The previous wrapper implementation only wraps the getFrame function.
However, as it also overrides instanceData as well, when the filter's
free function is called, it is guaranteed to receive the incorrect
instanceData, leading to SIGSEGV when freeing the filter.

We fix this by really implementing a wrapper for nfMakeLinear source
filters: it wraps both getFrame and free functions.

Additionally, we also fix another subtle bug of the previous implementation:
it was calling the filter's free with VSAPI4 instead of VSAPI3.