### PR TITLE
Update Core properties in cython module

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -13,7 +13,7 @@ After you completed the second step, you can test it by opening a Python command
 and type this::
 
    from vapoursynth import core
-   print(core.version())
+   print(str(core))
 
 After pressing return at the final line, you should see the version printed along with a
 few other lines describing the options used when instantiating the Core object.

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -232,6 +232,30 @@ Classes and Functions
       Set the upper framebuffer cache size after which memory is aggressively
       freed. The value is in megabytes.
 
+   .. py:attribute:: used_cache_size
+
+      The size of the core's current cache. The value is in bytes.
+
+   .. py:attribute:: core_version
+
+      Returns the core version as VapourSynthVersion tuple.
+
+      .. note::
+
+         If you are writing a library, and are not retrieving this from the proxy,
+         you should consider using *vapoursynth.__version__* instead not to have to
+         unnecessarily fetch the core and lock inside an environment.
+
+   .. py:attribute:: api_version
+
+      Returns the api version as VapourSynthAPIVersion tuple.
+
+      .. note::
+
+         If you are writing a library, and are not retrieving this from the proxy,
+         you should consider using *vapoursynth.__api_version__* instead not to have to
+         unnecessarily fetch the core and lock inside an environment.
+
    .. py:method:: plugins()
 
       Containing all loaded plugins.
@@ -263,18 +287,6 @@ Classes and Functions
    .. py:method:: log_message(message_type, message)
 
       Send a message through VapourSynth’s logging framework.
-
-   .. py:method:: version()
-
-      Returns version information as a string.
-
-   .. py:method:: version_number()
-
-      Returns the core version as a number.
-
-      .. note::
-
-         If you are writing a library, you should use *vapoursynth.__version__* or *vapoursynth.__api_version__* instead.
 
    .. py:method:: rule6()
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -83,8 +83,25 @@ __all__ = [
   'core',
 ]
 
-__version__ = namedtuple("VapourSynthVersion", "release_major release_minor")(VS_CURRENT_RELEASE, 0)
-__api_version__ = namedtuple("VapourSynthAPIVersion", "api_major api_minor")(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR)
+class VapourSynthVersion(typing.NamedTuple):
+    release_major: int
+    release_minor: int
+
+    def __str__(self):
+        if self.release_minor:
+            return f'R{self.release_major}.{self.release_minor}'
+        return f'R{self.release_major}'
+
+class VapourSynthAPIVersion(typing.NamedTuple):
+    api_major: int
+    api_minor: int
+
+    def __str__(self):
+        return f'R{self.api_major}.{self.api_minor}'
+
+
+__version__ = VapourSynthVersion(VS_CURRENT_RELEASE, 0)
+__api_version__ = VapourSynthAPIVersion(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR)
 
 
 @final
@@ -2654,8 +2671,8 @@ cdef class _CoreProxy(object):
         if _env_current() is None:
             return (
                 'Uninitialized Environment:\n'
-                f'\tCore R{__version__[0]}\n'
-                f'\tAPI R{__api_version__[0]}.{__api_version__[1]}\n'
+                f'\tCore {__version__:s}\n'
+                f'\tAPI {__api_version__:s}\n'
                 '\tOptions: Unknown\n'
                 '\tNumber of Threads: Unknown\n'
                 '\tMax Cache Size: Unknown\n'

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2496,6 +2496,12 @@ cdef class Core(object):
             self.funcs.setMaxCacheSize(new_size, self.core)
 
     @property
+    def used_cache_size(self):
+        cdef VSCoreInfo v
+        self.funcs.getCoreInfo(self.core, &v)
+        return v.usedFramebufferSize
+
+    @property
     def flags(self):
         return self.creationFlags
 
@@ -2585,7 +2591,8 @@ cdef class Core(object):
     def __repr__(self):
         return _construct_repr(
             self, core_version=self.core_version, api_version=self.api_version,
-            num_threads=self.num_threads, max_cache_size=self.max_cache_size
+            num_threads=self.num_threads, max_cache_size=self.max_cache_size,
+            used_cache_size=self.used_cache_size
         )
 
     def __str__(self):


### PR DESCRIPTION
This PR mainly updates the last functions that should be properties (getters).

`version` is useless as it was superseded by the new `__str__` implementation that formats `CoreInfo.versionString`.

`version_number` was also ambiguous, so I added `core_version` to remove the ambiguity and `api_version` because that never got exposed other than in `version()` but you had to parse the string.

Those getters now return the version namedtuples we use in the module (`__version__`, `__api_version__`) to be consistent. 
About those namedtuples, I also added a `__str__` to them so they get formatted as everywhere else in the application. (Rxx/Rxx.y)

Then I added `used_cache_size` which is a simple getter to return CoreInfo.usedFramebufferSize (Fixes #1003 )
