### PR TITLE
Align stubs, runtime, and expected behavior in Cython module

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2299,18 +2299,18 @@ cdef class VideoNode(RawNode):
         if hasattr(fileobj, "flush"):
             fileobj.flush()
 
-    def __add__(x, y):
-        if not isinstance(x, VideoNode) or not isinstance(y, VideoNode):
+    def __add__(self, other):
+        if not isinstance(self, VideoNode) or not isinstance(other, VideoNode):
             return NotImplemented
-        return (<VideoNode>x).core.std.Splice(clips=[x, y])
+        return (<VideoNode>self).core.std.Splice(clips=[self, other])
 
-    def __mul__(a, b):
-        if isinstance(a, VideoNode):
-            node = a
-            val = b
+    def __mul__(self, other):
+        if isinstance(self, VideoNode):
+            node = self
+            val = other
         else:
-            node = b
-            val = a
+            node = other
+            val = self
 
         if not isinstance(val, int):
             raise TypeError('Clips may only be repeated by integer factors')
@@ -2473,18 +2473,18 @@ cdef class AudioNode(RawNode):
     def channels(self):
         return ChannelLayout(self.channel_layout)
 
-    def __add__(x, y):
-        if not isinstance(x, AudioNode) or not isinstance(y, AudioNode):
+    def __add__(self, other):
+        if not isinstance(self, AudioNode) or not isinstance(other, AudioNode):
             return NotImplemented
-        return (<AudioNode>x).core.std.AudioSplice(clips=[x, y])
+        return (<AudioNode>self).core.std.AudioSplice(clips=[self, other])
 
-    def __mul__(a, b):
-        if isinstance(a, AudioNode):
-            node = a
-            val = b
+    def __mul__(self, other):
+        if isinstance(self, AudioNode):
+            node = self
+            val = other
         else:
-            node = b
-            val = a
+            node = other
+            val = self
 
         if not isinstance(val, int):
             raise TypeError('Clips may only be repeated by integer factors')

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1177,7 +1177,7 @@ cdef class VideoFormat(object):
 cdef VideoFormat createVideoFormat(const VSVideoFormat *f, const VSAPI *funcs, VSCore *core):
     cdef VideoFormat instance = VideoFormat.__new__(VideoFormat)
     cdef char nameBuffer[32]
-    if f.colorFamily <> cfUndefined:
+    if f.colorFamily != cfUndefined:
         funcs.getVideoFormatName(f, nameBuffer)
         instance.name = nameBuffer.decode('utf-8')
     else:
@@ -2496,7 +2496,7 @@ cdef class AudioNode(RawNode):
         if isinstance(val, slice):
             if val.step is not None and val.step == 0:
                 raise ValueError('Slice step cannot be zero')
-            if val.step is not None and abs(val.step) <> 1:
+            if val.step is not None and abs(val.step) != 1:
                 raise ValueError('Slice step must be 1')
 
             indices = val.indices(self.num_samples)
@@ -2838,7 +2838,7 @@ cdef Core createCore(EnvironmentData env):
     instance.core = instance.funcs.createCore(env.coreCreationFlags)
     instance.timings = createCoreTimings(instance)
     instance.creationFlags = env.coreCreationFlags
-    if instance.core_version.release_major <> VS_CURRENT_RELEASE:
+    if instance.core_version.release_major != VS_CURRENT_RELEASE:
         instance.log_message(mtWarning, f'Version mismatch: The VapourSynth Python module version is R{__version__.release_major:d} but the VapourSynth core library is R{instance.core_version.release_major:d}. This usually indicates a broken install.')
     return instance
 
@@ -2853,7 +2853,7 @@ cdef Core createCore2(VSCore *core):
         raise Error('Failed to obtain VapourSynth API pointer. Is the Python module and loaded core library mismatched?')
     instance.core = core
     instance.timings = createCoreTimings(instance)
