### PR TITLE
fix return types

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -515,9 +515,24 @@ def construct_signature(signature, return_signature, injected=None):
     
     if injected:
         del params[0]
-    
-    return inspect.Signature(tuple(params), return_annotation=_construct_type(return_signature))
-    
+
+    if return_signature == 'any':
+        return_signature = 'clip:vnode;'
+
+    return_param = [
+        _construct_parameter(param).annotation
+        for param in return_signature.split(";")
+        if param
+    ]
+    if len(return_param) == 0:
+        return_type = None
+    elif len(return_param) == 1:
+        return_type = return_param.pop()
+    else:
+        return_type = tuple(return_param)
+
+    return inspect.Signature(tuple(params), return_annotation=return_type)
+
 
 class Error(Exception):
     def __init__(self, value):


### PR DESCRIPTION
We assume here that 'any' is a vnode. Without it, most of the filters will just output a garbage return type