### PR TITLE
Fix VSMap clear

### DIFF
--- a/src/core/vscore.h
+++ b/src/core/vscore.h
@@ -333,9 +333,10 @@ public:
     }
 
     void clear() {
-        if (data->unique())
+        if (data->unique()) {
             data->data.clear();
-        else
+            data->error = false;
+        } else
             data = new VSMapStorage();
     }
 


### PR DESCRIPTION
Not setting error when clearing the map, will make getErrorMessage assume that the _Error key still exists
Fixes #976