### PR TITLE
doc: Clarify filter modes wrt single-threaded behavior

### DIFF
--- a/doc/api/vapoursynth4.h.rst
+++ b/doc/api/vapoursynth4.h.rst
@@ -466,11 +466,12 @@ enum VSFilterMode
 
    * fmParallelRequests
 
-     For filters that are serial in nature but can request in advance one or
+     For filters that are single-threaded in nature but can request in advance one or
      more frames they need.
      A filter's "getframe" function will be called from multiple threads at a
      time with activation reason arInitial, but only one thread will call it
-     with activation reason arAllFramesReady at a time.
+     with activation reason arAllFramesReady at a time. Calls with arAllFramesReady are not
+     guaranteed to be serial, meaning that frame 2 may be requested before frame 1, etc.
 
    * fmUnordered
 

--- a/doc/apireference.rst
+++ b/doc/apireference.rst
@@ -26,9 +26,9 @@ Plugins
 -------
 Plugin code may run more multithreaded than it initially appears. *VapourSynthPluginInit* is the only function always guaranteed to not run in parallel. This means that the constructor and destructor of a filter may be run in parallel for several instances. Use proper synchronization if you need to initialize shared data.
 
-The *GetFrame* function is a bit more complicated so see the reference of the constants. Do however note that the parallelism is per instance. Even if a filter is *fmUnordered* or *fmSerial* other instances may enter *GetFrame* simultaneously.
+The *GetFrame* function is a bit more complicated so see the reference of the constants. Do however note that the parallelism is per instance. Even if a filter is *fmUnordered* or *fmFrameState* other instances may enter *GetFrame* simultaneously.
 
-There are two common misconseptions about which mode should be used. A simple rule is that *fmSerial* should never be used. And source filters (those returning a frame on *arInitial*) that need locking should use *fmUnordered*.
+There are two common misconseptions about which mode should be used. A simple rule is that *fmFrameState* should never be used. And source filters (those returning a frame on *arInitial*) that need locking should use *fmUnordered*.
 
 Reserved Frame Properties
 #########################

--- a/include/VapourSynth4.h
+++ b/include/VapourSynth4.h
@@ -162,7 +162,7 @@ typedef enum VSPresetVideoFormat {
 
 typedef enum VSFilterMode {
     fmParallel = 0, /* completely parallel execution */
-    fmParallelRequests = 1, /* for filters that are serial in nature but can request one or more frames they need in advance */
+    fmParallelRequests = 1, /* for filters that are single-threaded in nature but can request one or more frames they need in advance */
     fmUnordered = 2, /* for filters that modify their internal state every request like source filters that read a file */
     fmFrameState = 3 /* DO NOT USE UNLESS ABSOLUTELY NECESSARY, for compatibility with external code that can only keep the processing state of a single frame at a time */
 } VSFilterMode;

--- a/sdk/invert_example.c
+++ b/sdk/invert_example.c
@@ -131,7 +131,7 @@ static void VS_CC invertCreate(const VSMap *in, VSMap *out, void *userData, VSCo
     // is handled. In general you should only use fmParallel whenever possible. This is if you
     // need to modify no shared data at all when the filter is running.
     // For more complicated filters, fmParallelRequests is usually easier to achieve as it can
-    // be prefetched in parallel but the actual processing is serialized.
+    // be prefetched in parallel but the actual processing is single-threaded.
     // The others can be considered special cases where fmFrameState is useful to source filters and
     // fmUnordered is useful when a filter's state may change even when deciding which frames to
     // prefetch (such as a cache filter).


### PR DESCRIPTION
Removes possible confusion from the use of the word "serial", which previously could be interpreted as all frames being requested in order.

Inspired by conversation in https://github.com/dubhatervapoursynth/vapoursynth-cnr2/pull/6