### PR TITLE
Fix VSMap leaking from setFrameProps

### DIFF
--- a/src/core/simplefilters.cpp
+++ b/src/core/simplefilters.cpp
@@ -2308,7 +2308,7 @@ static void VS_CC setFramePropsCreate(const VSMap *in, VSMap *out, void *userDat
     vsapi->mapDeleteKey(d->props, "clip");
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "SetFrameProps", vsapi->getVideoInfo(d->node), setFramePropsGetFrame, filterFree<SetFramePropsData>, fmParallel, deps, 1, d.get(), core);
+    vsapi->createVideoFilter(out, "SetFrameProps", vsapi->getVideoInfo(d->node), setFramePropsGetFrame, setFramePropsFree, fmParallel, deps, 1, d.get(), core);
     d.release();
 }
 


### PR DESCRIPTION
Generic `filterFree` doesn't call `freeMap()` on owning raw pointer inside `SetFramePropData`. Seems like an overlook during refactoring, because proper clean-up function `setFramePropsFree` is still present.