### PR TITLE
Add rpAutoFallback and make it default for API3

### DIFF
--- a/include/VapourSynth4.h
+++ b/include/VapourSynth4.h
@@ -297,7 +297,8 @@ typedef enum VSDataTypeHint {
 typedef enum VSRequestPattern {
     rpGeneral = 0, /* General pattern */
     rpNoFrameReuse = 1, /* When requesting all output frames from the filter no frame will be requested more than once from this input clip, never requests frames beyond the end of the clip */
-    rpStrictSpatial = 2 /* Always (and only) requests frame n from input clip when generating output frame n, never requests frames beyond the end of the clip */
+    rpStrictSpatial = 2, /* Always (and only) requests frame n from input clip when generating output frame n, never requests frames beyond the end of the clip */
+    rpAutoFallback = 3 /* Strict spatial by default. Fallback to general once non-spatial request occur. */
 } VSRequestPattern;
 
 /* Core entry point */

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -735,7 +735,7 @@ VSNode::VSNode(const VSMap *in, VSMap *out, const std::string &name, vs3::VSFilt
     // Worst case there are false positives and an extra cache gets activated
     // NoCache is generally the equivalent strict spatial for filters
 
-    int requestPattern = !!(flags & vs3::nfNoCache) ? rpNoFrameReuse : rpGeneral;
+    int requestPattern = !!(flags & vs3::nfNoCache) ? rpNoFrameReuse : rpAutoFallback;
     int numKeys = vs_internal_vsapi.mapNumKeys(in);
 
     bool makeLinear = (flags & vs3::nfMakeLinear);

--- a/src/core/vsthreadpool.cpp
+++ b/src/core/vsthreadpool.cpp
@@ -353,6 +353,21 @@ void VSThreadPool::startInternalRequest(const PVSFrameContext &notify, NodeOutpu
     if (key.second < 0)
         core->logFatal("Negative frame request by: " + notify->key.first->getName());
 
+    // fallback for rpAutoFallback
+    if (notify->key.second != key.second) {
+        auto node = notify->key.first;
+        auto source = key.first;
+        for (auto dependency : node->dependencies) {
+            if (dependency.source == source) {
+                if (dependency.requestPattern == rpAutoFallback) {
+                    dependency.requestPattern = rpGeneral;
+                    source->registerCache(true);
+                }
+                break;
+            }
+        }
+    }
+
     // check to see if it's time to reevaluate cache sizes
     if (core->memory->isOverLimit()) {
         ticks = 0;

--- a/src/core/vsthreadpool.cpp
+++ b/src/core/vsthreadpool.cpp
@@ -357,7 +357,7 @@ void VSThreadPool::startInternalRequest(const PVSFrameContext &notify, NodeOutpu
     if (notify->key.second != key.second) {
         auto node = notify->key.first;
         auto source = key.first;
-        for (auto dependency : node->dependencies) {
+        for (auto& dependency : node->dependencies) {
             if (dependency.source == source) {
                 if (dependency.requestPattern == rpAutoFallback) {
                     dependency.requestPattern = rpGeneral;


### PR DESCRIPTION
This commit adds a new request pattern: rpAutoFallback, which means: initially strict spatial by default, fallback to rpGeneral once a non-spatial request is issued.

This commit also makes rpAutoFallback the default request pattern for legacy API3 filters. Before this commit, we treat legacy API3 filters rpGeneral and always add caches for them. However, a large proportion of these filters are actually spatial. By introducing rpAutoFallback, we can treat legacy API3 filters smartly.

The implementation is straightforward: when a non-spatial request occurs, iterate the dependencies of the node, find the corresponding dependency, reset the request pattern to rpGeneral, and then add cache for the dependency node.