### PR TITLE
Rename PresetFormat to PresetVideoFormat and fix typo

### DIFF
--- a/doc/api/vapoursynth4.h.rst
+++ b/doc/api/vapoursynth4.h.rst
@@ -1587,7 +1587,7 @@ struct VSAPI
       Thread-safe.
 
       *id*
-         The format identifier: one of VSPresetFormat_ or a custom registered
+         The format identifier: one of VSPresetVideoFormat_ or a custom registered
          format.
 
       Returns NULL if the identifier is not known.

--- a/src/cython/vapoursynth.pxd
+++ b/src/cython/vapoursynth.pxd
@@ -61,7 +61,7 @@ cdef extern from "include/VapourSynth4.h" nogil:
         INTEGER "stInteger"
         FLOAT "stFloat"
 
-    cpdef enum PresetFormat "VSPresetFormat":
+    cpdef enum PresetVideoFormat "VSPresetVideoFormat":
         NONE "pfNone"
 
         GRAY8 "pfGray8"


### PR DESCRIPTION
Fixes #948 

Should we consider making an alias to export, maybe with a deprecation warning on access with a proxy, so people transition without major breakage?

Typing PR: https://github.com/vapoursynth/vsrepo/pull/206