### PR TITLE
Add value_zimg to ColorRange enum

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -104,6 +104,17 @@ __version__ = VapourSynthVersion(VS_CURRENT_RELEASE, 0)
 __api_version__ = VapourSynthAPIVersion(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR)
 
 
+class ColorRange(enum.Flag):
+    RANGE_FULL = VSC_RANGE_FULL
+    RANGE_LIMITED = VSC_RANGE_LIMITED
+
+    @property
+    def value_zimg(self):
+        return ~self.value + 2
+
+RANGE_FULL = ColorRange.RANGE_FULL
+RANGE_LIMITED = ColorRange.RANGE_LIMITED
+
 @final
 cdef class EnvironmentData(object):
     cdef bint alive

--- a/src/cython/vsconstants.pxd
+++ b/src/cython/vsconstants.pxd
@@ -19,9 +19,9 @@
 #
 
 cdef extern from "include/VSConstants4.h" nogil:
-    cpdef enum ColorRange "VSColorRange":
-        RANGE_FULL "VSC_RANGE_FULL"
-        RANGE_LIMITED "VSC_RANGE_LIMITED"
+    cpdef enum:
+        VSC_RANGE_FULL "VSC_RANGE_FULL"
+        VSC_RANGE_LIMITED "VSC_RANGE_LIMITED"
 
     cpdef enum ChromaLocation "VSChromaLocation":
         CHROMA_LEFT "VSC_CHROMA_LEFT"


### PR DESCRIPTION
Fix #857

I think this is the only solution not to break 99% of the scripts out there.

Previous
```py
# limited => full
# had to swap the values as they are between VSColorRange and the resize API
clip.resize.Bicubic(range_in=vs.RANGE_FULL, range=vs.RANGE_LIMITED)
```

With this PR
```py
# limited => full
# Append .value_zimg to get the correct value
clip.resize.Bicubic(range_in=vs.RANGE_LIMITED.value_zimg, range=vs.RANGE_FULL.value_zimg)
```

May not be the prettiest solution but I think it's way better than using the wrong enum value to get the correct int value.

I choose the name `value_zimg` because `value` is a built-in, so making a difference between the value (vs) and value_zimg (zimg, resize) makes sense to me 🤔