### PR TITLE
cython: restore old low-level frame data access APIs (take 2)

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -159,6 +159,9 @@ associated with it. It is possible to access the raw data using either
 A more Python friendly wrapping is also available where each plane/channel can be accessed
 as a Python array using *frame[plane/channel]*.
 
+For backward compatibility reasons, the VideoFrame class also provides *get_read_array(plane)*
+and *get_write_array(plane)*, which return *numpy.ndarray* for full PEP-3118 compliance.
+
 To get a frame simply call *get_frame(n)* on a clip. Should you desire to get
 all frames in a clip, use this code::
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -27,6 +27,7 @@ from cpython.buffer cimport PyBUF_SIMPLE
 from cpython.buffer cimport PyBuffer_FillInfo
 from cpython.buffer cimport PyBuffer_IsContiguous
 from cpython.buffer cimport PyBuffer_Release
+from cpython.buffer cimport PyBUF_RECORDS_RO, PyBUF_RECORDS
 from cpython.memoryview cimport PyMemoryView_FromObject
 from cpython.memoryview cimport PyMemoryView_GET_BUFFER
 from cpython.number cimport PyIndex_Check
@@ -1281,6 +1282,12 @@ cdef class VideoFrame(RawFrame):
         s += '\tHeight: ' + str(self.height) + '\n'
         return s
 
+    def get_read_array(self, int index):
+        return view.memoryview(self.__getitem__(index), PyBUF_RECORDS_RO)
+    def get_write_array(self, int index):
+        if self.readonly:
+            raise Error('Cannot obtain write array to read only frame')
+        return view.memoryview(self.__getitem__(index), PyBUF_RECORDS)
 
 cdef VideoFrame createConstVideoFrame(const VSFrame *constf, const VSAPI *funcs, VSCore *core):
     cdef VideoFrame instance = VideoFrame.__new__(VideoFrame)

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -22,14 +22,11 @@ cimport vsconstants
 from vsscript_internal cimport VSScript
 cimport cython.parallel
 from cython cimport view, final
-from cython.view cimport memoryview
 from libc.stdint cimport intptr_t, int16_t, uint16_t, int32_t, uint32_t
 from cpython.buffer cimport PyBUF_SIMPLE
 from cpython.buffer cimport PyBuffer_FillInfo
 from cpython.buffer cimport PyBuffer_IsContiguous
 from cpython.buffer cimport PyBuffer_Release
-from cpython.buffer cimport PyObject_GetBuffer
-from cpython.buffer cimport PyBUF_RECORDS_RO, PyBUF_RECORDS
 from cpython.memoryview cimport PyMemoryView_FromObject
 from cpython.memoryview cimport PyMemoryView_GET_BUFFER
 from cpython.number cimport PyIndex_Check
@@ -1202,24 +1199,6 @@ cdef class RawFrame(object):
     def readonly(self):
         return not self.flags & 1
 
-cdef class memoryview2(object):
-    """ This wraps cython's view.memoryview and fixes its PEP-3118 compliance. """
-    cdef memoryview view
-    cdef object obj
-    def __cinit__(memoryview2 self, object obj, bint readonly = False):
-        self.view = memoryview(obj, PyBUF_RECORDS_RO if readonly else PyBUF_RECORDS)
-        self.obj = obj
-    def __getbuffer__(self, Py_buffer *info, int flags):
-        PyObject_GetBuffer(self.obj, info, flags)
-    def __getattr__(memoryview2 self, object attr):
-        return getattr(self.view, attr)
-    def __getitem__(memoryview2 self, object index):
-        return self.view.__getitem__(index)
-    def __setitem__(memoryview2 self, object index, object val):
-        self.view.__setitem__(index, val)
-    def __len__(memoryview2 self): return self.view.__len__()
-    def __str__(memoryview2 self): return self.view.__str__()
-    def __repr__(memoryview2 self): return self.view.__repr__()
 
 cdef class VideoFrame(RawFrame):
     cdef readonly VideoFormat format
@@ -1303,11 +1282,12 @@ cdef class VideoFrame(RawFrame):
         return s
 
     def get_read_array(self, int index):
-        return memoryview2(self.__getitem__(index), True)
+        import numpy
+        return numpy.asarray(self[index])
     def get_write_array(self, int index):
         if self.readonly:
             raise Error('Cannot obtain write array to read only frame')
-        return memoryview2(self.__getitem__(index))
+        return self.get_read_array(index)
 
 cdef VideoFrame createConstVideoFrame(const VSFrame *constf, const VSAPI *funcs, VSCore *core):
     cdef VideoFrame instance = VideoFrame.__new__(VideoFrame)


### PR DESCRIPTION
It seems the reason `get_read_array` and `get_write_array` are removed is because cython's `view.memoryview` is not fully PEP-3118 compliant (e.g. write the buffer to a file when the buffer is not fully contiguous, e.g. #423).

However, this should not be the reason to drop an otherwise working API and break existing user code.

We fix the issue by using a wrapper class that delegates `__getbuffer__` to the newly introduced fully PEP-3118 compliant mechanism from #735, but still exposes the rich interface from cython's `view.memoryview` as in R54 so that no user code will be broken in R55.

All done with minimum amount of added complexity.

Code is tested with an extensive test suite that covers all known use cases.