### PR TITLE
Add `approximate_gamma` parameter to vsresize

### DIFF
--- a/doc/functions/video/resize.rst
+++ b/doc/functions/video/resize.rst
@@ -1,7 +1,7 @@
 Resize
 ======
 
-.. function::   Bilinear(vnode clip[, int width, int height, int format, enum matrix, enum transfer, enum primaries, enum range, enum chromaloc, enum matrix_in, enum transfer_in, enum primaries_in, enum range_in, enum chromaloc_in, float filter_param_a, float filter_param_b, string resample_filter_uv, float filter_param_a_uv, float filter_param_b_uv, string dither_type="none", string cpu_type, float src_left, float src_top, float src_width, float src_height, float nominal_luminance])
+.. function::   Bilinear(vnode clip[, int width, int height, int format, enum matrix, enum transfer, enum primaries, enum range, enum chromaloc, enum matrix_in, enum transfer_in, enum primaries_in, enum range_in, enum chromaloc_in, float filter_param_a, float filter_param_b, string resample_filter_uv, float filter_param_a_uv, float filter_param_b_uv, string dither_type="none", string cpu_type, float src_left, float src_top, float src_width, float src_height, float nominal_luminance, bint approximate_gamma=True])
                 Bicubic(vnode clip[, ...])
                 Point(vnode clip[, ...])
                 Lanczos(vnode clip[, ...])
@@ -130,6 +130,10 @@ Resize
    *nominal_luminance*:
    
       Determines the physical brightness of the value 1.0. The unit is in cd/m^2.
+      
+   *approximate_gamma*:
+
+      Use LUT to evaluate transfer functions. Defaults to True.
       
    To convert to YV12::
 

--- a/src/core/vsresize.cpp
+++ b/src/core/vsresize.cpp
@@ -554,7 +554,7 @@ class vszimg {
             lookup_enum(in, "chromaloc_in", g_chromaloc_table, &m_frame_params_in.chromaloc, vsapi);
 
             m_params.cpu_type = ZIMG_CPU_AUTO_64B;
-            m_params.allow_approximate_gamma = 1;
+            m_params.allow_approximate_gamma = propGetScalarDef<int>(in, "approximate_gamma", 1, vsapi);
             m_params.resample_filter = u.filter;
             m_params.filter_param_a = propGetScalarDef<double>(in, "filter_param_a", m_params.filter_param_a, vsapi);
             m_params.filter_param_b = propGetScalarDef<double>(in, "filter_param_b", m_params.filter_param_b, vsapi);
@@ -922,7 +922,8 @@ void resizeInitialize(VSPlugin *plugin, const VSPLUGINAPI *vspapi) {
   FLOAT_OPT(src_top) \
   FLOAT_OPT(src_width) \
   FLOAT_OPT(src_height) \
-  FLOAT_OPT(nominal_luminance)
+  FLOAT_OPT(nominal_luminance) \
+  INT_OPT(approximate_gamma)
 
     static const char RESAMPLE_ARGS[] =
         "clip:vnode;"


### PR DESCRIPTION
Allow users to control it while maintaining the current behavior (bb91ba4) unchanged.
This results in a significant difference in the transfer related to HLG due to the faster implementation in zimg, which is actually another function. See:
https://github.com/sekrit-twc/zimg/blob/71431815950664f1e11b9ee4e5d4ba23d6d997f1/src/zimg/colorspace/gamma.cpp#L287-L291

For most other cases it should be okay.