### PR TITLE
Fix vspipe help string typo (missing quote)

### DIFF
--- a/src/vspipe/vspipe.cpp
+++ b/src/vspipe/vspipe.cpp
@@ -682,7 +682,7 @@ static void printHelp() {
         "    vspipe [options] script.vpy -\n"
 #ifdef _WIN32
         "  Write to a named pipe (Windows only):\n"
-        "    vspipe [options] script.vpy \"\\\\.\\pipe\\<pipename>\n"
+        "    vspipe [options] script.vpy \"\\\\.\\pipe\\<pipename>\"\n"
 #endif
         "  Request all frames but don't output them:\n"
         "    vspipe [options] script.vpy --\n"


### PR DESCRIPTION
vspipe help is missing a quote `"` here:

```
  Write to a named pipe (Windows only):
    vspipe [options] script.vpy "\\.\pipe\<pipename>"
                                                                                   ^
```