### PR TITLE
Add /usr/local include and library paths in macos build action.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,8 @@ jobs:
       run: |
         echo "CC=$(brew --prefix llvm@15)/bin/clang" >> $GITHUB_ENV
         echo "CXX=$(brew --prefix llvm@15)/bin/clang++" >> $GITHUB_ENV
+        echo "CPATH=/usr/local/include:$CPATH" >> $GITHUB_ENV
+        echo "LIBRARY_PATH=/usr/local/lib:$LIBRARY_PATH" >> $GITHUB_ENV
 
     - name: Print compiler version
       run: ${{ env.CC }} --version


### PR DESCRIPTION
They aren't currently in the default target's setup for homebrew-installed clang.