### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ x64
 Debug
 Release
 msvc_project/.vs
+
+.ccls-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,9 @@ dist/
 .eggs
 *.egg-info/
 
-zimg/
+libp2p
+vsrepo
+zimg
 AviSynthPlus
 
 *.log


### PR DESCRIPTION
Only zimg and avs+ were ignored, of the four deps.