### PR TITLE
Add RISC-V platform handling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,7 @@ else
 endif
 
 host_system = host_machine.system()
+host_cpu_family = host_machine.cpu_family()
 is_win = host_system in ['cygwin', 'windows']
 
 if is_win
@@ -29,7 +30,11 @@ else
     dl_dep = dependency('dl')
 endif
 
-if not host_machine.cpu_family().startswith('x86')
+if host_cpu_family.startswith('riscv')
+    add_project_arguments('-DVS_TARGET_CPU_RISCV', language: ['c', 'cpp'])
+endif
+
+if not host_cpu_family.startswith('x86')
     enable_x86_asm = false
 endif
 

--- a/src/avfs/include/ptpublic.h
+++ b/src/avfs/include/ptpublic.h
@@ -39,7 +39,7 @@
 
 #if !defined(RC_INVOKED) && !defined(RC_PLIST)
 
-#if (defined(INT_MAX) && LONG_MAX > INT_MAX) || defined(_WIN64) || defined(__x86_64__) || defined(__powerpc64__) || defined(__ppc64__) || defined(__mips64__) || defined(__arm64__) || defined(__ia64__) || (defined(__riscv) && __riscv_xlen == 64)
+#if (defined(INT_MAX) && LONG_MAX > INT_MAX) || defined(_WIN64) || defined(__x86_64__) || defined(__powerpc64__) || defined(__ppc64__) || defined(__mips64__) || defined(__arm64__) || defined(__ia64__)
  #define PT_SIZEOF_PTR 64
 #else
  #define PT_SIZEOF_PTR 32

--- a/src/avfs/include/ptpublic.h
+++ b/src/avfs/include/ptpublic.h
@@ -39,7 +39,7 @@
 
 #if !defined(RC_INVOKED) && !defined(RC_PLIST)
 
-#if (defined(INT_MAX) && LONG_MAX > INT_MAX) || defined(_WIN64) || defined(__x86_64__) || defined(__powerpc64__) || defined(__ppc64__) || defined(__mips64__) || defined(__arm64__) || defined(__ia64__)
+#if (defined(INT_MAX) && LONG_MAX > INT_MAX) || defined(_WIN64) || defined(__x86_64__) || defined(__powerpc64__) || defined(__ppc64__) || defined(__mips64__) || defined(__arm64__) || defined(__ia64__) || (defined(__riscv) && __riscv_xlen == 64)
  #define PT_SIZEOF_PTR 64
 #else
  #define PT_SIZEOF_PTR 32

--- a/src/core/cpufeatures.cpp
+++ b/src/core/cpufeatures.cpp
@@ -135,6 +135,11 @@ int doGetX86ABILevel(void) {
     return 3;
 }
 
+#elif defined(VS_TARGET_CPU_RISCV)
+static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
+    *cpuFeatures = {};
+    cpuFeatures->can_run_vs = 1;
+}
 #else
 static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
     *cpuFeatures = {};


### PR DESCRIPTION
## Why

VapourSynth did not have explicit RISC-V target handling in its Meson CPU selection and pointer-width gates, so riscv builds fell through generic non-x86 behavior without clear target labeling. This patch makes the baseline RISC-V path explicit without introducing a new JIT or vector backend.

## What changed

- Define `VS_TARGET_CPU_RISCV` for Meson hosts whose CPU family starts with `riscv`.
- Keep RISC-V on the existing portable C/C++ baseline path instead of enabling x86 JIT, SSE, or AVX code.
- Add an explicit RISC-V CPU feature baseline branch.
- Treat `__riscv` with `__riscv_xlen == 64` as a 64-bit pointer platform in `ptpublic.h`.

## Verification

- Compiled `src/core/cpufeatures.cpp` with `VS_TARGET_CPU_RISCV`, `__riscv`, and `__riscv_xlen=64`.
- Compiled `src/core/cpufeatures.cpp` with `VS_TARGET_CPU_X86` to check the existing x86 CPU feature path still builds.
- Compiled `src/core/expr/jitcompiler.cpp` with `VS_TARGET_CPU_RISCV` to check the non-x86 JIT fallback path.
- Compiled a RISC-V 64 preprocessing assertion that checks `PT_SIZEOF_PTR == 64`.
- Ran a simulated `riscv64` Meson setup. Meson recognized the host as `riscv64`; setup then stopped on the Windows host because the simulated Linux target dependency `dl` is unavailable locally.

## Notes

This is a conservative portability patch. It does not add an RVV backend or a RISC-V JIT compiler. The intent is to make the RISC-V platform path explicit while preserving the current portable fallback behavior.