### PR TITLE
Add prop_src to ShufflePlanes/SplitPlanes

### DIFF
--- a/doc/functions/video/shuffleplanes.rst
+++ b/doc/functions/video/shuffleplanes.rst
@@ -1,7 +1,7 @@
 ShufflePlanes
 =============
 
-.. function::   ShufflePlanes(vnode[] clips, int[] planes, int colorfamily)
+.. function::   ShufflePlanes(vnode[] clips, int[] planes, int colorfamily[, vnode[] prop_src=clips[0]])
    :module: std
 
    ShufflePlanes can extract and combine planes from different clips in the most
@@ -25,6 +25,10 @@ ShufflePlanes
    Properties such as subsampling are determined from the relative size of the
    given planes to combine.
 
+   The argument *prop_src* is used to specify the output props of the clip.
+   By default it will grab the first node of *clips*. You can pass an empty array
+   to remove the props entirely from the output clip.
+
    ShufflePlanes accepts clips with variable format and dimensions only when
    extracting a single plane.
 
@@ -46,3 +50,13 @@ ShufflePlanes
    Cast a YUV clip to RGB::
 
       ShufflePlanes(clips=[YUVclip], planes=[0, 1, 2], colorfamily=vs.RGB)
+
+   Note that in any example that mixes color families, if the clip has correct colorspace
+   information specified in its frame props, when you try to pass it to functions that
+   access and check frame props, it will error;
+   For example any function in the *resize* plugin will throw an error saying that an RGB clip
+   can't have GRAY/YUV colorspace information and vice-versa.
+
+   To avoid this you can set prop_src to an empty array to remove said props::
+
+      ShufflePlanes(clips=[YUVclip], planes=[0, 1, 2], colorfamily=vs.RGB, prop_src=[])

--- a/doc/functions/video/splitplanes.rst
+++ b/doc/functions/video/splitplanes.rst
@@ -1,8 +1,10 @@
 SplitPlanes
 ===========
 
-.. function::   SplitPlanes(vnode clip)
+.. function::   SplitPlanes(vnode clip[, vnode[] prop_src=clip])
    :module: std
 
    SplitPlanes returns each plane of the input as
    separate clips.
+
+   Refer to :doc:`ShufflePlanes <shuffleplanes>` for *prop_src* usage.

--- a/test/test.py
+++ b/test/test.py
@@ -266,6 +266,29 @@ class CoreTestSequence(unittest.TestCase):
         with self.assertRaises(vs.Error):
             self.core.std.ShufflePlanes([clip1, clip2, clip1], planes=[0, 1, 2], colorfamily=vs.RGB)               
 
+    def test_suffleplanes_arg7(self):
+        clip = self.core.std.BlankClip(format=vs.YUV420P8)
+        clip1 = clip.std.SetFrameProps(Test=1)
+        clip2 = self.core.std.ShufflePlanes(clip, planes=[0, 1, 2], colorfamily=vs.YUV, prop_src=clip1)
+        self.assertEqual(clip2.get_frame(0).props.Test, 1)
+
+    def test_suffleplanes_arg8(self):
+        clip = self.core.std.BlankClip(format=vs.GRAY8)
+        clip1 = clip.std.SetFrameProps(Test=1)
+        clip2 = self.core.std.ShufflePlanes(clip, planes=0, colorfamily=vs.GRAY, prop_src=clip1)
+        self.assertEqual(clip2.get_frame(0).props.Test, 1)
+
+    def test_suffleplanes_arg9(self):
+        clip = self.core.std.BlankClip(format=vs.YUV420P8).std.SetFrameProps(RemoveMe=1)
+        clip1 = self.core.std.ShufflePlanes(clip, planes=[0, 1, 2], colorfamily=vs.YUV, prop_src=[])
+        with self.assertRaises(KeyError):
+            clip1.get_frame(0).props['RemoveMe']
+
+    def test_suffleplanes_arg10(self):
+        clip = self.core.std.BlankClip(format=vs.YUV420P8)
+        with self.assertRaises(vs.Error):
+            self.core.std.ShufflePlanes(clip, planes=[0, 1, 2], colorfamily=vs.YUV, prop_src=[clip, clip])
+
 #clamp tests
     def test_levels_clamp(self):
         for i in range(1024):

--- a/test/test.py
+++ b/test/test.py
@@ -289,6 +289,29 @@ class CoreTestSequence(unittest.TestCase):
         with self.assertRaises(vs.Error):
             self.core.std.ShufflePlanes(clip, planes=[0, 1, 2], colorfamily=vs.YUV, prop_src=[clip, clip])
 
+    def test_splitplanes_arg1(self):
+        clip = self.core.std.BlankClip(format=vs.YUV420P8)
+
+        planes = self.core.std.SplitPlanes(clip, prop_src=[clip.std.SetFrameProps(Plane=i) for i in range(3)])
+
+        for i, plane in enumerate(planes):
+            self.assertEqual(plane.get_frame(0).props.Plane, i)
+
+    def test_splitplanes_arg2(self):
+        clip = self.core.std.BlankClip(format=vs.YUV420P8)
+
+        with self.assertRaises(vs.Error):
+            self.core.std.SplitPlanes(clip, prop_src=[clip, clip, clip, clip])
+
+    def test_splitplanes_arg3(self):
+        clip = self.core.std.BlankClip(format=vs.YUV420P8).std.SetFrameProps(RemoveMe=1)
+
+        planes = self.core.std.SplitPlanes(clip, prop_src=[])
+
+        for plane in planes:
+            with self.assertRaises(KeyError):
+                plane.get_frame(0).props['RemoveMe']
+
 #clamp tests
     def test_levels_clamp(self):
         for i in range(1024):


### PR DESCRIPTION
Fix #844

Implements https://github.com/vapoursynth/vapoursynth/issues/844#issuecomment-1685313650

In this PR `ShufflePlanes` and `SplitPlanes` take a `prop_src` parameter that can be an empty array or the number of planes they output (aka ShufflePlanes only takes one and SplitPlanes one or three).