### PR TITLE
imwri: load embedded ICC to _ICCProfile frame property

### DIFF
--- a/doc/plugins/imwri.rst
+++ b/doc/plugins/imwri.rst
@@ -43,7 +43,7 @@ ImageMagick Writer-Reader (IMWRI) is a plugin that can read and write many image
          A grayscale clip containing the alpha channel for the image to write. Apart from being grayscale, its properties must be identical to the main *clip*.
         
 
-.. function:: Read(string[] filename[, int firstnum=0, bint mismatch=False, bint alpha=False, bint float_output = False])
+.. function:: Read(string[] filename[, int firstnum=0, bint mismatch=False, bint alpha=False, bint float_output = False, bint embed_icc = False])
    :module: imwri
 
    Possible output formats when reading: 8-16 bit integer and 32 bit float
@@ -67,3 +67,6 @@ ImageMagick Writer-Reader (IMWRI) is a plugin that can read and write many image
 
       float_output
          Always return the read image in a float format. Due to the output format guessing this option can be useful when reading half precision float images.
+
+      embed_icc
+         For each read image, if an embedded ICC profile is found, it will be attached via the frame property ``_ICCProfile``. If IMWRI is not built with Little CMS support, this option is forced disabled.

--- a/src/filters/imwri/imwri.cpp
+++ b/src/filters/imwri/imwri.cpp
@@ -53,6 +53,10 @@
 #error ImageMagick must be compiled with HDRI enabled
 #endif
 
+#if defined(MAGICKCORE_LCMS_DELEGATE)
+#define IMWRI_HAS_LCMS2
+#endif
+
 // Because proper namespace handling is too hard for ImageMagick shitvelopers
 using MagickCore::Quantum;
 
@@ -523,6 +527,7 @@ struct ReadData {
     bool floatOutput;
     int cachedFrameNum;
     bool cachedAlpha;
+    bool embedICC;
     const VSFrameRef *cachedFrame;
 
     ReadData() : fileListMode(true), cachedFrameNum(-1), cachedAlpha(false), cachedFrame(nullptr) {};
@@ -723,6 +728,14 @@ static const VSFrameRef *VS_CC readGetFrame(int n, int activationReason, void **
             } else if (fi->bytesPerSample == 1) {
                 readImageHelper<uint8_t>(frame, alphaFrame, isGray, image, width, height, fi->bitsPerSample, vsapi);
             }
+#if defined(IMWRI_HAS_LCMS2)
+            if (d->embedICC) {
+                const MagickCore::StringInfo *icc_profile = MagickCore::GetImageProfile(image.constImage(), "icc");
+                if (icc_profile) {
+                    vsapi->propSetData(vsapi->getFramePropsRW(frame), "_ICCProfile", reinterpret_cast<const char *>(icc_profile->datum), icc_profile->length, paReplace);
+                }
+            }
+#endif
         } catch (Magick::Exception &e) {
             vsapi->setFilterError((std::string("Read: ImageMagick error: ") + e.what()).c_str(), frameCtx);
             vsapi->freeFrame(frame);
@@ -770,7 +783,11 @@ static void VS_CC readCreate(const VSMap *in, VSMap *out, void *userData, VSCore
     d->alpha = !!vsapi->propGetInt(in, "alpha", 0, &err);
     d->mismatch = !!vsapi->propGetInt(in, "mismatch", 0, &err);
     d->floatOutput = !!vsapi->propGetInt(in, "float_output", 0, &err);
-
+#if defined(IMWRI_HAS_LCMS2)
+    d->embedICC = !!vsapi->propGetInt(in, "embed_icc", 0, &err);
+#else
+    d->embedICC = false;
+#endif
     int numElem = vsapi->propNumElements(in, "filename");
     d->filenames.resize(numElem);
     for (int i = 0; i < numElem; i++)
@@ -832,5 +849,5 @@ static void VS_CC readCreate(const VSMap *in, VSMap *out, void *userData, VSCore
 VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin) {
     configFunc(IMWRI_ID, IMWRI_NAMESPACE, IMWRI_PLUGIN_NAME, VAPOURSYNTH_API_VERSION, 1, plugin);
     registerFunc("Write", "clip:clip;imgformat:data;filename:data;firstnum:int:opt;quality:int:opt;dither:int:opt;compression_type:data:opt;overwrite:int:opt;alpha:clip:opt;", writeCreate, nullptr, plugin);
-    registerFunc("Read", "filename:data[];firstnum:int:opt;mismatch:int:opt;alpha:int:opt;float_output:int:opt;", readCreate, nullptr, plugin);
+    registerFunc("Read", "filename:data[];firstnum:int:opt;mismatch:int:opt;alpha:int:opt;float_output:int:opt;embed_icc:int:opt;", readCreate, nullptr, plugin);
 }


### PR DESCRIPTION
This commit will let ImageMagick extract embedded ICC profiles from images and keep them in VS. Should be helpful for #533.
It is enabled only when
1. ImageMagick was built having Little CMS linked;
2. user sets `embed_icc=True`.

An ICC profile is usually from 1KB to 1MB.
