### PR TITLE
Fix BlankClip deliveredInfo structure

### DIFF
--- a/src/core/simplefilters.cpp
+++ b/src/core/simplefilters.cpp
@@ -1335,6 +1335,7 @@ static void VS_CC blankClipCreate(const VSMap *in, VSMap *out, void *userData, V
     tmp2 = vsapi->mapGetInt(in, "varformat", 0, &err);
     if (!err && tmp2) {
         deliveredInfo.format.colorFamily = cfUndefined;
+        deliveredInfo.format.sampleType = stInteger;
         deliveredInfo.format.bitsPerSample = 0;
         deliveredInfo.format.bytesPerSample = 0;
         deliveredInfo.format.subSamplingW = 0;

--- a/src/core/simplefilters.cpp
+++ b/src/core/simplefilters.cpp
@@ -1334,13 +1334,7 @@ static void VS_CC blankClipCreate(const VSMap *in, VSMap *out, void *userData, V
 
     tmp2 = vsapi->mapGetInt(in, "varformat", 0, &err);
     if (!err && tmp2) {
-        deliveredInfo.format.colorFamily = cfUndefined;
-        deliveredInfo.format.sampleType = stInteger;
-        deliveredInfo.format.bitsPerSample = 0;
-        deliveredInfo.format.bytesPerSample = 0;
-        deliveredInfo.format.subSamplingW = 0;
-        deliveredInfo.format.subSamplingH = 0;
-        deliveredInfo.format.numPlanes = 0;
+        deliveredInfo.format = {};
     }
 
     vsapi->createVideoFilter(out, "BlankClip", &deliveredInfo, blankClipGetframe, blankClipFree, d->keep ? fmUnordered : fmParallel, nullptr, 0, d.get(), core);


### PR DESCRIPTION
VSVideoInfo with dynamic format should also have Integer sample type as specified here
https://github.com/vapoursynth/vapoursynth/blob/master/src/core/vscore.cpp#L1318-L1319

Can reproduce with: `core.std.BlankClip(format=vs.GRAYS, varformat=True)`
```
vapoursynth.Error: The VSVideoInfo structure passed by BlankClip is invalid.
```