### PR TITLE
Fix windows actions and vapoursynth-portable deploy

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,6 +40,11 @@ jobs:
         # The target architecture (x86, x64) of the Python interpreter.
         architecture: ${{ matrix.arch }}
 
+    - name: Install cython
+      run: |
+        python -m pip install -U pip
+        pip install -U cython setuptools
+
     - name: Get Python 3.8 Install Path
       run: |
         $py_install_path = (Split-Path -Path (Get-Command python.exe).Path)
@@ -129,7 +134,6 @@ jobs:
         $env:SKIP_COMPRESS="yes"
         $env:SKIP_WAIT="yes"
         & ".\make_portable.bat"
-
 
         if ("${{ matrix.arch }}" -eq "x64") {
           pushd buildp64

--- a/installer/setup.py
+++ b/installer/setup.py
@@ -64,7 +64,6 @@ setup(
 
     packages=[],
     install_requires=["vapoursynth==" + CURRENT_RELEASE],
-    setup_requires=["vapoursynth==" + CURRENT_RELEASE],
     data_files = [
         ("Lib\\site-packages", [
             os.path.join(build_dir, p)


### PR DESCRIPTION
The installation shouldn't depend on pypi, as _it is_ the thing that deploys to pypi.
Weird circular dependency.
Also missing cython for py38.