### PR TITLE
Log a warning if autoloading a plugin fails

### DIFF
--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -1656,8 +1656,8 @@ bool VSCore::loadAllPluginsInPath(const std::string &path, const std::string &fi
     do {
         try {
             loadPlugin(utf16_to_utf8(path + L"\\" + findData.cFileName));
-        } catch (VSException &) {
-            // Ignore any errors
+        } catch (VSException &e) {
+            logMessage(mtWarning, e.what());
         }
     } while (FindNextFile(findHandle, &findData));
     FindClose(findHandle);
@@ -1683,8 +1683,8 @@ bool VSCore::loadAllPluginsInPath(const std::string &path, const std::string &fi
                 std::string fullname;
                 fullname.append(path).append("/").append(name);
                 loadPlugin(fullname);
-            } catch (VSException &) {
-                // Ignore any errors
+            } catch (VSException &e) {
+                logMessage(mtWarning, e.what());
             }
         }
     }


### PR DESCRIPTION
As of now, failing to autoload a plugin is just silently ignored.
Adding a warning may annoy some people that have a messy plugin directory, but that's a good thing.
This warning helped me find some broken plugins.