### PR TITLE
Fix function signatures

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -488,6 +488,12 @@ def _construct_type(signature):
     return type
 
 def _construct_parameter(signature):
+    if signature == "any":
+        return inspect.Parameter(
+            "kwargs", inspect.Parameter.VAR_KEYWORD,
+            annotation=typing.Any
+        )
+
     name, signature = signature.split(":", 1)
     type = _construct_type(signature)
     

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -520,11 +520,24 @@ def construct_signature(signature, return_signature, injected=None):
         for param in signature.split(";")
         if param
     )
-    
+
     if injected:
         del params[0]
-    
-    return inspect.Signature(tuple(params), return_annotation=_construct_type(return_signature))
+
+    return_annotations = list(
+        _construct_parameter(rparam).annotation
+        for rparam in return_signature.split(";")
+        if rparam
+    )
+
+    if len(return_annotations) == 0:
+        return_annotation = None
+    elif len(return_annotations) == 1:
+        return_annotation = return_annotations.pop()
+    else:
+        return_annotation = typing.Tuple[typing.Any, ...]
+
+    return inspect.Signature(tuple(params), return_annotation=return_annotation)
     
 
 class Error(Exception):


### PR DESCRIPTION
When a function has `any` in its parameters, a mapping of key values is expected.
When `any` is used in the return type, it should be just a `typing.Any`.

These commits fix the return types while managing the number of them.
Unfortunately, we can't build a dynamic `typing.Tuple[...]` of annotations so if a function returns more than one object, we just fallback to a tuple of `typing.Any`.