### PR TITLE
Add mtDeprecation and annoying warnings for plugins.

### DIFF
--- a/doc/api/vapoursynth4.h.rst
+++ b/doc/api/vapoursynth4.h.rst
@@ -614,6 +614,8 @@ enum VSMessageType
 
    * mtFatal
 
+   * mtDeprecation
+
 
 .. _VSCoreCreationFlags:
 

--- a/include/VapourSynth4.h
+++ b/include/VapourSynth4.h
@@ -271,7 +271,8 @@ typedef enum VSMessageType {
     mtInformation = 1, 
     mtWarning = 2,
     mtCritical = 3,
-    mtFatal = 4 /* also terminates the process, should generally not be used by normal filters */
+    mtFatal = 4, /* also terminates the process, should generally not be used by normal filters */
+    mtDeprecation = 5
 } VSMessageType;
 
 typedef enum VSCoreCreationFlags {

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -1278,6 +1278,7 @@ void VSCore::logMessage(VSMessageType type, const char *msg) {
         case mtDebug:
             vsLog3(vs3::mtDebug, "%s", msg);
             break;
+        case mtDeprecation:
         case mtInformation:
         case mtWarning:
             vsLog3(vs3::mtWarning, "%s", msg);

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -2209,6 +2209,9 @@ bool VSPlugin::configPlugin(const std::string &identifier, const std::string &pl
     if (fnamespace.empty())
         fnamespace = pluginNamespace;
 
+    if (pluginVersion <= 0)
+        core->logMessage(mtDeprecation, "Plugin " + identifier + " has invalid version, and will be unsupported in the future: " + std::to_string(pluginVersion) + "!");
+
     this->pluginVersion = pluginVersion;
     this->fullname = fullname;
 
@@ -2217,6 +2220,9 @@ bool VSPlugin::configPlugin(const std::string &identifier, const std::string &pl
         apiMinor = (apiMajor & 0xFFFF);
         apiMajor >>= 16;
     }
+
+    if (apiMajor <= 3)
+        core->logMessage(mtDeprecation, "Plugin " + identifier + " uses an old API version, and will be unsupported in the future: APIv" + std::to_string(apiMajor) + "!");
 
     readOnlySet = !(flags & pcModifiable);
     hasConfig = true;

--- a/src/core/vsresize.cpp
+++ b/src/core/vsresize.cpp
@@ -564,7 +564,7 @@ class vszimg {
             lookup_enum_str_opt(in, "cpu_type", g_cpu_type_table, &m_params.cpu_type, vsapi);
 
             if (vsapi->mapNumElements(in, "prefer_props") >= 0)
-                vsapi->logMessage(mtWarning, "The deprecated argument prefer_props was passed to a resizer. Ignoring argument.", core);
+                vsapi->logMessage(mtDeprecation, "The deprecated argument prefer_props was passed to a resizer. Ignoring argument.", core);
 
             m_src_left = propGetScalarDef<double>(in, "src_left", NAN, vsapi);
             m_src_top = propGetScalarDef<double>(in, "src_top", NAN, vsapi);

--- a/src/cython/vapoursynth.pxd
+++ b/src/cython/vapoursynth.pxd
@@ -221,6 +221,7 @@ cdef extern from "include/VapourSynth4.h" nogil:
         MESSAGE_TYPE_WARNING "mtWarning"
         MESSAGE_TYPE_CRITICAL "mtCritical"
         MESSAGE_TYPE_FATAL "mtFatal"
+        MESSAGE_TYPE_DEPRECATION "mtDeprecation"
 
     cpdef enum CoreCreationFlags "VSCoreCreationFlags":
         ccfEnableGraphInspection

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -152,6 +152,7 @@ cdef class StandaloneEnvironmentPolicy:
             MessageType.MESSAGE_TYPE_DEBUG: logging.DEBUG,
             MessageType.MESSAGE_TYPE_INFORMATION: logging.INFO,
             MessageType.MESSAGE_TYPE_WARNING: logging.WARN,
+            MessageType.MESSAGE_TYPE_DEPRECATION: logging.WARN,
             MessageType.MESSAGE_TYPE_CRITICAL: logging.ERROR,
             MessageType.MESSAGE_TYPE_FATAL: logging.FATAL
         }


### PR DESCRIPTION
As discussed on discord [here](https://discord.com/channels/856381934052704266/856406641872207903/1115631205166108723) and for code cleanness, and for being able to distinguish the logs I added mtDeprecation (idea from a comment by @YomikoR [here](https://github.com/vapoursynth/vapoursynth/issues/912#issuecomment-1410513304)).

- Resolves #912, then in the future (with APIv3 drop ~next year?) the warning can be swapped with an `API misuse` fatal error.
- Starts warning users of plugins still on APIv3.