### PR TITLE
fix max_cache_size setter crash

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2681,7 +2681,8 @@ cdef class Core(object):
     def max_cache_size(self, int mb):
         if mb <= 0:
             raise ValueError("Maximum cache size must be a positive number")
-        cdef int64_t new_size = mb * 1024 * 1024
+        cdef int64_t new_size = mb
+        new_size = new_size * 1024 * 1024
         self.funcs.setMaxCacheSize(new_size, self.core)
 
     @property


### PR DESCRIPTION
regression https://github.com/vapoursynth/vapoursynth/pull/1143

integer overflow probably, restore pre PR code

```py
from vapoursynth import core

a = core.max_cache_size
print(a)
core.max_cache_size = a
print(a)
```
```
4096
zsh: IOT instruction  python repro.py
```