### PR TITLE
fix double free on error in averageframes

### DIFF
--- a/src/core/averageframesfilter.cpp
+++ b/src/core/averageframesfilter.cpp
@@ -277,8 +277,6 @@ static void VS_CC averageFramesCreate(const VSMap *in, VSMap *out, void *userDat
         getPlanesArg(in, d->process, vsapi);
 
     } catch (const std::runtime_error &e) {
-        for (auto iter : d->nodes)
-            vsapi->freeNode(iter);
         vsapi->mapSetError(out, ("AverageFrames: "s + e.what()).c_str());
         return;
     }


### PR DESCRIPTION
repro
```python
import vapoursynth as vs
core = vs.core

var_format = core.std.BlankClip(format=vs.YUV420P16, varformat=True)
try:
    around = var_format.std.AverageFrames([1, 1, 1,1,1])
except:
    pass
```
```
==2745282==ERROR: AddressSanitizer: heap-use-after-free on address 0x51600009ae80 at pc 0x7cede147a0f2 bp 0x7ffe5d5733b0 sp 0x7ffe5d5733a0
WRITE of size 8 at 0x51600009ae80 thread T0
    #0 0x7cede147a0f1 in freeNode(VSNode*) (/usr/lib/libvapoursynth.so+0x27a0f1) (BuildId: d7eb8c0010fff74fa556a80ca61448d71d84a48e)
    #1 0x7cede16b7aa6 in __pyx_tp_dealloc_11vapoursynth_RawNode (/usr/lib/python3.13/site-packages/vapoursynth.so+0xb7aa6) (BuildId: d95c39d64c7145fbd995d456bb238b56b98e523f)
    #2 0x7cede555ba05  (/usr/lib/libpython3.13.so.1.0+0x15ba05) (BuildId: 67d4cf633cf3974def8ac0772f63a2be029cc910)
    #3 0x7cede567f7fc  (/usr/lib/libpython3.13.so.1.0+0x27f7fc) (BuildId: 67d4cf633cf3974def8ac0772f63a2be029cc910)
    #4 0x7cede554db53  (/usr/lib/libpython3.13.so.1.0+0x14db53) (BuildId: 67d4cf633cf3974def8ac0772f63a2be029cc910)
    #5 0x7cede567f10e  (/usr/lib/libpython3.13.so.1.0+0x27f10e) (BuildId: 67d4cf633cf3974def8ac0772f63a2be029cc910)
    #6 0x7cede565f7c4  (/usr/lib/libpython3.13.so.1.0+0x25f7c4) (BuildId: 67d4cf633cf3974def8ac0772f63a2be029cc910)
    #7 0x7cede5675594 in Py_RunMain (/usr/lib/libpython3.13.so.1.0+0x275594) (BuildId: 67d4cf633cf3974def8ac0772f63a2be029cc910)
    #8 0x7cede563057b in Py_BytesMain (/usr/lib/libpython3.13.so.1.0+0x23057b) (BuildId: 67d4cf633cf3974def8ac0772f63a2be029cc910)
    #9 0x7cede5234e07  (/usr/lib/libc.so.6+0x25e07) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #10 0x7cede5234ecb in __libc_start_main (/usr/lib/libc.so.6+0x25ecb) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #11 0x5c5c599e8044 in _start (/usr/bin/python3.13+0x1044) (BuildId: e0631243880b00dad808c97806a09143fbcba2d8)
```
[here](https://github.com/vapoursynth/vapoursynth/blob/7be5ef4d755eb8a2c8c0d0017cb38b0eacab8084/src/core/filtershared.h#L124)
[and here](https://github.com/vapoursynth/vapoursynth/blob/7be5ef4d755eb8a2c8c0d0017cb38b0eacab8084/src/core/averageframesfilter.cpp#L281)