### PR TITLE
Fix error when using the graphapi in python

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1970,7 +1970,7 @@ cdef class RawNode(object):
             raise Error("This node is not inspectable")
 
         return tuple(
-            createNode(self.funcs.getNodeDependencies(self.node)[idx].source, self.funcs, self.core)
+            createNode(self.funcs.addNodeRef(self.funcs.getNodeDependencies(self.node)[idx].source), self.funcs, self.core)
             for idx in range(self.funcs.getNumNodeDependencies(self.node))
         )
 


### PR DESCRIPTION
Using _dependencies from the graph api in python seems to cause memory corruption.

Repro
```python
import vapoursynth

core = vapoursynth.core
assert vapoursynth._try_enable_introspection(0)

a = core.std.BlankClip()
b = a.std.FlipHorizontal()

for _ in range(20):
    d0 = b._dependencies[0]

print(b.get_frame(0))
```
```
No frame returned at the end of processing by BlankClip
VapourSynth encountered a fatal error: No frame returned at the end of processing by BlankClip
terminate called without an active exception
zsh: IOT instruction  python lel3.py
```

Every other call to createNode uses a node from mapGetNode which increases the refcount and RawNode has a \_\_dealloc__ which calls freeNode, so do it in _dependencies aswell.

Seems to fix the issue.

(as always im not that familiar with vapoursynth codebase, so double check)