### PR TITLE
Use BSD & GNU sed-compatible command for autoconf version extraction.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,8 +22,7 @@ jobs:
     - name: Install required packages
       run: |
         brew update
-        brew install automake gnu-sed
-        echo "PATH=$(brew --prefix gnu-sed)/libexec/gnubin:$PATH" >> $GITHUB_ENV
+        brew install automake
 
     - name: Install zimg
       run: |

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,10 @@
-AC_INIT([vapoursynth], m4_esyscmd([sed -e 's/.*\s\(.*\)/\1/' VAPOURSYNTH_VERSION]), [https://github.com/vapoursynth/vapoursynth/issues], [vapoursynth], [http://www.vapoursynth.com/])
+AC_INIT(
+        [vapoursynth],
+        m4_esyscmd_s([sed -e 's/.* \(.*\)/\1/' VAPOURSYNTH_VERSION]),
+        [https://github.com/vapoursynth/vapoursynth/issues],
+        [vapoursynth],
+        [http://www.vapoursynth.com/]
+)
 
 : ${CFLAGS=""}
 : ${CXXFLAGS=""}


### PR DESCRIPTION
The `\s` character class symbol doesn't exist in basic regular expressions as interpreted by BSD `sed`. BSD sed also emits a newline no matter the input or group extraction. Fixes vapoursynth/vapoursynth#987.