### PR TITLE
Add more detail to core.__getattr__ error message

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2561,7 +2561,7 @@ cdef class Core(object):
         if plugin:
             return createPlugin(plugin, self.funcs, self)
         else:
-            raise AttributeError('No attribute with the name ' + name + ' exists. Did you mistype a plugin namespace?')
+            raise AttributeError('No attribute with the name ' + name + ' exists. Did you mistype a plugin namespace or forget to install a plugin?')
 
     def plugins(self):
         cdef VSPlugin *plugin = self.funcs.getNextPlugin(NULL, self.core)


### PR DESCRIPTION
Clarify that an attribute not existing may be due to plugins not being installed, since this error message often confuses new users. The wording "forget to install a plugin" (as opposed to, say, "are you missing a plugin") was chosen to make the error message imply that this can be fixed by installing the plugin.