### PR TITLE
Update VideoFrame's `writelines` method

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -474,7 +474,7 @@ Classes and Functions
 
       Returns the stride between lines in a *plane*.
 
-   .. py:method:: writelines()
+   .. py:method:: writechunks()
 
       This method is usually used to dump the contents of a VideoFrame to disk.
       The returned generator yields contiguous chunks of the VideoFrame memory.
@@ -482,8 +482,8 @@ Classes and Functions
       .. code::
          with open('output.raw', 'wb') as file:
             with vs.core.std.BlankClip(color=[25, 50, 60]).get_frame(0) as f:
-               for line in f.writelines():
-                  file.write(line)
+               for chunk in f.writechunks():
+                  file.write(chunk)
 
       .. note::
          Usually, the frame contents will be held in a contiguous array,

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -474,21 +474,24 @@ Classes and Functions
 
       Returns the stride between lines in a *plane*.
 
-   .. py:method:: writelines(write)
+   .. py:method:: writelines()
 
       This method is usually used to dump the contents of a VideoFrame to disk.
-      The `write` parameter is a callable that must take a memoryview as input, and outputs None.
+      The returned generator yields contiguous chunks of the VideoFrame memory.
 
       .. code::
          with open('output.raw', 'wb') as file:
             with vs.core.std.BlankClip(color=[25, 50, 60]).get_frame(0) as f:
-               f.writelines(file.write)
+               for line in f.writelines():
+                  file.write(line)
 
       .. note::
-         Usually, the frame contents will be held in a contiguous array, and `write` will get the full plane data.
-         Don't, however, take this for granted, as it can't be the case, and `write` will be called with each line.
+         Usually, the frame contents will be held in a contiguous array,
+         and this method will yield *n_planes* of data chunks each holding the entire plane.
+         Don't, however, take this for granted, as it can't be the case,
+         and you will iterate over lines of plane data instead, which are assured to be contiguous.
          
-         If you want to read the whole plane, use frame[plane_idx] to get the plane memoryview.
+         If you want to safely read the whole plane, use frame[plane_idx] to get the plane memoryview.
 
 .. py:class:: VideoFormat
 

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -474,6 +474,22 @@ Classes and Functions
 
       Returns the stride between lines in a *plane*.
 
+   .. py:method:: writelines(write)
+
+      This method is usually used to dump the contents of a VideoFrame to disk.
+      The `write` parameter is a callable that must take a memoryview as input, and outputs None.
+
+      .. code::
+         with open('output.raw', 'wb') as file:
+            with vs.core.std.BlankClip(color=[25, 50, 60]).get_frame(0) as f:
+               f.writelines(file.write)
+
+      .. note::
+         Usually, the frame contents will be held in a contiguous array, and `write` will get the full plane data.
+         Don't, however, take this for granted, as it can't be the case, and `write` will be called with each line.
+         
+         If you want to read the whole plane, use frame[plane_idx] to get the plane memoryview.
+
 .. py:class:: VideoFormat
 
    This class represents all information needed to describe a frame format. It

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -474,7 +474,7 @@ Classes and Functions
 
       Returns the stride between lines in a *plane*.
 
-   .. py:method:: writechunks()
+   .. py:method:: readchunks()
 
       This method is usually used to dump the contents of a VideoFrame to disk.
       The returned generator yields contiguous chunks of the VideoFrame memory.
@@ -482,7 +482,7 @@ Classes and Functions
       .. code::
          with open('output.raw', 'wb') as file:
             with vs.core.std.BlankClip(color=[25, 50, 60]).get_frame(0) as f:
-               for chunk in f.writechunks():
+               for chunk in f.readchunks():
                   file.write(chunk)
 
       .. note::

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1286,7 +1286,7 @@ cdef class VideoFrame(RawFrame):
         self._ensure_open()
         return createVideoFrame(self.funcs.copyFrame(self.constf, self.core), self.funcs, self.core)
 
-    def writechunks(self):
+    def readchunks(self):
         self._ensure_open()
 
         lib = self.funcs
