### PR TITLE
Add an environment variable VAPOURSYNTH_CONF_PATH

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -312,6 +312,8 @@ $XDG_CONFIG_HOME/vapoursynth/vapoursynth.conf,
 or $HOME/.config/vapoursynth/vapoursynth.conf if XDG_CONFIG_HOME is not
 defined.
 
+To provide your own path to the config file, you can use $VAPOURSYNTH_CONF_PATH.
+
 Two configuration options may be used: **UserPluginDir**, empty by default,
 and **SystemPluginDir**, whose default value is set at compile time to
 ``$libdir/vapoursynth``, or to the location passed to the ``--with-plugindir``
@@ -331,3 +333,5 @@ OS X
 Autoloading can be configured using the file
 $HOME/Library/Application Support/VapourSynth/vapoursynth.conf. Everything else is
 the same as in Linux.
+
+Like on linux, you can use $VAPOURSYNTH_CONF_PATH to provide your own configuration.

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -1858,21 +1858,33 @@ VSCore::VSCore(int flags) :
 
 #else
     std::string configFile;
-    const char *home = getenv("HOME");
 #ifdef VS_TARGET_OS_DARWIN
-    std::string filter = ".dylib";
-    if (home) {
-        configFile.append(home).append("/Library/Application Support/VapourSynth/vapoursynth.conf");
-    }
+    const std::string filter = ".dylib";
 #else
-    std::string filter = ".so";
-    const char *xdg_config_home = getenv("XDG_CONFIG_HOME");
-    if (xdg_config_home) {
-        configFile.append(xdg_config_home).append("/vapoursynth/vapoursynth.conf");
-    } else if (home) {
-        configFile.append(home).append("/.config/vapoursynth/vapoursynth.conf");
-    } // If neither exists, an empty string will do.
+    const std::string filter = ".so";
 #endif
+    
+    const char *override = getenv("VAPOURSYNTH_CONF_PATH");
+
+    if (override) {
+        configFile.append(override);
+    } else {
+        const char *home = getenv("HOME");
+#ifdef VS_TARGET_OS_DARWIN
+        std::string filter = ".dylib";
+        if (home) {
+            configFile.append(home).append("/Library/Application Support/VapourSynth/vapoursynth.conf");
+        }
+#else
+        std::string filter = ".so";
+        const char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+        if (xdg_config_home) {
+            configFile.append(xdg_config_home).append("/vapoursynth/vapoursynth.conf");
+        } else if (home) {
+            configFile.append(home).append("/.config/vapoursynth/vapoursynth.conf");
+        } // If neither exists, an empty string will do.
+#endif
+    }
 
     VSMap *settings = readSettings(configFile);
     const char *error = vs_internal_vsapi.mapGetError(settings);


### PR DESCRIPTION
This allows a user to provide a custom vapoursynth.conf.