-    if instance.core_version.release_major <> VS_CURRENT_RELEASE:
+    if instance.core_version.release_major != VS_CURRENT_RELEASE:
         instance.log_message(mtWarning, f'Version mismatch: The VapourSynth Python module version is R{__version__.release_major:d} but the VapourSynth core library is R{instance.core_version.release_major:d}. This usually indicates a broken install.')
     plugin = instance.funcs.getPluginByID('com.vapoursynth.std', core)
     min = instance.funcs.createMap()
@@ -2861,7 +2861,7 @@ cdef Core createCore2(VSCore *core):
     instance.funcs.freeMap(min)
     node = instance.funcs.mapGetNode(mout, "clip", 0, NULL)
     instance.funcs.freeMap(mout)
-    if instance.funcs.getNodeCreationFunctionName(node, 0) <> NULL:
+    if instance.funcs.getNodeCreationFunctionName(node, 0) != NULL:
         instance.creationFlags = ccfEnableGraphInspection
     instance.funcs.freeNode(node)
     return instance

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1463,6 +1463,9 @@ cdef class RawFrame(object):
         if self.funcs:
             self.funcs.freeFrame(self.constf)
 
+    def copy(self):
+        raise NotImplementedError
+
     @property
     def closed(self):
         return self.constf == NULL
@@ -1478,6 +1481,12 @@ cdef class RawFrame(object):
         if self.funcs:
             self.funcs.freeFrame(self.constf)
         self.constf = NULL
+
+    def __getitem__(self, index):
+        raise NotImplementedError
+
+    def __len__(self):
+        raise NotImplementedError
 
     def __enter__(self):
         return self

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1950,6 +1950,12 @@ cdef class RawNode(object):
     cdef ensure_valid_frame_number(self, int n):
         raise NotImplementedError("Needs to be implemented by subclass.")
 
+    def get_frame(self, int n):
+        raise NotImplementedError
+
+    def set_output(self, int index = 0):
+        raise NotImplementedError
+
     def get_frame_async(self, int n, object cb = None):
         if cb is None:
             _handle_future = _get_handle_future()
@@ -2129,6 +2135,21 @@ cdef class RawNode(object):
             raise Error("This node is not inspectable.")
 
         return mapToDict(self.funcs.getNodeCreationFunctionArguments(self.node, 0), False)
+
+    def __add__(self, other):
+        raise NotImplementedError
+
+    def __mul__(self, other):
+        raise NotImplementedError
+
+    def __getattr__(self, str name):
+        raise NotImplementedError
+
+    def __getitem__(self, val):
+        raise NotImplementedError
+    
+    def __len__(self):
+        raise NotImplementedError
 
     def __eq__(self, other):
         if other is self:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2101,15 +2101,15 @@ cdef class RawNode(object):
     def node_name(self):
         return self.funcs.getNodeName(self.node).decode("utf-8")
 
-    property timings:
-        def __get__(self):
-            return self.funcs.getNodeProcessingTime(self.node, False)
-        
-        def __set__(self, bint value):
-            if value != 0:
-                raise ValueError('You can only set timings to 0, to reset its counter!')
+    @property
+    def timings(self):
+        return self.funcs.getNodeProcessingTime(self.node, False)
 
-            self.funcs.getNodeProcessingTime(self.node, True)
+    @timings.setter
+    def timings(self, bint value):
+        if value != 0:
+            raise ValueError("You can only set timings to 0, to reset its counter!")
+        self.funcs.getNodeProcessingTime(self.node, True)
 
     @property
     def mode(self):
@@ -2620,22 +2620,23 @@ cdef class CoreTimings(object):
     def __init__(self):
         raise Error('Class cannot be instantiated directly')
 
-    property enabled:
-        def __get__(self):
-            return bool(self.core.funcs.getCoreNodeTiming(self.core.core))
+    @property
+    def enabled(self):
+        return bool(self.core.funcs.getCoreNodeTiming(self.core.core))
 
-        def __set__(self, bint enabled):
-            self.core.funcs.setCoreNodeTiming(self.core.core, enabled)
+    @enabled.setter
+    def enabled(self, bint enabled):
+        self.core.funcs.setCoreNodeTiming(self.core.core, enabled)
 
