### PR TITLE
fix two doc build warnings

### DIFF
--- a/doc/api/vshelper4.h.rst
+++ b/doc/api/vshelper4.h.rst
@@ -156,7 +156,7 @@ vsh_aligned_free
 
 
 isConstantVideoFormat
-----------------
+---------------------
 
 .. cpp:function:: static inline bool vsh::isConstantVideoFormat(const VSVideoInfo *vi)
 

--- a/doc/output.rst
+++ b/doc/output.rst
@@ -68,7 +68,7 @@ Write to stdout:
     ``vspipe [options] script.vpy -``
 
 Write to a named pipe (Windows only):
-    ``vspipe [options] script.vpy "\\\\.\\pipe\\<pipename>"
+    ``vspipe [options] script.vpy "\\\\.\\pipe\\<pipename>"``
 
 Request all frames but don't output them:
     ``vspipe [options] script.vpy --``


### PR DESCRIPTION
C:\Users\Lenovo\vapoursynth\doc\api\vshelper4.h.rst:159: WARNING: Title underline too short. 
isConstantVideoFormat
---------------- [docutils]

C:\Users\Lenovo\vapoursynth\doc\output.rst:71: WARNING: Inline literal start-string without end-string. [docutils]