### PR TITLE
Fixes ValueError when a parameter is a python identifier

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -46,6 +46,7 @@ import functools
 import typing
 import traceback
 import warnings
+import keyword
 from threading import local as ThreadLocal, Lock, RLock
 from types import MappingProxyType
 from collections import namedtuple
@@ -712,6 +713,10 @@ def _construct_parameter(signature):
         )
 
     name, signature = signature.split(":", 1)
+
+    if keyword.iskeyword(name):
+        name += "_"
+
     type = _construct_type(signature)
 
     __,*opt = signature.split(":")


### PR DESCRIPTION
Before, this failed:
```py
print(vs.core.mv.Analyse)

Traceback (most recent call last):
  File "test.py", line 19, in <module>
    print(vs.core.mv.Analyse)
    ~~~~~^^^^^^^^^^^^^^^^^^^^
  File "src/cython/vapoursynth.pyx", line 3122, in vapoursynth.Function.__repr__
  File "src/cython/vapoursynth.pyx", line 3018, in vapoursynth.Function.__signature__.__get__
  File "src/cython/vapoursynth.pyx", line 732, in vapoursynth.construct_signature
  File "src/cython/vapoursynth.pyx", line 733, in genexpr
  File "src/cython/vapoursynth.pyx", line 723, in vapoursynth._construct_parameter
  File "C:\Users\Varde\AppData\Local\Programs\Python\Python313\Lib\inspect.py", line 2855, in __init__
    raise ValueError("{!r} is not a valid parameter name".format(name))
ValueError: 'lambda' is not a valid parameter name
```