-    property freed_nodes:
-        def __get__(self):
-            return self.core.funcs.getFreedNodeProcessingTime(self.core.core, False)
-        
-        def __set__(self, bint value):
-            if value != 0:
-                raise ValueError('You can only set freed_nodes to 0, to reset its counter!')
+    @property
+    def freed_nodes(self):
+        return self.core.funcs.getFreedNodeProcessingTime(self.core.core, False)
 
-            self.core.funcs.getFreedNodeProcessingTime(self.core.core, True)
+    @freed_nodes.setter
+    def freed_nodes(self, bint value):
+        if value != 0:
+            raise ValueError("You can only set freed_nodes to 0, to reset its counter!")
+        self.core.funcs.getFreedNodeProcessingTime(self.core.core, True)
 
     def __repr__(self):
         return _construct_repr(
@@ -2672,30 +2673,30 @@ cdef class Core(object):
         if self.funcs:
             self.funcs.freeCore(self.core)
 
-    property num_threads:
-        def __get__(self):
-            cdef VSCoreInfo v
-            self.funcs.getCoreInfo(self.core, &v)
-            return v.numThreads
+    @property
+    def num_threads(self):
+        cdef VSCoreInfo v
+        self.funcs.getCoreInfo(self.core, &v)
+        return v.numThreads
 
-        def __set__(self, int value):
-            self.funcs.setThreadCount(value, self.core)
+    @num_threads.setter
+    def num_threads(self, int value):
+        self.funcs.setThreadCount(value, self.core)
 
-    property max_cache_size:
-        def __get__(self):
-            cdef VSCoreInfo v
-            self.funcs.getCoreInfo(self.core, &v)
-            cdef int64_t current_size = <int64_t>v.maxFramebufferSize
-            current_size = current_size + 1024 * 1024 - 1
-            current_size = current_size // <int64_t>(1024 * 1024)
-            return current_size
+    @property
+    def max_cache_size(self):
+        cdef VSCoreInfo v
+        self.funcs.getCoreInfo(self.core, &v)
+        cdef int64_t current_size = <int64_t>v.maxFramebufferSize
+        current_size = (current_size + 1024 * 1024 - 1) // <int64_t>(1024 * 1024)
+        return current_size
 
-        def __set__(self, int mb):
-            if mb <= 0:
-                raise ValueError('Maximum cache size must be a positive number')
-            cdef int64_t new_size = mb
-            new_size = new_size * 1024 * 1024
-            self.funcs.setMaxCacheSize(new_size, self.core)
+    @max_cache_size.setter
+    def max_cache_size(self, int mb):
+        if mb <= 0:
+            raise ValueError("Maximum cache size must be a positive number")
+        cdef int64_t new_size = mb * 1024 * 1024
+        self.funcs.setMaxCacheSize(new_size, self.core)
 
     @property
     def used_cache_size(self):


### PR DESCRIPTION
To better align the stubs, expected behavior, and runtime behavior, I propose the following changes:

* Add *abstract* base methods for `RawFrame` and `RawNode`.

* Update `FrameProps`:
  Currently, it is registered as a `Mapping`.
  The stubs annotate it as a `MutableMapping`.
  At runtime, it already behaves like a `MutableMapping`.
  I propose to formally register it as a `MutableMapping` with the following adjustments:

    * `__iter__`: make iteration independent and faster by using C objects.
    * `keys`, `items`, `values`: return the expected view objects, consistent with `MutableMapping`.
    * `pop`, `get`, `setdefault`: support positional-only parameters, as in `MutableMapping`.
    * Remove docstrings so they are not retrievable at runtime.
    * Remove redundant calls to `self.frame._ensure_open()`, since these checks are already performed in higher-level dunder methods.

* Additional cleanup commits:

  * Remove Python 2 legacy `<>` operator.
  * Update parameter names to follow Python conventions (e.g., `def __add__(self, other):` instead of `__add__(x, y):`).
  * Remove usage of deprecated legacy properties.
