### PR TITLE
Make error buffer size bigger in cython get_frame

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2045,13 +2045,13 @@ cdef class VideoNode(RawNode):
             raise ValueError('Requesting frame number is beyond the last frame')
 
     def get_frame(self, int n):
-        cdef char errorMsg[512]
+        cdef char errorMsg[4096]
         cdef char *ep = errorMsg
         cdef const VSFrame *f
         self.ensure_valid_frame_number(n)
 
         with nogil:
-            f = self.funcs.getFrame(n, self.node, errorMsg, 500)
+            f = self.funcs.getFrame(n, self.node, errorMsg, 4096)
         if f == NULL:
             if (errorMsg[0]):
                 raise Error(ep.decode('utf-8'))
@@ -2296,13 +2296,13 @@ cdef class AudioNode(RawNode):
             raise ValueError('Requesting frame number is beyond the last frame')
 
     def get_frame(self, int n):
-        cdef char errorMsg[512]
+        cdef char errorMsg[4096]
         cdef char *ep = errorMsg
         cdef const VSFrame *f
         self.ensure_valid_frame_number(n)
 
         with nogil:
-            f = self.funcs.getFrame(n, self.node, errorMsg, 500)
+            f = self.funcs.getFrame(n, self.node, errorMsg, 4096)
         if f == NULL:
             if (errorMsg[0]):
                 raise Error(ep.decode('utf-8'))


### PR DESCRIPTION
I had already talked about this feature to @cid-chan a couple months ago.

If you have a better way to implement this I'd be happy to implement it but for now I just added a variable that's in EnvironmentData so it's pretty inaccessible to normal users.

Main application is previewers really, since they use get_frame to display frames and when there's errors in frame evals and such they always get truncated.

I also bumped the default characters from 512 to 1024 since pretty much everything got truncated; let me know if I should revert this.