### PR TITLE
Fix ownership not transferred properly from unique_ptr

### DIFF
--- a/src/avisynth/avisynth_compat.cpp
+++ b/src/avisynth/avisynth_compat.cpp
@@ -189,8 +189,7 @@ static VSNode *VS_CC packYUY2Create(VSNode *node, VSCore *core, const VSAPI *vsa
     vsapi->getVideoFormatByID(&d->vi.format, pfGray16, core);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    VSNode *ret = vsapi->createVideoFilter2("PackYUY2", &d->vi, packYUY2GetFrame, filterFree<PackYUY2Data>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    VSNode *ret = vsapi->createVideoFilter2("PackYUY2", &d->vi, packYUY2GetFrame, filterFree<PackYUY2Data>, fmParallel, deps, 1, d.release(), core);
     return ret;
 }
 
@@ -246,8 +245,7 @@ static VSNode *VS_CC unpackYUY2Create(VSNode *node, VSCore *core, const VSAPI *v
     vsapi->getVideoFormatByID(&d->vi.format, pfYUV422P8, core);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    VSNode *ret = vsapi->createVideoFilter2("UnpackRGB32", &d->vi, unpackYUY2GetFrame, filterFree<UnpackYUY2Data>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    VSNode *ret = vsapi->createVideoFilter2("UnpackRGB32", &d->vi, unpackYUY2GetFrame, filterFree<UnpackYUY2Data>, fmParallel, deps, 1, d.release(), core);
     return ret;
 }
 
@@ -303,8 +301,7 @@ static VSNode *VS_CC packRGB32Create(VSNode *node, VSCore *core, const VSAPI *vs
     vsapi->getVideoFormatByID(&d->vi.format, pfGray32, core);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    VSNode *ret = vsapi->createVideoFilter2("PackRGB32", &d->vi, packRGB32GetFrame, filterFree<PackRGB32Data>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    VSNode *ret = vsapi->createVideoFilter2("PackRGB32", &d->vi, packRGB32GetFrame, filterFree<PackRGB32Data>, fmParallel, deps, 1, d.release(), core);
     return ret;
 }
 
@@ -360,8 +357,7 @@ static VSNode *VS_CC unpackRGB32Create(VSNode *node, VSCore *core, const VSAPI *
     vsapi->getVideoFormatByID(&d->vi.format, pfRGB24, core);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    VSNode *ret = vsapi->createVideoFilter2("UnpackRGB32", &d->vi, unpackRGB32GetFrame, filterFree<UnpackRGB32Data>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    VSNode *ret = vsapi->createVideoFilter2("UnpackRGB32", &d->vi, unpackRGB32GetFrame, filterFree<UnpackRGB32Data>, fmParallel, deps, 1, d.release(), core);
     return ret;
 }
 
@@ -871,7 +867,7 @@ static void VS_CC fakeAvisynthFunctionWrapper(const VSMap *in, VSMap *out, void 
         PClip clip = ret.AsClip();
 
         PrefetchInfo prefetchInfo = getPrefetchInfo(wf->name, in, core, vsapi);
-        std::unique_ptr<WrappedClip> filterData(new WrappedClip(wf->name, clip, preFetchClips, prefetchInfo, fakeEnv.get()));
+        std::unique_ptr<WrappedClip> filterData(new WrappedClip(wf->name, clip, preFetchClips, prefetchInfo, fakeEnv.release()));
 
         if (!filterData->preFetchClips.empty())
             filterData->fakeEnv->uglyNode = filterData->preFetchClips.front();
@@ -925,8 +921,6 @@ static void VS_CC fakeAvisynthFunctionWrapper(const VSMap *in, VSMap *out, void 
     } else if (ret.IsString()) {
         vsapi->mapSetData(out, "val", ret.AsString(), -1, dtUtf8, maReplace);
     }
-
-    fakeEnv.release();
 }
 
 void FakeAvisynth::AddFunction(const char *name, const char *params, ApplyFunc apply, void *user_data) {

--- a/src/core/audiofilters.cpp
+++ b/src/core/audiofilters.cpp
@@ -139,8 +139,7 @@ static void VS_CC audioTrimCreate(const VSMap *in, VSMap *out, void *userData, V
     d->ai.numSamples = trimlen;
 
     VSFilterDependency deps[] = {{d->node, rpGeneral}};
-    vsapi->createAudioFilter(out, "AudioTrim", &d->ai, audioTrimGetframe, filterFree<AudioTrimData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createAudioFilter(out, "AudioTrim", &d->ai, audioTrimGetframe, filterFree<AudioTrimData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -260,8 +259,7 @@ static void VS_CC audioSpliceCreate(const VSMap *in, VSMap *out, void *userData,
     std::vector<VSFilterDependency> deps;
     for (int i = 0; i < numNodes; i++)
         deps.push_back({d->nodes[i], (i == 0) ? rpNoFrameReuse : rpGeneral});
-    vsapi->createAudioFilter(out, "AudioSplice", &d->ai, audioSpliceGetframe, filterFree<AudioSpliceData>, fmParallel, deps.data(), numNodes, d.get(), core);
-    d.release();
+    vsapi->createAudioFilter(out, "AudioSplice", &d->ai, audioSpliceGetframe, filterFree<AudioSpliceData>, fmParallel, deps.data(), numNodes, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -352,8 +350,7 @@ static void VS_CC audioLoopCreate(const VSMap *in, VSMap *out, void *userData, V
     }
 
     VSFilterDependency deps[] = {{d->node, rpGeneral}};
-    vsapi->createAudioFilter(out, "AudioLoop", &d->ai, audioLoopGetFrame, filterFree<AudioLoopData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createAudioFilter(out, "AudioLoop", &d->ai, audioLoopGetFrame, filterFree<AudioLoopData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -421,10 +418,9 @@ static void VS_CC audioReverseCreate(const VSMap *in, VSMap *out, void *userData
 
     VSFilterDependency deps[] = {{d->node, rpGeneral}};
     if (d->ai->format.bytesPerSample == 2)
-        vsapi->createAudioFilter(out, "AudioReverse", d->ai, audioReverseGetFrame<int16_t>, filterFree<AudioReverseData>, fmParallel, deps, 1, d.get(), core);
+        vsapi->createAudioFilter(out, "AudioReverse", d->ai, audioReverseGetFrame<int16_t>, filterFree<AudioReverseData>, fmParallel, deps, 1, d.release(), core);
     else
-        vsapi->createAudioFilter(out, "AudioReverse", d->ai, audioReverseGetFrame<int32_t>, filterFree<AudioReverseData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+        vsapi->createAudioFilter(out, "AudioReverse", d->ai, audioReverseGetFrame<int32_t>, filterFree<AudioReverseData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -477,12 +473,11 @@ static void VS_CC audioGainCreate(const VSMap *in, VSMap *out, void *userData, V
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
     if (d->ai->format.bytesPerSample == 4 && d->ai->format.sampleType == stFloat)
-        vsapi->createAudioFilter(out, "AudioGain", d->ai, audioGainGetFrame<float>, filterFree<AudioGainData>, fmParallel, deps, 1, d.get(), core);
+        vsapi->createAudioFilter(out, "AudioGain", d->ai, audioGainGetFrame<float>, filterFree<AudioGainData>, fmParallel, deps, 1, d.release(), core);
     else if (d->ai->format.bytesPerSample == 2)
-        vsapi->createAudioFilter(out, "AudioGain", d->ai, audioGainGetFrame<int16_t>, filterFree<AudioGainData>, fmParallel, deps, 1, d.get(), core);
+        vsapi->createAudioFilter(out, "AudioGain", d->ai, audioGainGetFrame<int16_t>, filterFree<AudioGainData>, fmParallel, deps, 1, d.release(), core);
     else
-        vsapi->createAudioFilter(out, "AudioGain", d->ai, audioGainGetFrame<int32_t>, filterFree<AudioGainData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+        vsapi->createAudioFilter(out, "AudioGain", d->ai, audioGainGetFrame<int32_t>, filterFree<AudioGainData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -638,12 +633,11 @@ static void VS_CC audioMixCreate(const VSMap *in, VSMap *out, void *userData, VS
     for (const auto &iter : d->reqNodes)
         deps.push_back({iter, rpStrictSpatial});
     if (d->ai.format.sampleType == stFloat)
-        vsapi->createAudioFilter(out, "AudioMix", &d->ai, audioMixGetFrame<float>, audioMixFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.get(), core);
+        vsapi->createAudioFilter(out, "AudioMix", &d->ai, audioMixGetFrame<float>, audioMixFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.release(), core);
     else if (d->ai.format.bytesPerSample == 2)
-        vsapi->createAudioFilter(out, "AudioMix", &d->ai, audioMixGetFrame<int16_t>, audioMixFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.get(), core);
+        vsapi->createAudioFilter(out, "AudioMix", &d->ai, audioMixGetFrame<int16_t>, audioMixFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.release(), core);
     else
-        vsapi->createAudioFilter(out, "AudioMix", &d->ai, audioMixGetFrame<int32_t>, audioMixFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.get(), core);
-    d.release();
+        vsapi->createAudioFilter(out, "AudioMix", &d->ai, audioMixGetFrame<int32_t>, audioMixFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -780,8 +774,7 @@ static void VS_CC shuffleChannelsCreate(const VSMap *in, VSMap *out, void *userD
     for (const auto &iter : d->reqNodes)
         deps.push_back({iter, (d->ai.numFrames <= vsapi->getVideoInfo(iter)->numFrames) ? rpStrictSpatial : rpGeneral});
 
-    vsapi->createAudioFilter(out, "ShuffleChannels", &d->ai, shuffleChannelsGetFrame, shuffleChannelsFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.get(), core);
-    d.release();
+    vsapi->createAudioFilter(out, "ShuffleChannels", &d->ai, shuffleChannelsGetFrame, shuffleChannelsFree, fmParallel, deps.data(), static_cast<int>(deps.size()), d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -862,8 +855,7 @@ static void VS_CC assumeSampleRateCreate(const VSMap *in, VSMap *out, void *user
         RETERROR("AssumeSampleRate: invalid samplerate specified");
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createAudioFilter(out, "AssumeSampleRate", &ai, assumeSampleRateGetframe, filterFree<AssumeSampleRateData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createAudioFilter(out, "AssumeSampleRate", &ai, assumeSampleRateGetframe, filterFree<AssumeSampleRateData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -983,8 +975,7 @@ static void VS_CC blankAudioCreate(const VSMap *in, VSMap *out, void *userData, 
     if (!vsapi->queryAudioFormat(&d->ai.format, d->ai.format.sampleType, d->ai.format.bitsPerSample, d->ai.format.channelLayout, core))
         RETERROR("BlankAudio: invalid format");
 
-    vsapi->createAudioFilter(out, "BlankAudio", &d->ai, blankAudioGetframe, blankAudioFree, d->keep ? fmUnordered : fmParallel, nullptr, 0, d.get(), core);
-    d.release();
+    vsapi->createAudioFilter(out, "BlankAudio", &d->ai, blankAudioGetframe, blankAudioFree, d->keep ? fmUnordered : fmParallel, nullptr, 0, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -1055,8 +1046,7 @@ static void VS_CC testAudioCreate(const VSMap *in, VSMap *out, void *userData, V
     if (!vsapi->queryAudioFormat(&d->ai.format, isfloat ? stFloat : stInteger, bits, channels, core))
         RETERROR("TestAudio: invalid format");
 
-    vsapi->createAudioFilter(out, "TestAudio", &d->ai, testAudioGetframe, filterFree<TestAudioData>, fmParallel, nullptr, 0, d.get(), core);
-    d.release();
+    vsapi->createAudioFilter(out, "TestAudio", &d->ai, testAudioGetframe, filterFree<TestAudioData>, fmParallel, nullptr, 0, d.release(), core);
 }
 
 //////////////////////////////////////////

--- a/src/core/averageframesfilter.cpp
+++ b/src/core/averageframesfilter.cpp
@@ -290,8 +290,7 @@ static void VS_CC averageFramesCreate(const VSMap *in, VSMap *out, void *userDat
         for (int i = 0; i < numNodes; i++)
             deps.push_back({d->nodes[i], (vsapi->getVideoInfo(d->nodes[i])->numFrames >= d->vi.numFrames) ? rpStrictSpatial : rpGeneral});
     }
-    vsapi->createVideoFilter(out, "AverageFrames", &d->vi, averageFramesGetFrame, filterFree<AverageFrameData>, fmParallel, deps.data(), numNodes, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "AverageFrames", &d->vi, averageFramesGetFrame, filterFree<AverageFrameData>, fmParallel, deps.data(), numNodes, d.release(), core);
 }
 
 } // namespace

--- a/src/core/exprfilter.cpp
+++ b/src/core/exprfilter.cpp
@@ -358,8 +358,7 @@ static void VS_CC exprCreate(const VSMap *in, VSMap *out, void *userData, VSCore
     std::vector<VSFilterDependency> deps;
     for (int i = 0; i < d->numInputs; i++)
         deps.push_back({d->node[i], (d->vi.numFrames <= vsapi->getVideoInfo(d->node[i])->numFrames) ? rpStrictSpatial : rpGeneral});
-    vsapi->createVideoFilter(out, "Expr", &d->vi, exprGetFrame, exprFree, fmParallel, deps.data(), d->numInputs, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "Expr", &d->vi, exprGetFrame, exprFree, fmParallel, deps.data(), d->numInputs, d.release(), core);
 }
 
 } // namespace

--- a/src/core/genericfilters.cpp
+++ b/src/core/genericfilters.cpp
@@ -645,8 +645,7 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
     }
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, d->filter_name, d->vi, genericGetframe<op>, filterFree<GenericData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, d->filter_name, d->vi, genericGetframe<op>, filterFree<GenericData>, fmParallel, deps, 1, d.release(), core);
 }
 
 ///////////////////////////////
@@ -700,8 +699,7 @@ static void VS_CC invertCreate(const VSMap *in, VSMap *out, void *userData, VSCo
     }
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, d->name, d->vi, singlePixelGetFrame<InvertData, InvertOp>, filterFree<InvertData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, d->name, d->vi, singlePixelGetFrame<InvertData, InvertOp>, filterFree<InvertData>, fmParallel, deps, 1, d.release(), core);
 }
 
 /////////////////
@@ -756,8 +754,7 @@ static void VS_CC limitCreate(const VSMap *in, VSMap *out, void *userData, VSCor
     }
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, d->name, d->vi, singlePixelGetFrame<LimitData, LimitOp>, filterFree<LimitData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, d->name, d->vi, singlePixelGetFrame<LimitData, LimitOp>, filterFree<LimitData>, fmParallel, deps, 1, d.release(), core);
 }
 
 /////////////////
@@ -818,8 +815,7 @@ static void VS_CC binarizeCreate(const VSMap *in, VSMap *out, void *userData, VS
     }
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, d->name, d->vi, singlePixelGetFrame<BinarizeData, BinarizeOp>, filterFree<BinarizeData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, d->name, d->vi, singlePixelGetFrame<BinarizeData, BinarizeOp>, filterFree<BinarizeData>, fmParallel, deps, 1, d.release(), core);
 }
 
 /////////////////
@@ -986,12 +982,11 @@ static void VS_CC levelsCreate(const VSMap *in, VSMap *out, void *userData, VSCo
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
     if (d->vi->format.bytesPerSample == 1)
-        vsapi->createVideoFilter(out, d->name, d->vi, levelsGetframe<uint8_t>, filterFree<LevelsData>, fmParallel, deps, 1, d.get(), core);
+        vsapi->createVideoFilter(out, d->name, d->vi, levelsGetframe<uint8_t>, filterFree<LevelsData>, fmParallel, deps, 1, d.release(), core);
     else if (d->vi->format.bytesPerSample == 2)
-        vsapi->createVideoFilter(out, d->name, d->vi, levelsGetframe<uint16_t>, filterFree<LevelsData>, fmParallel, deps, 1, d.get(), core);
+        vsapi->createVideoFilter(out, d->name, d->vi, levelsGetframe<uint16_t>, filterFree<LevelsData>, fmParallel, deps, 1, d.release(), core);
     else
-        vsapi->createVideoFilter(out, d->name, d->vi, levelsGetframeF<float>, filterFree<LevelsData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+        vsapi->createVideoFilter(out, d->name, d->vi, levelsGetframeF<float>, filterFree<LevelsData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////

--- a/src/core/lutfilters.cpp
+++ b/src/core/lutfilters.cpp
@@ -177,8 +177,7 @@ static void lutCreateHelper(const VSMap *in, VSMap *out, VSFunction *func, std::
     }
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "Lut", &d->vi_out, lutGetframe<T, U>, filterFree<LutData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "Lut", &d->vi_out, lutGetframe<T, U>, filterFree<LutData>, fmParallel, deps, 1, d.release(), core);
 }
 
 static void VS_CC lutCreate(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
@@ -419,8 +418,7 @@ static void lut2CreateHelper(const VSMap *in, VSMap *out, VSFunction *func, std:
     }
 
     VSFilterDependency deps[] = {{ d->node1, rpStrictSpatial }, { d->node2, (d->vi[0]->numFrames <= d->vi[1]->numFrames) ? rpStrictSpatial : rpGeneral }};
-    vsapi->createVideoFilter(out, "Lut2", &d->vi_out, lut2Getframe<T, U, V>, filterFree<Lut2Data>, fmParallel, deps, 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "Lut2", &d->vi_out, lut2Getframe<T, U, V>, filterFree<Lut2Data>, fmParallel, deps, 2, d.release(), core);
 }
 
 static void VS_CC lut2Create(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {

--- a/src/core/mergefilters.cpp
+++ b/src/core/mergefilters.cpp
@@ -136,8 +136,7 @@ static void VS_CC preMultiplyCreate(const VSMap *in, VSMap *out, void *userData,
     }
 
     VSFilterDependency deps[] = {{ d->nodes[0], rpStrictSpatial }, { d->nodes[1], (d->vi->numFrames <= vsapi->getVideoInfo(d->nodes[1])->numFrames) ? rpStrictSpatial : rpGeneral }, { d->nodes[2], (d->vi->numFrames <= vsapi->getVideoInfo(d->nodes[1])->numFrames) ? rpStrictSpatial : rpGeneral }};
-    vsapi->createVideoFilter(out, "PreMultiply", d->vi, preMultiplyGetFrame, filterFree<PreMultiplyData>, fmParallel, deps, d->nodes[2] ? 3 : 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "PreMultiply", d->vi, preMultiplyGetFrame, filterFree<PreMultiplyData>, fmParallel, deps, d->nodes[2] ? 3 : 2, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -285,8 +284,7 @@ static void VS_CC mergeCreate(const VSMap *in, VSMap *out, void *userData, VSCor
         RETERROR("Merge: more weights given than the number of planes to merge");
 
     VSFilterDependency deps[] = {{d->node1, rpStrictSpatial}, {d->node2, (d->vi->numFrames <= vsapi->getVideoInfo(d->node2)->numFrames) ? rpStrictSpatial : rpGeneral}};
-    vsapi->createVideoFilter(out, "Merge", d->vi, mergeGetFrame, filterFree<MergeData>, fmParallel, deps, 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "Merge", d->vi, mergeGetFrame, filterFree<MergeData>, fmParallel, deps, 2, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -457,8 +455,7 @@ static void VS_CC maskedMergeCreate(const VSMap *in, VSMap *out, void *userData,
     d->cpulevel = vs_get_cpulevel(core);
 
     VSFilterDependency deps[] = {{ d->nodes[0], rpStrictSpatial }, { d->nodes[1], (d->vi->numFrames <= vsapi->getVideoInfo(d->nodes[1])->numFrames) ? rpStrictSpatial : rpGeneral }, { d->nodes[2], (d->vi->numFrames <= vsapi->getVideoInfo(d->nodes[2])->numFrames) ? rpStrictSpatial : rpGeneral }, { d->nodes[3], (d->vi->numFrames <= vsapi->getVideoInfo(d->nodes[2])->numFrames) ? rpStrictSpatial : rpGeneral }};
-    vsapi->createVideoFilter(out, "MaskedMerge", d->vi, maskedMergeGetFrame, filterFree<MaskedMergeData>, fmParallel, deps, d->nodes[3] ? 4 : 3, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "MaskedMerge", d->vi, maskedMergeGetFrame, filterFree<MaskedMergeData>, fmParallel, deps, d->nodes[3] ? 4 : 3, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -563,8 +560,7 @@ static void VS_CC makeDiffCreate(const VSMap *in, VSMap *out, void *userData, VS
     d->cpulevel = vs_get_cpulevel(core);
 
     VSFilterDependency deps[] = {{d->node1, rpStrictSpatial}, {d->node2, (d->vi->numFrames <= vsapi->getVideoInfo(d->node2)->numFrames) ? rpStrictSpatial : rpGeneral}};
-    vsapi->createVideoFilter(out, "MakeDiff", d->vi, makeDiffGetFrame, filterFree<MakeDiffData>, fmParallel, deps, 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "MakeDiff", d->vi, makeDiffGetFrame, filterFree<MakeDiffData>, fmParallel, deps, 2, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -665,8 +661,7 @@ static void VS_CC makeFullDiffCreate(const VSMap *in, VSMap *out, void *userData
     d->cpulevel = vs_get_cpulevel(core);
 
     VSFilterDependency deps[] = { {d->node1, rpStrictSpatial}, {d->node2, (d->vi->numFrames <= vsapi->getVideoInfo(d->node2)->numFrames) ? rpStrictSpatial : rpGeneral} };
-    vsapi->createVideoFilter(out, "MakeFullDiff", &d->outvi, makeFullDiffGetFrame, filterFree<MakeFullDiffData>, fmParallel, deps, 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "MakeFullDiff", &d->outvi, makeFullDiffGetFrame, filterFree<MakeFullDiffData>, fmParallel, deps, 2, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -771,8 +766,7 @@ static void VS_CC mergeDiffCreate(const VSMap *in, VSMap *out, void *userData, V
     d->cpulevel = vs_get_cpulevel(core);
 
     VSFilterDependency deps[] = {{d->node1, rpStrictSpatial}, {d->node2, (d->vi->numFrames <= vsapi->getVideoInfo(d->node2)->numFrames) ? rpStrictSpatial : rpGeneral}};
-    vsapi->createVideoFilter(out, "MergeDiff", d->vi, mergeDiffGetFrame, filterFree<MergeDiffData>, fmParallel, deps, 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "MergeDiff", d->vi, mergeDiffGetFrame, filterFree<MergeDiffData>, fmParallel, deps, 2, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -869,8 +863,7 @@ static void VS_CC mergeFullDiffCreate(const VSMap *in, VSMap *out, void *userDat
     d->cpulevel = vs_get_cpulevel(core);
 
     VSFilterDependency deps[] = { {d->node1, rpStrictSpatial}, {d->node2, (d->vi->numFrames <= vsapi->getVideoInfo(d->node2)->numFrames) ? rpStrictSpatial : rpGeneral} };
-    vsapi->createVideoFilter(out, "MergeFullDiff", d->vi, mergeFullDiffGetFrame, filterFree<MergeFullDiffData>, fmParallel, deps, 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "MergeFullDiff", d->vi, mergeFullDiffGetFrame, filterFree<MergeFullDiffData>, fmParallel, deps, 2, d.release(), core);
 }
 
 //////////////////////////////////////////

--- a/src/core/reorderfilters.cpp
+++ b/src/core/reorderfilters.cpp
@@ -261,8 +261,7 @@ static void VS_CC interleaveCreate(const VSMap *in, VSMap *out, void *userData, 
         std::vector<VSFilterDependency> deps;
         for (int i = 0; i < d->numclips; i++)
             deps.push_back({d->nodes[i], (maxNumFrames <= vsapi->getVideoInfo(d->nodes[i])->numFrames) ? rpStrictSpatial : rpGeneral});
-        vsapi->createVideoFilter(out, "Interleave", &d->vi, interleaveGetframe, filterFree<InterleaveData>, fmParallel, deps.data(), d->numclips, d.get(), core);
-        d.release();
+        vsapi->createVideoFilter(out, "Interleave", &d->vi, interleaveGetframe, filterFree<InterleaveData>, fmParallel, deps.data(), d->numclips, d.release(), core);
     }
 }
 
@@ -290,8 +289,7 @@ static void VS_CC reverseCreate(const VSMap *in, VSMap *out, void *userData, VSC
     d->vi = vsapi->getVideoInfo(d->node);
 
     VSFilterDependency deps[] = {{ d->node, rpNoFrameReuse }};
-    vsapi->createVideoFilter(out, "Reverse", d->vi, reverseGetframe, filterFree<ReverseData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "Reverse", d->vi, reverseGetframe, filterFree<ReverseData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -501,8 +499,7 @@ static void VS_CC spliceCreate(const VSMap *in, VSMap *out, void *userData, VSCo
         std::vector<VSFilterDependency> deps;
         for (int i = 0; i < d->numclips; i++)
             deps.push_back({ d->nodes[i], rpNoFrameReuse });
-        vsapi->createVideoFilter(out, "Splice", &vi, spliceGetframe, filterFree<SpliceData>, fmParallel, deps.data(), d->numclips, d.get(), core);
-        d.release();
+        vsapi->createVideoFilter(out, "Splice", &vi, spliceGetframe, filterFree<SpliceData>, fmParallel, deps.data(), d->numclips, d.release(), core);
     }
 }
 

--- a/src/core/simplefilters.cpp
+++ b/src/core/simplefilters.cpp
@@ -653,13 +653,11 @@ static void VS_CC shufflePlanesCreate(const VSMap *in, VSMap *out, void *userDat
 
     if (d->format == cfGray) {
         VSFilterDependency deps1[] = {{ d->nodes[0], rpStrictSpatial }};
-        vsapi->createVideoFilter(out, "ShufflePlanes", &d->vi, shufflePlanesGetframe, filterFree<ShufflePlanesData>, fmParallel, deps1, 1, d.get(), core);
+        vsapi->createVideoFilter(out, "ShufflePlanes", &d->vi, shufflePlanesGetframe, filterFree<ShufflePlanesData>, fmParallel, deps1, 1, d.release(), core);
     } else {
         VSFilterDependency deps3[] = {{ d->nodes[0], (d->vi.numFrames <= vsapi->getVideoInfo(d->nodes[0])->numFrames) ? rpStrictSpatial : rpGeneral }, { d->nodes[1], (d->vi.numFrames <= vsapi->getVideoInfo(d->nodes[1])->numFrames) ? rpStrictSpatial : rpGeneral }, { d->nodes[2], (d->vi.numFrames <= vsapi->getVideoInfo(d->nodes[2])->numFrames) ? rpStrictSpatial : rpGeneral }};
-        vsapi->createVideoFilter(out, "ShufflePlanes", &d->vi, shufflePlanesGetframe, filterFree<ShufflePlanesData>, fmParallel, deps3, 3, d.get(), core);
+        vsapi->createVideoFilter(out, "ShufflePlanes", &d->vi, shufflePlanesGetframe, filterFree<ShufflePlanesData>, fmParallel, deps3, 3, d.release(), core);
     }
-
-    d.release();
 }
 
 //////////////////////////////////////////
@@ -796,8 +794,7 @@ static void VS_CC separateFieldsCreate(const VSMap *in, VSMap *out, void *userDa
         muldivRational(&d->vi.fpsNum, &d->vi.fpsDen, 2, 1);
 
     VSFilterDependency deps[] = {{d->node, rpGeneral}};
-    vsapi->createVideoFilter(out, "SeparateFields", &d->vi, separateFieldsGetframe, filterFree<SeparateFieldsData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "SeparateFields", &d->vi, separateFieldsGetframe, filterFree<SeparateFieldsData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -901,8 +898,7 @@ static void VS_CC doubleWeaveCreate(const VSMap *in, VSMap *out, void *userData,
         RETERROR("DoubleWeave: clip must have constant format and dimensions");
 
     VSFilterDependency deps[] = {{d->node, rpGeneral}};
-    vsapi->createVideoFilter(out, "DoubleWeave", &d->vi, doubleWeaveGetframe, filterFree<DoubleWeaveData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "DoubleWeave", &d->vi, doubleWeaveGetframe, filterFree<DoubleWeaveData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -941,8 +937,7 @@ static void VS_CC flipVerticalCreate(const VSMap *in, VSMap *out, void *userData
     std::unique_ptr<FlipVeritcalData> d(new FlipVeritcalData(vsapi));
     d->node = vsapi->mapGetNode(in, "clip", 0, 0);
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "FlipVertical", vsapi->getVideoInfo(d->node), flipVerticalGetframe, filterFree<FlipVeritcalData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "FlipVertical", vsapi->getVideoInfo(d->node), flipVerticalGetframe, filterFree<FlipVeritcalData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -1039,8 +1034,7 @@ static void VS_CC flipHorizontalCreate(const VSMap *in, VSMap *out, void *userDa
     d->flip = !!userData;
     d->node = vsapi->mapGetNode(in, "clip", 0, 0);
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, d->flip ? "Turn180" : "FlipHorizontal", vsapi->getVideoInfo(d->node), flipHorizontalGetframe, filterFree<FlipHorizontalData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, d->flip ? "Turn180" : "FlipHorizontal", vsapi->getVideoInfo(d->node), flipHorizontalGetframe, filterFree<FlipHorizontalData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -1136,8 +1130,7 @@ static void VS_CC stackCreate(const VSMap *in, VSMap *out, void *userData, VSCor
         std::vector<VSFilterDependency> deps;
         for (int i = 0; i < numclips; i++)
             deps.push_back({d->nodes[i], (d->vi.numFrames <= vsapi->getVideoInfo(d->nodes[i])->numFrames) ? rpStrictSpatial : rpGeneral});
-        vsapi->createVideoFilter(out, d->vertical ? "StackVertical" : "StackHorizontal", &d->vi, stackGetframe, filterFree<StackData>, fmParallel, deps.data(), numclips, d.get(), core);
-        d.release();
+        vsapi->createVideoFilter(out, d->vertical ? "StackVertical" : "StackHorizontal", &d->vi, stackGetframe, filterFree<StackData>, fmParallel, deps.data(), numclips, d.release(), core);
     }
 }
 
@@ -1336,8 +1329,7 @@ static void VS_CC blankClipCreate(const VSMap *in, VSMap *out, void *userData, V
         deliveredInfo.format.numPlanes = 0;
     }
 
-    vsapi->createVideoFilter(out, "BlankClip", &deliveredInfo, blankClipGetframe, blankClipFree, d->keep ? fmUnordered : fmParallel, nullptr, 0, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "BlankClip", &deliveredInfo, blankClipGetframe, blankClipFree, d->keep ? fmUnordered : fmParallel, nullptr, 0, d.release(), core);
 }
 
 
@@ -1406,8 +1398,7 @@ static void VS_CC assumeFPSCreate(const VSMap *in, VSMap *out, void *userData, V
     reduceRational(&d->vi.fpsNum, &d->vi.fpsDen);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "AssumeFPS", &d->vi, assumeFPSGetframe, filterFree<AssumeFPSData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "AssumeFPS", &d->vi, assumeFPSGetframe, filterFree<AssumeFPSData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -1577,8 +1568,7 @@ static void VS_CC frameEvalCreate(const VSMap *in, VSMap *out, void *userData, V
         deps.push_back({d->propsrc[i], rpGeneral}); // FIXME, propsrc could be strict spatial
     for (int i = 0; i < numclipsrc; i++)
         deps.push_back({clipsrc[i], rpGeneral});
-    vsapi->createVideoFilter(out, "FrameEval", &d->vi, (d->propsrc.size() > 0) ? frameEvalGetFrameWithProps : frameEvalGetFrameNoProps, frameEvalFree, (d->propsrc.size() > 0) ? fmParallelRequests : fmUnordered, deps.data(), deps.size(), d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "FrameEval", &d->vi, (d->propsrc.size() > 0) ? frameEvalGetFrameWithProps : frameEvalGetFrameNoProps, frameEvalFree, (d->propsrc.size() > 0) ? fmParallelRequests : fmUnordered, deps.data(), deps.size(), d.release(), core);
 
     for (auto &iter : clipsrc)
         vsapi->freeNode(iter);
@@ -1675,8 +1665,7 @@ static void VS_CC modifyFrameCreate(const VSMap *in, VSMap *out, void *userData,
     std::vector<VSFilterDependency> deps;
     for (int i = 0; i < numnode; i++)
         deps.push_back({d->node[i], rpStrictSpatial});
-    vsapi->createVideoFilter(out, "ModifyFrame", d->vi, modifyFrameGetFrame, modifyFrameFree, fmParallelRequests, deps.data(), numnode, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "ModifyFrame", d->vi, modifyFrameGetFrame, modifyFrameFree, fmParallelRequests, deps.data(), numnode, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -1760,8 +1749,7 @@ static void VS_CC transposeCreate(const VSMap *in, VSMap *out, void *userData, V
     d->cpulevel = vs_get_cpulevel(core);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "Transpose", &d->vi, transposeGetFrame, filterFree<TransposeData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "Transpose", &d->vi, transposeGetFrame, filterFree<TransposeData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -2049,8 +2037,7 @@ static void VS_CC planeStatsCreate(const VSMap *in, VSMap *out, void *userData, 
     d->cpulevel = vs_get_cpulevel(core);
 
     VSFilterDependency deps[] = {{d->node1, rpStrictSpatial}, {d->node2, !d->node2 ? 0 : (vi->numFrames <= vsapi->getVideoInfo(d->node2)->numFrames) ? rpStrictSpatial : rpGeneral}};
-    vsapi->createVideoFilter(out, "PlaneStats", vi, planeStatsGetFrame, filterFree<PlaneStatsData>, fmParallel, deps, d->node2 ? 2 : 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "PlaneStats", vi, planeStatsGetFrame, filterFree<PlaneStatsData>, fmParallel, deps, d->node2 ? 2 : 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -2173,8 +2160,7 @@ static void VS_CC propToClipCreate(const VSMap *in, VSMap *out, void *userData, 
     vsapi->freeFrame(src);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "PropToClip", &d->vi, propToClipGetFrame, filterFree<PropToClipData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "PropToClip", &d->vi, propToClipGetFrame, filterFree<PropToClipData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -2259,8 +2245,7 @@ static void VS_CC setFramePropCreate(const VSMap *in, VSMap *out, void *userData
     }
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "SetFrameProp", vsapi->getVideoInfo(d->node), setFramePropGetFrame, filterFree<SetFramePropData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "SetFrameProp", vsapi->getVideoInfo(d->node), setFramePropGetFrame, filterFree<SetFramePropData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -2361,8 +2346,7 @@ static void VS_CC removeFramePropsCreate(const VSMap *in, VSMap *out, void *user
     d->node = vsapi->mapGetNode(in, "clip", 0, nullptr);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "RemoveFrameProps", vsapi->getVideoInfo(d->node), removeFramePropsGetFrame, filterFree<RemoveFramePropsData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "RemoveFrameProps", vsapi->getVideoInfo(d->node), removeFramePropsGetFrame, filterFree<RemoveFramePropsData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -2403,8 +2387,7 @@ static void VS_CC setFieldBasedCreate(const VSMap *in, VSMap *out, void *userDat
     d->node = vsapi->mapGetNode(in, "clip", 0, nullptr);
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, "SetFieldBased", vsapi->getVideoInfo(d->node), setFieldBasedGetFrame, filterFree<SetFieldBasedData>, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "SetFieldBased", vsapi->getVideoInfo(d->node), setFieldBasedGetFrame, filterFree<SetFieldBasedData>, fmParallel, deps, 1, d.release(), core);
 }
 
 //////////////////////////////////////////
@@ -2440,8 +2423,7 @@ static void VS_CC copyFramePropsCreate(const VSMap *in, VSMap *out, void *userDa
     d->node2 = vsapi->mapGetNode(in, "prop_src", 0, nullptr);
 
     VSFilterDependency deps[] = {{d->node1, rpStrictSpatial}, {d->node2, (vsapi->getVideoInfo(d->node1)->numFrames <= vsapi->getVideoInfo(d->node2)->numFrames) ? rpStrictSpatial : rpGeneral}};
-    vsapi->createVideoFilter(out, "CopyFrameProps", vsapi->getVideoInfo(d->node1), copyFramePropsGetFrame, filterFree<CopyFramePropsData>, fmParallel, deps, 2, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, "CopyFrameProps", vsapi->getVideoInfo(d->node1), copyFramePropsGetFrame, filterFree<CopyFramePropsData>, fmParallel, deps, 2, d.release(), core);
 }
 
 //////////////////////////////////////////

--- a/src/core/textfilter.cpp
+++ b/src/core/textfilter.cpp
@@ -723,8 +723,7 @@ static void VS_CC textCreate(const VSMap *in, VSMap *out, void *userData, VSCore
     }
 
     VSFilterDependency deps[] = {{d->node, rpStrictSpatial}};
-    vsapi->createVideoFilter(out, d->instanceName.c_str(), d->vi, textGetFrame, textFree, fmParallel, deps, 1, d.get(), core);
-    d.release();
+    vsapi->createVideoFilter(out, d->instanceName.c_str(), d->vi, textGetFrame, textFree, fmParallel, deps, 1, d.release(), core);
 }
 
 

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -2013,8 +2013,8 @@ void VSCore::loadPlugin(const std::string &filename, const std::string &forcedNa
         throw VSException(error);
     }
 
-    plugins.insert(std::make_pair(p->getID(), p.get()));
-    p.release();
+    auto id = p->getID();
+    plugins.insert(std::make_pair(id, p.release()));
 }
 
 void VSCore::createFilter3(const VSMap *in, VSMap *out, const std::string &name, vs3::VSFilterInit init, VSFilterGetFrame getFrame, VSFilterFree free, VSFilterMode filterMode, int flags, void *instanceData, int apiMajor) {


### PR DESCRIPTION
```
foo(u_ptr.get());
u_ptr.release();
```
is a roundabout way to transfer ownership. And a more lengthy one.
Ideally `release()` should be marked `[[nodiscard]]`, because it's not meant to be called just for its side effects, but it's missing, as well as in many-many other places in the standard library.