### PR TITLE
Support XDG_CONFIG_HOME for config discovery

### DIFF
--- a/src/py/_utils.py
+++ b/src/py/_utils.py
@@ -220,7 +220,8 @@ def _get_vapoursynth_config_path():
     if sys.platform == "win32":
         config_path = Path(os.getenv("APPDATA")) / "vapoursynth"
     else:
-        config_path = Path.home() / ".config/vapoursynth"
+        config_home = os.getenv("XDG_CONFIG_HOME") or Path.home() / ".config"
+        config_path = Path(config_home) / "vapoursynth"
     config_path.mkdir(parents=True, exist_ok=True)
     return config_path / "vapoursynth.toml"
 

--- a/src/vsscript/vsscript.cpp
+++ b/src/vsscript/vsscript.cpp
@@ -115,8 +115,15 @@ static std::pair<std::filesystem::path, std::filesystem::path> readEnvConfig(con
 
     std::filesystem::path configPath = _wgetenv(L"APPDATA");
 #else
-    std::filesystem::path configPath = std::getenv("HOME");
-    configPath /= ".config";
+    std::filesystem::path configPath;
+    const auto xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+
+    if (xdg_config_home && *xdg_config_home) {
+        configPath = xdg_config_home;
+    } else {
+        const auto home = std::getenv("HOME");
+        configPath = std::filesystem::path(home ? home : "") / ".config";
+    }
 #endif
     configPath /= "vapoursynth";
     configPath /= "vapoursynth.toml";


### PR DESCRIPTION
Following the XDG Base Directory Specification, the logic now checks if XDG_CONFIG_HOME is set and non-empty before falling back to the standard ~/.config location.