### PR TITLE
fix binary data getting truncated in mapToDict

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -815,7 +815,8 @@ cdef object mapToDict(const VSMap *map, bint flatten):
             elif proptype == ptFloat:
                 newval = funcs.mapGetFloat(map, retkey, y, NULL)
             elif proptype == ptData:
-                newval = funcs.mapGetData(map, retkey, y, NULL)
+                data = funcs.mapGetData(map, retkey, y, NULL)
+                newval = data[:funcs.mapGetDataSize(map, retkey, y, NULL)]
                 if funcs.mapGetDataTypeHint(map, retkey, y, NULL) == dtUtf8:
                     newval = newval.decode('utf-8')
             elif proptype == ptVideoNode or proptype == ptAudioNode:


### PR DESCRIPTION
Adjusted mapToDict to account for size like the code from __getitem__ in FrameProps.

Repro for the issue involed
```c
#include <cstdint>
#include <cstdlib>

#include <vapoursynth/VapourSynth4.h>
#include <vapoursynth/VSHelper4.h>

uint8_t data[] = {0x41,0x42,0x41,0x00,0x41,0x41,0x41};

void VS_CC sample_create(const VSMap *in, VSMap *out, void *userData, VSCore *core, const VSAPI *vsapi) {
    vsapi->mapSetData(
        out,
        "testa",
        (const char*)data,
        sizeof(data),
        VSDataTypeHint::dtBinary,
        VSMapAppendMode::maReplace
    );
}



VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI *vspapi) {
    vspapi->configPlugin("com.sources.d2vsourcadse", "testa", "D2V Soursce", VS_MAKE_VERSION(1, 1), VAPOURSYNTH_API_VERSION, 0, plugin);

    vspapi->registerFunction("Source", "rff:int:opt;", "testa:data;", sample_create, 0, plugin);
}
/*
>>> from vstools import *
>>> a = core.testa.Source()
>>> len(a)
3
>>> a
b'ABA'
>>> type(a)
<class 'bytes'>
>>> 
*/
```