### PR TITLE
Fix typo VS_TARGET_OS_WINDOWS => VS_TARGET_CPU_X86

### DIFF
--- a/src/avisynth/avisynth_compat.cpp
+++ b/src/avisynth/avisynth_compat.cpp
@@ -1345,7 +1345,7 @@ static void VS_CC avsLoadPlugin(const VSMap *in, VSMap *out, void *userData, VSC
 #endif
     }
 
-#ifdef VS_TARGET_OS_WINDOWS
+#ifdef VS_TARGET_CPU_X86
     if (!vs_isSSEStateOk())
         vsapi->logMessage(mtFatal, ("Bad SSE state detected after loading "s + rawPath).c_str(), core);
 #endif

--- a/src/core/vscore.cpp
+++ b/src/core/vscore.cpp
@@ -955,7 +955,7 @@ PVSFrame VSNode::getFrameInternal(int n, int activationReason, VSFrameContext *f
         std::chrono::nanoseconds duration = std::chrono::high_resolution_clock::now() - startTime;
         processingTime.fetch_add(duration.count(), std::memory_order_relaxed);
     }
-#ifdef VS_TARGET_OS_WINDOWS
+#ifdef VS_TARGET_CPU_X86
     if (!vs_isSSEStateOk())
         core->logFatal("Bad SSE state detected after return from "+ name);
 #endif
@@ -1767,7 +1767,7 @@ VSCore::VSCore(int flags) :
     cpuLevel(INT_MAX),
     memory(new vs::MemoryUse()),
     enableGraphInspection(flags & ccfEnableGraphInspection) {
-#ifdef VS_TARGET_OS_WINDOWS
+#ifdef VS_TARGET_CPU_X86
     if (!vs_isSSEStateOk())
         logFatal("Bad SSE state detected when creating new core");
 #endif
@@ -2163,7 +2163,7 @@ VSPlugin::VSPlugin(const std::string &relFilename, const std::string &forcedName
     else
         pluginInit3(configPlugin3, vs_internal_vsapi3.registerFunction, this);
 
-#ifdef VS_TARGET_OS_WINDOWS
+#ifdef VS_TARGET_CPU_X86
     if (!vs_isSSEStateOk())
         core->logFatal("Bad SSE state detected after loading " + filename);
 #endif

--- a/src/core/vsthreadpool.cpp
+++ b/src/core/vsthreadpool.cpp
@@ -67,7 +67,7 @@ void VSThreadPool::runTasksWrapper(VSThreadPool *owner, std::atomic<bool> &stop)
 }
 
 void VSThreadPool::runTasks(std::atomic<bool> &stop) {
-#ifdef VS_TARGET_OS_WINDOWS
+#ifdef VS_TARGET_CPU_X86
     if (!vs_isSSEStateOk())
         core->logFatal("Bad SSE state detected after creating new thread");
 #endif


### PR DESCRIPTION
`x86utils.h` will only be imported when `VS_TARGET_CPU_X86`, and of course `vs_isSSEStateOk` can only be used when compiling with it.