### PR TITLE
std: restore ability to delete frame property with SetFrameProp

### DIFF
--- a/doc/functions/setframeprop.rst
+++ b/doc/functions/setframeprop.rst
@@ -1,10 +1,10 @@
 SetFrameProp
 ============
 
-.. function:: SetFrameProp(vnode clip, string prop[, int[] intval, float[] floatval, string[] data])
+.. function:: SetFrameProp(vnode clip, string prop[, bint delete=False, int[] intval, float[] floatval, string[] data])
    :module: std
 
-   Adds a frame property to every frame in *clip*.
+   Adds/deletes a frame property to every frame in *clip*.
 
    If there is already a property with the name *prop* in the frames,
    it will be overwritten.
@@ -18,3 +18,7 @@ SetFrameProp
    For example, to set the field order to top field first::
 
       clip = c.std.SetFrameProp(clip, prop="_FieldBased", intval=2)
+
+   For users not requiring compatibility with R54 or older VapourSynth releases, it
+   is recommended to use the more intuitive *SetFrameProps* and *RemoveFrameProps*
+   functions instead.

--- a/doc/functions/setframeprop.rst
+++ b/doc/functions/setframeprop.rst
@@ -4,7 +4,7 @@ SetFrameProp
 .. function:: SetFrameProp(vnode clip, string prop[, bint delete=False, int[] intval, float[] floatval, string[] data])
    :module: std
 
-   Adds/deletes a frame property to every frame in *clip*.
+   Adds a frame property to every frame in *clip*.
 
    If there is already a property with the name *prop* in the frames,
    it will be overwritten.
@@ -19,6 +19,8 @@ SetFrameProp
 
       clip = c.std.SetFrameProp(clip, prop="_FieldBased", intval=2)
 
-   For users not requiring compatibility with R54 or older VapourSynth releases, it
-   is recommended to use the more intuitive *SetFrameProps* and *RemoveFrameProps*
-   functions instead.
+   For backward compatibility reasons, it is possible to delete the given property
+   by setting *delete=True*, however a new API is provided as *RemoveFrameProps*
+   for this. For users not requiring compatibility with R54 or older VapourSynth
+   releases, it is also recommended to use the more intuitive *SetFrameProps*
+   function to set frame properties.


### PR DESCRIPTION
This PR ensures compatibility with older releases and also recommends the users to use the new and more intuitive `SetFrameProps` and `RemoveFrameProps` APIs.

Fixes #736.

<hr>
The following are copied from [issue comment](https://github.com/vapoursynth/vapoursynth/issues/736#issuecomment-906005013)

The compatibility of releases is important. As is, you can't have a script
that removes frame props working in both R54 and R55 without conditional
code.

And there are code that must work across multiple versions, e.g. mvsfunc:
https://github.com/vxzms/mvsfunc/commit/ca5194854108ae32553decb471595d06e8ee1846

Regrettably, it already contains some conditional code to deal with past
API incompatibilities, but the good news is that most of them are for way
older releases. We managed to keep recent VS releases compatible enough
that most people don't even realize there used to be incompatible changes
on the API.

This is such a simple case: the original API is not broken, just not
intuitive and users have come to depend on them. If we think the newer
alternatives are better, we can certainly advertise new APIs to gradually
phase out existing users. But breaking those existing code is not the most effective way forward.

Could we please make R55 more compatible with R54? (You might think
changing the script to use R55 is acceptable, but in my experience that
makes persuading users to switch significantly harder.)
