### PR TITLE
Fix construct_signature

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -489,7 +489,7 @@ def construct_signature(signature, return_signature, injected=None):
         if param
     )
 
-    if injected:
+    if injected and params:
         del params[0]
 
     return_annotations = list(


### PR DESCRIPTION
Sorry for the one line fix, could've asked to change it directly, but i also wanted to ask.
Is this something this function should accept or should plugin writers not have this?

<https://github.com/AkarinVS/vapoursynth-plugin/blob/master/expr/exprfilter.cpp#L3973>

Error is simple and clear, but:
it throws `IndexError` if a Plugin is clip bound (it becomes since Expr in this case is bound) and a Function in it doesn't accept any arguments.