@@ -1937,13 +1937,13 @@ cdef class VideoNode(RawNode):
             fileobj.write(data.encode("ascii"))
 
         write = fileobj.write
-        writechunks = VideoFrame.writechunks
+        readchunks = VideoFrame.readchunks
 
         for idx, frame in enumerate(self.frames(prefetch, backlog, close=True)):
             if y4m:
                 fileobj.write(b"FRAME\n")
             
-            for chunk in writechunks(frame):
+            for chunk in readchunks(frame):
                 write(chunk)
 
             if progress_update is not None:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1286,7 +1286,7 @@ cdef class VideoFrame(RawFrame):
         self._ensure_open()
         return createVideoFrame(self.funcs.copyFrame(self.constf, self.core), self.funcs, self.core)
 
-    def _writelines(self, write):
+    def writelines(self, write):
         self._ensure_open()
         assert callable(write), "'write' is not callable"
 
@@ -1938,7 +1938,7 @@ cdef class VideoNode(RawNode):
             fileobj.write(data.encode("ascii"))
 
         write = fileobj.write
-        writelines = VideoFrame._writelines
+        writelines = VideoFrame.writelines
 
         for idx, frame in enumerate(self.frames(prefetch, backlog, close=True)):
             if y4m:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1286,7 +1286,7 @@ cdef class VideoFrame(RawFrame):
         self._ensure_open()
         return createVideoFrame(self.funcs.copyFrame(self.constf, self.core), self.funcs, self.core)
 
-    def writelines(self):
+    def writechunks(self):
         self._ensure_open()
 
         lib = self.funcs
@@ -1937,14 +1937,14 @@ cdef class VideoNode(RawNode):
             fileobj.write(data.encode("ascii"))
 
         write = fileobj.write
-        writelines = VideoFrame.writelines
+        writechunks = VideoFrame.writechunks
 
         for idx, frame in enumerate(self.frames(prefetch, backlog, close=True)):
             if y4m:
                 fileobj.write(b"FRAME\n")
             
-            for line in writelines(frame):
-                write(line)
+            for chunk in writechunks(frame):
+                write(chunk)
 
             if progress_update is not None:
                 progress_update(idx+1, len(self))

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1286,9 +1286,8 @@ cdef class VideoFrame(RawFrame):
         self._ensure_open()
         return createVideoFrame(self.funcs.copyFrame(self.constf, self.core), self.funcs, self.core)
 
-    def writelines(self, write):
+    def writelines(self):
         self._ensure_open()
-        assert callable(write), "'write' is not callable"
 
         lib = self.funcs
         frame = <VSFrame*> self.constf
@@ -1317,10 +1316,10 @@ cdef class VideoFrame(RawFrame):
 
                 for _ in range(lines):
                     line = PyMemoryView_FromObject(data)
-                    write(line)
+                    yield line
                     tmp.buf = &(<char*> tmp.buf)[stride]
             else:
-                write(data)
+                yield data
 
     def __getitem__(self, index):
         self._ensure_open()
@@ -1943,8 +1942,9 @@ cdef class VideoNode(RawNode):
         for idx, frame in enumerate(self.frames(prefetch, backlog, close=True)):
             if y4m:
                 fileobj.write(b"FRAME\n")
-
-            writelines(frame, write)
+            
+            for line in writelines(frame):
+                write(line)
 
             if progress_update is not None:
                 progress_update(idx+1, len(self))


### PR DESCRIPTION
Complementary PR of vsrepo's, so that this method can be added to public typing stubs.

EDIT: Following cid's request, I converted this PR into updating this method, so it's more clear and pythonic; instead of taking a callback, it now yields chunks of data.

The only public use I know of is in [lvsfunc](https://github.com/Irrational-Encoding-Wizardry/lvsfunc/blob/master/lvsfunc/render.py#L65), and for that @tomato39 had to [modify](https://github.com/tomato39/vsrepo/commit/318ac44e64f423fade47517bf1bc70da09c1f234) the template.
CC: @LightArrowsEXE, you'll need to update that line.

_Originally posted by @cid-chan in https://github.com/vapoursynth/vsrepo/pull/186#discussion_r973683694_