### PR TITLE
fix node reference count not being decremented in setCache

### DIFF
--- a/src/core/simplefilters.cpp
+++ b/src/core/simplefilters.cpp
@@ -2464,6 +2464,7 @@ static void VS_CC setCache(const VSMap *in, VSMap *out, void *userData, VSCore *
     if (err)
         maxhistory = -1;
     vsapi->setCacheOptions(node, fixedsize, maxsize, maxhistory);
+    vsapi->freeNode(node);
 }
 
 //////////////////////////////////////////


### PR DESCRIPTION
repro for memory leak from version before
```python
from vapoursynth import core

while True:
    testnode = core.std.BlankClip(width=1920*4,height=1080*4,length=100)
    core.std.SetVideoCache(testnode,1,maxsize=200)
    frms = []
    for a in range(60):
        frms += [testnode.get_frame(a)]
    print("done")
    #core.std.SetVideoCache(testnode,0)
    del testnode
    del frms
    input()
```