### PR TITLE
Refactor VideoFrame's buffer protocol support [doodle1]

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1605,7 +1605,7 @@ cdef AudioFrame createConstAudioFrame(const VSFrame *constf, const VSAPI *funcs,
     instance.f = NULL
     instance.funcs = funcs
     instance.core = core
-    instance.readonly = True
+    instance.flags = 0
     cdef const VSAudioFormat *format = funcs.getAudioFrameFormat(constf)
     instance.sample_type = SampleType(format.sampleType);
     instance.bits_per_sample = format.bitsPerSample
@@ -1622,7 +1622,7 @@ cdef AudioFrame createAudioFrame(VSFrame *f, const VSAPI *funcs, VSCore *core):
     instance.f = f
     instance.funcs = funcs
     instance.core = core
-    instance.readonly = False
+    instance.flags = -1
     cdef const VSAudioFormat *format = funcs.getAudioFrameFormat(f)
     instance.sample_type = SampleType(format.sampleType);
     instance.bits_per_sample = format.bitsPerSample

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1313,10 +1313,6 @@ cdef class VideoFrame(RawFrame):
             yield VideoPlane.__new__(VideoPlane, self, x)
 
     def _writelines(self, write):
-        cdef:
-            char* ptr
-            ssize_t stride  # no clue why cython turns this into a py object
-
         assert callable(write), "'write' is not callable"
 
         lib = self.funcs
@@ -1341,15 +1337,13 @@ cdef class VideoFrame(RawFrame):
                 tmp.strides += 1
                 tmp.len = tmp.shape[0] * tmp.itemsize
 
-                ptr = <char*> tmp.buf
                 lines = view.base.shape[0]
                 stride = view.base.strides[0]
 
                 for _ in range(lines):
                     line = PyMemoryView_FromObject(data)
                     write(line)
-                    ptr += stride
-                    tmp.buf = ptr
+                    tmp.buf = &(<char*> tmp.buf)[stride]
             else:
                 write(data)
 


### PR DESCRIPTION
This also includes the appropriate changes to AudioFrame.

Because of https://github.com/vapoursynth/vapoursynth/commit/64c1885a0066eb371f437820203ff0a3df99030f the tests in test/expr_test.py now fails.  The fix is simple but I want to submit the change for both doodle1 and master branches.  Unless keeping the two branches in sync in this case is unimportant, then I could just add an extra commit to this PR.

I should also probably add some regression tests for the changes made here, I'll see if I do so later today.

Other than that, these changes are functional and complete.