### PR TITLE
PoC #913 Solution: Request Debug callbacks API

### DIFF
--- a/include/VapourSynth4.h
+++ b/include/VapourSynth4.h
@@ -73,6 +73,7 @@ typedef struct VSPluginFunction VSPluginFunction;
 typedef struct VSFunction VSFunction;
 typedef struct VSMap VSMap;
 typedef struct VSLogHandle VSLogHandle;
+typedef struct VSRequestDebugHandle VSRequestDebugHandle;
 typedef struct VSFrameContext VSFrameContext;
 typedef struct VSPLUGINAPI VSPLUGINAPI;
 typedef struct VSAPI VSAPI;
@@ -316,6 +317,8 @@ typedef void (VS_CC *VSFilterFree)(void *instanceData, VSCore *core, const VSAPI
 typedef void (VS_CC *VSFrameDoneCallback)(void *userData, const VSFrame *f, int n, VSNode *node, const char *errorMsg);
 typedef void (VS_CC *VSLogHandler)(int msgType, const char *msg, void *userData);
 typedef void (VS_CC *VSLogHandlerFree)(void *userData);
+typedef void (VS_CC *VSRequestDebugHandler)(int n, int reqOrder, int cacheHit, void *userData);
+typedef void (VS_CC *VSRequestDebugHandlerFree)(void *userData);
 
 typedef struct VSPLUGINAPI {
     int (VS_CC *getAPIVersion)(void) VS_NOEXCEPT; /* returns VAPOURSYNTH_API_VERSION of the library */
@@ -481,6 +484,10 @@ struct VSAPI {
     void (VS_CC *setCoreNodeTiming)(VSCore *core, int enable) VS_NOEXCEPT; /* non-zero enables filter timing, note that disabling simply stops the counters from incrementing */
     int64_t (VS_CC *getNodeProcessingTime)(VSNode *node, int reset) VS_NOEXCEPT; /* time spent processing frames in nanoseconds, reset sets the counter to 0 again */
     int64_t (VS_CC *getFreedNodeProcessingTime)(VSCore *core, int reset) VS_NOEXCEPT; /* time spent processing frames in nanoseconds in all destroyed nodes, reset sets the counter to 0 again */
+
+    /* Node debug functions */
+    VSRequestDebugHandle *(VS_CC *addNodeRequestDebugHandler)(VSRequestDebugHandler handler, VSRequestDebugHandlerFree free, void *userData, VSNode *node) VS_NOEXCEPT; /* free and userData can be NULL, returns a handle that can be passed to removeNodeRequestDebugHandler */
+    int (VS_CC *removeNodeRequestDebugHandler)(VSRequestDebugHandle *handle, VSNode *node) VS_NOEXCEPT; /* returns non-zero if successfully removed */
 
 #if defined(VS_GRAPH_API)
     /* !!! Experimental/expensive graph information, these function require both the major and minor version to match exactly when using them !!!

--- a/src/core/vsapi.cpp
+++ b/src/core/vsapi.cpp
@@ -1050,6 +1050,16 @@ static int64_t VS_CC getFreedNodeProcessingTime(VSCore *core, int reset) VS_NOEX
     return core->getFreedNodeProcessingTime(!!reset);
 }
 
+static VSRequestDebugHandle *VS_CC addNodeRequestDebugHandler(VSRequestDebugHandler handler, VSRequestDebugHandlerFree free, void *userData, VSNode *node) VS_NOEXCEPT {
+    assert(handler && node);
+    return node->addRequestDebugHandler(handler, free, userData);
+}
+
+static int VS_CC removeNodeRequestDebugHandler(VSRequestDebugHandle *handle, VSNode *node) VS_NOEXCEPT {
+    assert(handle && node);
+    return node->removeRequestDebugHandler(reinterpret_cast<VSRequestDebugHandle *>(handle));
+}
+
 static int VS_CC getNumNodeDependencies(VSNode *node) VS_NOEXCEPT {
     assert(node);
     return static_cast<int>(node->getNumDependencies());
@@ -1224,6 +1234,9 @@ const VSAPI vs_internal_vsapi = {
     &setCoreNodeTiming,
     &getNodeProcessingTime,
     &getFreedNodeProcessingTime,
+
+    &addNodeRequestDebugHandler,
+    &removeNodeRequestDebugHandler,
 
     &getNodeCreationFunctionName,
     &getNodeCreationFunctionArguments

--- a/src/core/vsthreadpool.cpp
+++ b/src/core/vsthreadpool.cpp
@@ -96,6 +96,8 @@ void VSThreadPool::runTasks(std::atomic<bool> &stop) {
 #ifdef VS_DEBUG_FRAME_REQUESTS
                     core->logMessage(mtInformation, "Found requested frame: " + std::to_string(frameContext->key.second) + " filter: " + node->getName() + " (" + std::to_string(reinterpret_cast<uintptr_t>(node)) + ") in cache, skipping processing");
 #endif
+                    node->notifyRequestDebugHandlers(frameContext, true);
+
                     bool needsSort = false;
 
                     for (size_t i = 0; i < frameContext->notifyCtxList.size(); i++) {
@@ -177,6 +179,8 @@ void VSThreadPool::runTasks(std::atomic<bool> &stop) {
 
             PVSFrame f = node->getFrameInternal(frameContext->key.second, ar, frameContext);
             ranTask = true;
+
+            node->notifyRequestDebugHandlers(frameContext, false);
 
             bool frameProcessingDone = f || frameContext->hasError();
             if (frameContext->hasError() && f)

--- a/src/cython/vapoursynth.pxd
+++ b/src/cython/vapoursynth.pxd
@@ -45,6 +45,8 @@ cdef extern from "include/VapourSynth4.h" nogil:
         pass
     ctypedef struct VSLogHandle:
         pass
+    ctypedef struct VSRequestDebugHandle:
+        pass
     ctypedef struct VSFrameContext:
         pass
 
@@ -253,6 +255,9 @@ cdef extern from "include/VapourSynth4.h" nogil:
     ctypedef void (__stdcall *VSLogHandler)(int msgType, const char *msg, void *userData)
     ctypedef void (__stdcall *VSLogHandlerFree)(void *userData)
 
+    ctypedef void (__stdcall *VSRequestDebugHandler)(int n, int reqOrder, int cacheHit, void *userData)
+    ctypedef void (__stdcall *VSRequestDebugHandlerFree)(void *userData)
+
     ctypedef struct VSPLUGINAPI:
         int getAPIVersion() nogil
         bint configPlugin(const char *identifier, const char *pluginNamespace, const char *name, int pluginVersion, int apiVersion, int flags, VSPlugin *plugin) nogil
@@ -408,6 +413,10 @@ cdef extern from "include/VapourSynth4.h" nogil:
         void setCoreNodeTiming(VSCore *core, int enable) nogil
         int64_t getNodeProcessingTime(VSNode *node, int reset) nogil
         int64_t getFreedNodeProcessingTime(VSCore *core, int reset) nogil
+
+        # Node debug functions
+        VSRequestDebugHandle *addNodeRequestDebugHandler(VSRequestDebugHandler handler, VSRequestDebugHandlerFree free, void *userData, VSNode *node) nogil
+        bint removeNodeRequestDebugHandler(VSRequestDebugHandle *handle, VSNode *node) nogil
 
         # Unstable API, has no set place.
         const char *getNodeCreationFunctionName(VSNode *node, int level) nogil


### PR DESCRIPTION
Fix #913

This PR adds an API for VSNode which is tied to VSFrameContext that adds the possibility to register (and unregister) handlers that run when a frame is getting fetched and is mainly useful to know if it's getting fetched multiple times and isn't hitting cache.

This is a draft not only because it's a PoC, but because I also have some questions about this line in particular:

1) Is this the correct place to put the notifying call?
2) Should we pass the activationReason? If so, what do we pass when it's from cache?


https://github.com/Setsugennoao/vapoursynth/blob/80f9d1f85a4b48f28c75b19c6f00182aa37d184b/src/core/vsthreadpool.cpp#L183

```diff
/////////////////////////////////////////////////////////////////////////////////////////////
// Do the actual processing

lock.unlock();

PVSFrame f = node->getFrameInternal(frameContext->key.second, ar, frameContext);
ranTask = true;

+node->notifyRequestDebugHandlers(frameContext, false);

bool frameProcessingDone = f || frameContext->hasError();
if (frameContext->hasError() && f)
    core->logFatal("A frame was returned by " + node->name + " but an error was also set, this is not allowed");
```

Example usage:
(Prints after get_frame are [n, reqOrder, cacheHit])
![image](https://github.com/vapoursynth/vapoursynth/assets/41454651/d5dd7661-77d7-4cb0-ad90-a5e30086d340)

