### PR TITLE
Prevent swallowed exceptions by tunneling Python exceptions

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -51,7 +51,7 @@ import keyword
 from threading import local as ThreadLocal, Lock, RLock
 from types import MappingProxyType
 from collections.abc import ItemsView, Iterable, KeysView, MutableMapping, ValuesView
-from concurrent.futures import Future
+from concurrent.futures import Future, CancelledError as FutureCancelledError
 from fractions import Fraction
 
 
@@ -223,6 +223,9 @@ cdef class EnvironmentData(object):
     cdef Core core
     cdef object on_destroy
     cdef dict outputs
+    cdef dict active_exceptions
+    cdef int next_exc_id
+    cdef object exc_lock
 
     cdef int coreCreationFlags
     cdef VSLogHandle* log
@@ -244,6 +247,29 @@ cdef class EnvironmentData(object):
                 RuntimeWarning
             )
         _unset_logger(self)
+
+    cdef int store_exception(self, object e):
+        if self.active_exceptions is None:
+            return 0
+
+        with self.exc_lock:
+            self.next_exc_id += 1
+            self.active_exceptions[self.next_exc_id] = e
+
+            if len(self.active_exceptions) > 1000:
+                self.active_exceptions.pop(next(iter(self.active_exceptions)), None)
+
+            return self.next_exc_id
+
+    cdef object retrieve_exception(self, str msg_str):
+        if self.active_exceptions is not None and msg_str.startswith("[VS_PY_EXC_ID:"):
+            try:
+                parts = msg_str.split("]\n", 1)
+                exc_id = int(parts[0][len("[VS_PY_EXC_ID:"):])
+                return self.active_exceptions.pop(exc_id, None)
+            except (ValueError, KeyError, IndexError):
+                pass
+        return None
 
 
 class EnvironmentPolicy(object):
@@ -369,6 +395,9 @@ cdef class EnvironmentPolicyAPI:
         env.core = None
         env.log = NULL
         env.outputs = {}
+        env.active_exceptions = {}
+        env.next_exc_id = 0
+        env.exc_lock = Lock()
         env.coreCreationFlags = flags
         env.on_destroy = []
         env.env_locals = weakref.WeakKeyDictionary()
@@ -415,6 +444,8 @@ cdef class EnvironmentPolicyAPI:
         env.outputs = {}
         env.env_locals.clear()
         env.env_locals = None
+        env.active_exceptions = None
+        env.exc_lock = None
         env.alive = False
 
     def unregister_policy(self):
@@ -848,7 +879,10 @@ cdef class Func(object):
             self.funcs.callFunction(self.ref, inm, outm)
             error = self.funcs.mapGetError(outm)
             if error:
-                raise Error(error.decode('utf-8'))
+                msg_str = error.decode('utf-8')
+                env = _env_current()
+                py_exc = env.retrieve_exception(msg_str) if env is not None else None
+                raise py_exc or Error(msg_str)
             return mapToDict(outm, True)
         finally:
             vsapi.freeMap(outm)
@@ -921,10 +955,11 @@ cdef void __stdcall frameDoneCallback(void *data, const VSFrame *f, int n, VSNod
 
         try:
             if f == NULL:
-                error = 'Internal error - no error message.'
+                error_str = 'Internal error - no error message.'
                 if errormsg != NULL:
-                    error = errormsg.decode('utf-8')
-                error = Error(error)
+                    error_str = errormsg.decode('utf-8')
+                py_exc = d.env.retrieve_exception(error_str) if d.env is not None else None
+                error = py_exc or Error(error_str)
             else:
                 result = createConstFrame(f, d.funcs, d.node.core.core)
 
@@ -2226,7 +2261,10 @@ cdef class VideoNode(RawNode):
             f = self.funcs.getFrame(n, self.node, errorMsg, 4096)
         if f == NULL:
             if (errorMsg[0]):
-                raise Error(ep.decode('utf-8'))
+                msg_str = ep.decode('utf-8')
+                env = _env_current()
+                py_exc = env.retrieve_exception(msg_str) if env is not None else None
+                raise py_exc or Error(msg_str)
             else:
                 raise Error('Internal error - no error given')
         else:
@@ -3257,7 +3295,10 @@ cdef class Function(object):
         if err:
             emsg = err
             self.funcs.freeMap(outm)
-            raise Error(emsg.decode('utf-8'))
+            msg_str = emsg.decode('utf-8')
+            env = _env_current()
+            py_exc = env.retrieve_exception(msg_str) if env is not None else None
+            raise py_exc or Error(msg_str)
 
         retdict = mapToDict(outm, True)
         self.funcs.freeMap(outm)
@@ -3359,8 +3400,14 @@ cdef void __stdcall publicFunction(const VSMap *inm, VSMap *outm, void *userData
                     ret = {'val':ret}
                 dictToMap(ret, outm, core, vsapi)
         except BaseException as e:
-            emsg = b'\n' + ''.join(traceback.format_exception(type(e), e, e.__traceback__)).encode('utf-8')
-            vsapi.mapSetError(outm, emsg)
+            if (isinstance(e, BaseException) and not isinstance(e, Exception)) or isinstance(e, FutureCancelledError):
+                exc_id = d.env.store_exception(e) if d.env is not None else 0
+                tb_str = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
+                emsg = f"[VS_PY_EXC_ID:{exc_id}]\n{tb_str}".encode('utf-8')
+                vsapi.mapSetError(outm, emsg)
+            else:
+                emsg = b'\n' + ''.join(traceback.format_exception(type(e), e, e.__traceback__)).encode('utf-8')
+                vsapi.mapSetError(outm, emsg)
 
 
 @final

--- a/test/environment_test.py
+++ b/test/environment_test.py
@@ -273,6 +273,43 @@ class EnvironmentTest(unittest.TestCase):
 
             self.assertIsNone(wr())
 
+    @subprocess_runner
+    def test_exception_tunneling_and_no_leak(self):
+        class CustomException(BaseException):
+            pass
+
+        with _with_policy() as pol:
+            env = pol._api.create_environment()
+            wrapped = pol._api.wrap_environment(env)
+
+            with wrapped.use():
+                clip = vs.core.std.BlankClip(width=16, height=16, length=2)
+
+                exc = CustomException("Tunnel test")
+                exc_ref = weakref.ref(exc)
+
+                def callback(n, f):
+                    raise exc
+
+                modified = clip.std.ModifyFrame(clip, callback)
+
+                with self.assertRaises(CustomException) as ctx:
+                    modified.get_frame(0)
+
+                self.assertEqual(str(ctx.exception), "Tunnel test")
+
+                # Clear all references that might hold the exception
+                del ctx
+                del callback
+                del modified
+                del clip
+                del exc
+                gc.collect()
+                gc.collect()
+                gc.collect()
+
+                self.assertIsNone(exc_ref())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Came across this when I experienced with a cancellation system which raises a `concurrent.futures.CancelledError` error inside a ModifyFrame callback.
The exception is swallowed by VapourSynth and it's impossible to get the type or the traceback of the original error.