### PR TITLE
Fix long_description for non-portable installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ if is_win:
         library_dirs.append(join("msvc_project", "Release"))
         lib_suffix = "lib32"
 
+    is_portable = False
+
     #
     # This code detects the library directory by querying the Windows Registry
     # for the current VapourSynth directory location.
@@ -53,6 +55,8 @@ if is_win:
         # hit the path.
         #
         # This is an indicator for portable installations.
+        is_portable = True
+
         dll_path = which("vapoursynth.dll")
         if dll_path is None:
             # If the vapoursynth.dll is not located in PATH, we then hit the registry
@@ -87,7 +91,7 @@ setup(
     author_email = "fredrik.mellbin@gmail.com",
     license = "LGPL 2.1 or later",
     version = "57",
-    long_description = "A portable replacement for Avisynth",
+    long_description = "A portable replacement for Avisynth" if is_portable else "A modern replacement for Avisynth",
     platforms = "All",
     ext_modules = [Extension("vapoursynth", [join("src", "cython", "vapoursynth.pyx")],
                              libraries = ["vapoursynth"],


### PR DESCRIPTION
It's been bugging me for a while that PyPI and anything else that uses the `long_description` notes it as portable, even for non-portable installs.
So I complained and cid told me to PR it 👍🏻