### PR TITLE
Remove ability to destroy the Environment and Core while futures referring to it are still running

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -268,6 +268,10 @@ cdef class EnvironmentPolicyAPI:
         if not env.alive:
             return
 
+        if any(type(obj) is _FrameFuture for obj in gc.get_referrers(env)):
+            warnings.warn('Tried to destroy environment while a frame is still being rendered!', RuntimeWarning)
+            return
+
         callbacks = env.on_destroy
         env.on_destroy = None
 


### PR DESCRIPTION
This makes futures in get_frame_async/frames increment the reference count of the Environment so that it _can't_ be automatically destroyed by the garbage collector until they're done, as it should be since they can't be stopped.

Also, `EnvironmentPolicyAPI.destroy_environment` NEVER gets called outside of main-thread in normal operation, it should be plain and simply disallowed. A user could try doing something smart and fuck-up. This just does an extra check. @sekrit-twc also explains it in here: https://github.com/vapoursynth/vapoursynth/issues/853#issuecomment-1081269611
