### PR TITLE
Fix various typos

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -71,7 +71,7 @@ Filters can be chained with a dot::
 
    clip = clip.std.Trim(first=100, last=2000).std.FlipVertical()
 
-Which is quivalent to::
+Which is equivalent to::
 
    clip = core.std.FlipVertical(core.std.Trim(clip, first=100, last=2000))
    

--- a/src/avfs/include/ptblob.h
+++ b/src/avfs/include/ptblob.h
@@ -21,7 +21,7 @@
 // ptr,size argument pairs.
 //
 // The interfaces defined here are expected to be used as privimitives
-// in other interfaces, and so must indefinately maintain ABI
+// in other interfaces, and so must indefinitely maintain ABI
 // compatibility. Source compatibility may change over time.
 //---------------------------------------------------------------------------
 #ifndef PTBLOB_H

--- a/src/avfs/include/ptpin.h
+++ b/src/avfs/include/ptpin.h
@@ -19,7 +19,7 @@
 // ptsync.h provides a flexible implementation.
 //
 // The interfaces defined here are expected to be used as primitives
-// in other interfaces, and so must indefinately maintain ABI
+// in other interfaces, and so must indefinitely maintain ABI
 // compatibility. Source compatibility may change over time.
 //---------------------------------------------------------------------------
 #ifndef PTPIN_H

--- a/src/avisynth/avisynth.h
+++ b/src/avisynth/avisynth.h
@@ -845,8 +845,8 @@ enum CachePolicyHint {
 
   CACHE_AUDIO=50, // Explicitly cache audio, X byte cache.
   CACHE_AUDIO_NOTHING=51, // Explicitly do not cache audio.
-  CACHE_AUDIO_NONE=52, // Audio cache off (auto mode), X byte intial cache.
-  CACHE_AUDIO_AUTO=53, // Audio cache on (auto mode), X byte intial cache.
+  CACHE_AUDIO_NONE=52, // Audio cache off (auto mode), X byte initial cache.
+  CACHE_AUDIO_AUTO=53, // Audio cache on (auto mode), X byte initial cache.
 
   CACHE_GET_AUDIO_POLICY=70, // Get the current audio policy.
   CACHE_GET_AUDIO_SIZE=71, // Get the current audio cache size.

--- a/src/avisynth/interface.cpp
+++ b/src/avisynth/interface.cpp
@@ -229,7 +229,7 @@ int VideoInfo::BitsPerPixel() const {
 // Remark:
 // - total bitsize for interleaved/packed types, e.g. RGB48 = 48 = 3x16
 // - byte size corrected with U-V subsampling factor for Planar YUV/YUVA
-// - external softwares may use it for calculating buffer size
+// - external software may use it for calculating buffer size
 // - use BitsPerComponent instead for returning the pixel component format 8/10/12/14/16/32 bits
     switch (pixel_type) {
       case CS_BGR24:
@@ -1053,15 +1053,15 @@ extern __declspec(dllexport) const AVS_Linkage* const AVS_linkage = &avs_linkage
 
 #include "avisynth.h"
 
-/* New 2.6 requirment!!! */
+/* New 2.6 requirement!!! */
 // Declare and initialise server pointers static storage.
 const AVS_Linkage *AVS_linkage = 0;
 
-/* New 2.6 requirment!!! */
+/* New 2.6 requirement!!! */
 // DLL entry point called from LoadPlugin() to setup a user plugin.
 extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(IScriptEnvironment* env, const AVS_Linkage* const vectors) {
 
-  /* New 2.6 requirment!!! */
+  /* New 2.6 requirement!!! */
   // Save the server pointers.
   AVS_linkage = vectors;
 

--- a/src/core/expr/jitasm.h
+++ b/src/core/expr/jitasm.h
@@ -6715,7 +6715,7 @@ namespace compiler
 				bucket[p].clear();
 			}
 
-			// Explicity compute immediate dominator
+			// Explicitly compute immediate dominator
 			for (size_t w = 1; w < num_of_nodes; ++w) {
 				if (dom[w] != sdom_[w])
 					dom[w] = dom[dom[w]];
@@ -6952,7 +6952,7 @@ namespace compiler
 				}
 			}
 
-			// Make depth first orderd list
+			// Make depth first ordered list
 			MakeDepthFirstBlocks(*get_block(0));
 
 			// Numbering depth


### PR DESCRIPTION
Found via `codespell -q 3 -L indx,nin,technic`