### PR TITLE
vsscript: Fix loading python module in mingw

### DIFF
--- a/src/vsscript/vsscript.cpp
+++ b/src/vsscript/vsscript.cpp
@@ -41,7 +41,13 @@ static PyThreadState *ts = nullptr;
 static PyGILState_STATE s;
 
 static void real_init(void) VS_NOEXCEPT {
-#ifdef VS_TARGET_OS_WINDOWS
+
+//
+// Search for portable python library only if compiled with
+// MSVC toolchain. In MINGW, shared libraries are already
+// linked with libpython*.dll
+//
+#if defined(VS_TARGET_OS_WINDOWS) && defined(_MSC_VER)
 #ifdef _WIN64
     #define VS_INSTALL_REGKEY L"Software\\VapourSynth"
 #else


### PR DESCRIPTION
Search for portable python library only if compiled with
MSVC toolchain. In MINGW, shared libraries are already
linked with libpython*.dll