### PR TITLE
Add a .close-method on frames.

### DIFF
--- a/src/cython/vapoursynth.pxd
+++ b/src/cython/vapoursynth.pxd
@@ -274,7 +274,7 @@ cdef extern from "include/VapourSynth4.h" nogil:
         VSFrame *newAudioFrame(const VSAudioFormat *format, int sampleRate, const VSFrame *propSrc, VSCore *core) nogil
         VSFrame *newAudioFrame2(const VSAudioFormat *format, int numSamples, const VSFrame **channelSrc, const int *channels, const VSFrame *propSrc, VSCore *core) nogil
         void freeFrame(const VSFrame *f) nogil
-        const VSFrame *addFrameRef(VSFrame *f) nogil
+        const VSFrame *addFrameRef(const VSFrame *f) nogil
         VSFrame *copyFrame(const VSFrame *f, VSCore *core) nogil
         const VSMap *getFramePropertiesRO(const VSFrame *f) nogil
         VSMap *getFramePropertiesRW(VSFrame *f) nogil


### PR DESCRIPTION
Changes in other parts of vapoursynth:

1. RawFrame.props will be evaluated as needed and hold a reference on the generating RawFrame-instance.
2. `RawFrame[idx]` will clone the `const VSFrameRef`-pointer to prevent a use-after-free.
3. Added a parameter `close` to `RawFrame.frames()` which, if manually set to true, will automatically close the frames after each iteration.

What is missing:
I'd like to update the docs. :)