### PR TITLE
Update `is8to16orFloatFormat`, add `invalidVideoFormatMessage`

### DIFF
--- a/src/core/averageframesfilter.cpp
+++ b/src/core/averageframesfilter.cpp
@@ -229,7 +229,7 @@ static void VS_CC averageFramesCreate(const VSMap *in, VSMap *out, void *userDat
 
         d->vi = *vsapi->getVideoInfo(d->nodes[0]);
         if (!is8to16orFloatFormat(d->vi.format))
-            throw std::runtime_error("clips must be constant format and of integer 8-16 bit type or 32 bit float, passed " + videoFormatToName(d->vi.format, vsapi));
+            throw std::runtime_error(invalidVideoFormatMessage(d->vi.format, vsapi));
 
         for (size_t i = 1; i < d->nodes.size(); i++) {
             const VSVideoInfo *vi = vsapi->getVideoInfo(d->nodes[i]);

--- a/src/core/boxblurfilter.cpp
+++ b/src/core/boxblurfilter.cpp
@@ -316,7 +316,7 @@ static void VS_CC boxBlurCreate(const VSMap *in, VSMap *out, void *userData, VSC
         const VSVideoInfo *vi = vsapi->getVideoInfo(node);
 
         if (!is8to16orFloatFormat(vi->format))
-            throw std::runtime_error("clip must be constant format and of integer 8-16 bit type or 32 bit float, passed " + videoFormatToName(vi->format, vsapi));
+            throw std::runtime_error(invalidVideoFormatMessage(vi->format, vsapi));
 
         bool process[3];
         getPlanesArg(in, process, vsapi);

--- a/src/core/exprfilter.cpp
+++ b/src/core/exprfilter.cpp
@@ -290,15 +290,8 @@ static void VS_CC exprCreate(const VSMap *in, VSMap *out, void *userData, VSCore
                 throw std::runtime_error("All inputs must have the same number of planes and the same dimensions, subsampling included");
             }
 
-            if (EXPR_F16C_TEST) {
-                if ((vi[i]->format.bitsPerSample > 16 && vi[i]->format.sampleType == stInteger)
-                    || (vi[i]->format.bitsPerSample != 16 && vi[i]->format.bitsPerSample != 32 && vi[i]->format.sampleType == stFloat))
-                    throw std::runtime_error("Input clips must be 8-16 bit integer or 16/32 bit float format");
-            } else {
-                if ((vi[i]->format.bitsPerSample > 16 && vi[i]->format.sampleType == stInteger)
-                    || (vi[i]->format.bitsPerSample != 32 && vi[i]->format.sampleType == stFloat))
-                    throw std::runtime_error("Input clips must be 8-16 bit integer or 32 bit float format");
-            }
+            if (!is8to16orFloatFormat(vi[i]->format, EXPR_F16C_TEST))
+                throw std::runtime_error(invalidVideoFormatMessage(vi[i]->format, vsapi, nullptr, EXPR_F16C_TEST));
         }
 
         d->vi = *vi[0];

--- a/src/core/genericfilters.cpp
+++ b/src/core/genericfilters.cpp
@@ -151,7 +151,7 @@ static const VSFrame *VS_CC singlePixelGetFrame(int n, int activationReason, voi
         const VSVideoFormat *fi = vsapi->getVideoFrameFormat(src);
 
         if (!is8to16orFloatFormat(*fi)) {
-            vsapi->setFilterError((d->name + ": frame must be constant format and of integer 8-16 bit type or 32 bit float, passed "s + videoFormatToName(*fi, vsapi)).c_str(), frameCtx);
+            vsapi->setFilterError(invalidVideoFormatMessage(*fi, vsapi, d->name, false, false, true).c_str(), frameCtx);
             vsapi->freeFrame(src);
             return nullptr;
         }
@@ -201,8 +201,8 @@ static void templateInit(T& d, const char *name, bool allowVariableFormat, const
     d->node = vsapi->mapGetNode(in, "clip", 0, 0);
     d->vi = vsapi->getVideoInfo(d->node);
 
-    if (!is8to16orFloatFormat(d->vi->format, allowVariableFormat))
-        throw std::runtime_error("Clip must be constant format and of integer 8-16 bit type or 32 bit float, passed " + videoFormatToName(d->vi->format, vsapi) + ".");
+    if (!is8to16orFloatFormat(d->vi->format, false, allowVariableFormat))
+        throw std::runtime_error(invalidVideoFormatMessage(d->vi->format, vsapi));
 
     getPlanesArg(in, d->process, vsapi);
 }
@@ -447,7 +447,7 @@ static const VSFrame *VS_CC genericGetframe(int n, int activationReason, void *i
 
         try {
             if (!is8to16orFloatFormat(*fi))
-                throw std::runtime_error("Frame must be constant format and of integer 8-16 bit type or 32 bit float, passed " + videoFormatToName(*fi, vsapi) + ".");
+                throw std::runtime_error(invalidVideoFormatMessage(*fi, vsapi, nullptr, false, false, true));
             if (op == GenericConvolution && d->convolution_type == ConvolutionHorizontal && d->matrix_elements / 2 >= planeWidth(d->vi, d->vi->format.numPlanes - 1))
                 throw std::runtime_error("Width must be bigger than convolution radius.");
             if (op == GenericConvolution && d->convolution_type == ConvolutionVertical && d->matrix_elements / 2 >= planeHeight(d->vi, d->vi->format.numPlanes - 1))
@@ -519,7 +519,7 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
 
     try {
         if (!is8to16orFloatFormat(d->vi->format))
-            throw std::runtime_error("Clip must be constant format and of integer 8-16 bit type or 32 bit float, passed " + videoFormatToName(d->vi->format, vsapi) + ".");
+            throw std::runtime_error(invalidVideoFormatMessage(d->vi->format, vsapi));
 
         if (d->vi->height && d->vi->width)
             if (planeWidth(d->vi, d->vi->format.numPlanes - 1) < 4 || planeHeight(d->vi, d->vi->format.numPlanes - 1) < 4)

--- a/src/core/mergefilters.cpp
+++ b/src/core/mergefilters.cpp
@@ -113,7 +113,7 @@ static void VS_CC preMultiplyCreate(const VSMap *in, VSMap *out, void *userData,
     const VSVideoInfo *alphavi = vsapi->getVideoInfo(d->nodes[1]);
 
     if (!is8to16orFloatFormat(d->vi->format))
-        RETERROR(("PreMultiply: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(d->vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(d->vi->format, vsapi, "PreMultiply").c_str());
 
     if (alphavi->format.colorFamily != cfGray || alphavi->format.sampleType != d->vi->format.sampleType || alphavi->format.bitsPerSample != d->vi->format.bitsPerSample)
         RETERROR("PreMultiply: alpha clip must be grayscale and same sample format and bitdepth as main clip");
@@ -276,7 +276,7 @@ static void VS_CC mergeCreate(const VSMap *in, VSMap *out, void *userData, VSCor
     d->cpulevel = vs_get_cpulevel(core);
 
     if (!is8to16orFloatFormat(d->vi->format))
-        RETERROR(("Merge: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(d->vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(d->vi->format, vsapi, "Merge").c_str());
 
     if (!isConstantVideoFormat(d->vi) || !isSameVideoInfo(d->vi, vsapi->getVideoInfo(d->node2)))
         RETERROR(("Merge: both clips must have the same constant format and dimensions, passed " + videoInfoToString(d->vi, vsapi) + " and " + videoInfoToString(vsapi->getVideoInfo(d->node2), vsapi)).c_str());
@@ -416,7 +416,7 @@ static void VS_CC maskedMergeCreate(const VSMap *in, VSMap *out, void *userData,
         d->first_plane = 1;
 
     if (!is8to16orFloatFormat(d->vi->format))
-        RETERROR(("MaskedMerge: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(d->vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(d->vi->format, vsapi, "MaskedMerge").c_str());
 
     if (!isConstantVideoFormat(d->vi) || !isSameVideoInfo(d->vi, vsapi->getVideoInfo(d->nodes[1])))
         RETERROR(("MaskedMerge: both clips must have the same constant format and dimensions, passed " + videoInfoToString(d->vi, vsapi) + " and " + videoInfoToString(vsapi->getVideoInfo(d->nodes[1]), vsapi)).c_str());
@@ -552,7 +552,7 @@ static void VS_CC makeDiffCreate(const VSMap *in, VSMap *out, void *userData, VS
     d->vi = vsapi->getVideoInfo(d->node1);
 
     if (!is8to16orFloatFormat(d->vi->format))
-        RETERROR(("MakeDiff: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(d->vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(d->vi->format, vsapi, "MakeDiff").c_str());
 
     if (!isConstantVideoFormat(d->vi) || !isSameVideoInfo(d->vi, vsapi->getVideoInfo(d->node2)))
         RETERROR(("MakeDiff: both clips must have the same constant format and dimensions, passed " + videoInfoToString(d->vi, vsapi) + " and " + videoInfoToString(vsapi->getVideoInfo(d->node2), vsapi)).c_str());
@@ -651,7 +651,7 @@ static void VS_CC makeFullDiffCreate(const VSMap *in, VSMap *out, void *userData
     d->vi = vsapi->getVideoInfo(d->node1);
 
     if (!is8to16orFloatFormat(d->vi->format))
-        RETERROR(("MakeFullDiff: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(d->vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(d->vi->format, vsapi, "MakeFullDiff").c_str());
 
     if (!isConstantVideoFormat(d->vi) || !isSameVideoInfo(d->vi, vsapi->getVideoInfo(d->node2)))
         RETERROR(("MakeFullDiff: both clips must have the same constant format and dimensions, passed " + videoInfoToString(d->vi, vsapi) + " and " + videoInfoToString(vsapi->getVideoInfo(d->node2), vsapi)).c_str());
@@ -760,7 +760,7 @@ static void VS_CC mergeDiffCreate(const VSMap *in, VSMap *out, void *userData, V
     d->vi = vsapi->getVideoInfo(d->node1);
 
     if (!is8to16orFloatFormat(d->vi->format))
-        RETERROR(("MergeDiff: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(d->vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(d->vi->format, vsapi, "MergeDiff").c_str());
 
     if (!isConstantVideoFormat(d->vi) || !isSameVideoInfo(d->vi, vsapi->getVideoInfo(d->node2)))
         RETERROR(("MergeDiff: both clips must have the same constant format and dimensions, passed " + videoInfoToString(d->vi, vsapi) + " and " + videoInfoToString(vsapi->getVideoInfo(d->node2), vsapi)).c_str());
@@ -861,7 +861,7 @@ static void VS_CC mergeFullDiffCreate(const VSMap *in, VSMap *out, void *userDat
     d->vi = vsapi->getVideoInfo(d->node1);
 
     if (!is8to16orFloatFormat(d->vi->format))
-        RETERROR(("MergeFullDiff: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(d->vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(d->vi->format, vsapi, "MergeFullDiff").c_str());
 
     if (!isConstantVideoFormat(d->vi) || !mergeFullDiffIsCompatibleVideoInfo(d->vi, vsapi->getVideoInfo(d->node2)))
         RETERROR(("MergeFullDiff: both clips must have the same (bitdepth+1 for second clip) constant format and dimensions, passed " + videoInfoToString(d->vi, vsapi) + " and " + videoInfoToString(vsapi->getVideoInfo(d->node2), vsapi)).c_str());

--- a/src/core/simplefilters.cpp
+++ b/src/core/simplefilters.cpp
@@ -1857,7 +1857,7 @@ static void VS_CC pemVerifierCreate(const VSMap *in, VSMap *out, void *userData,
     const VSVideoInfo *vi = vsapi->getVideoInfo(d->node);
 
     if (!is8to16orFloatFormat(vi->format))
-        RETERROR(("PEMVerifier: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(vi->format, vsapi, "PEMVerifier").c_str());
 
     if (numlower < 0) {
         for (int i = 0; i < vi->format.numPlanes; i++) {
@@ -2033,7 +2033,7 @@ static void VS_CC planeStatsCreate(const VSMap *in, VSMap *out, void *userData, 
     const VSVideoInfo *vi = vsapi->getVideoInfo(d->node1);
 
     if (!is8to16orFloatFormat(vi->format))
-        RETERROR(("PlaneStats: only 8-16 bit integer and 32 bit float input supported, passed " + videoFormatToName(vi->format, vsapi)).c_str());
+        RETERROR(invalidVideoFormatMessage(vi->format, vsapi, "PlaneStats").c_str());
 
     d->plane = vsapi->mapGetIntSaturated(in, "plane", 0, &err);
     if (d->plane < 0 || d->plane >= vi->format.numPlanes)


### PR DESCRIPTION
Put video format error message creation in one function, to remove incosistency, mainly:
- Some functions were using `integer and float` and other `integer or float`, used the latter;
- Some functions were using `8-16 bit` and other `8..16 bit`, used the latter;
- Some fuctions didn't display the input format, made it always append it at the end;