### PR TITLE
Optimize VideoNode.output by avoiding Python generator overhead

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -19,16 +19,15 @@
 
 cimport vapoursynth
 include 'vsconstants.pxd'
+from vshelper cimport bitblt
 from vsscript_internal cimport VSScript
 from wave cimport WaveHeader, Wave64Header, CreateWave64Header, CreateWaveHeader, PackChannels16to16le, PackChannels32to24le, PackChannels32to32le
 cimport cython.parallel
 from cython cimport view, final
 from libc.stdlib cimport malloc, free, realloc
 from libc.stdint cimport intptr_t, int16_t, uint16_t, int32_t, uint32_t, uint8_t, uint64_t, int64_t
-from cpython.buffer cimport PyBUF_SIMPLE
-from cpython.buffer cimport PyBuffer_FillInfo
-from cpython.buffer cimport PyBuffer_Release
-from cpython.memoryview cimport PyMemoryView_FromObject
+from cpython.buffer cimport PyBUF_READ, PyBUF_SIMPLE, PyBuffer_FillInfo, PyBuffer_Release
+from cpython.memoryview cimport PyMemoryView_FromMemory, PyMemoryView_FromObject
 from cpython.number cimport PyIndex_Check
 from cpython.number cimport PyNumber_Index
 from cpython.ref cimport Py_INCREF, Py_DECREF
@@ -2332,17 +2331,72 @@ cdef class VideoNode(RawNode):
             fileobj.write(data.encode("ascii"))
 
         write = fileobj.write
-        readchunks = VideoFrame.readchunks
+        total = self.num_frames
 
-        for idx, frame in enumerate(self.frames(prefetch, backlog, close=True)):
-            if y4m:
-                fileobj.write(b"FRAME\n")
+        cdef:
+            const VSAPI *lib = self.funcs
+            const VSVideoFormat *fi
+            uint8_t *buffer = NULL
+            size_t buffer_size = <size_t>0
+            ptrdiff_t stride
+            const uint8_t *readPtr
+            size_t rowSize
+            int height
+            int p
+            const VSFrame *constf
 
-            for chunk in readchunks(frame):
-                write(chunk)
+        # Pre-allocate buffer for packing
+        buffer_size = <size_t>(self.width * self.height * self.format.bytes_per_sample)
+        buffer = <uint8_t *>malloc(buffer_size)
+        if not buffer:
+            raise Error("Failed to allocate memory for output buffer")
 
-            if progress_update is not None:
-                progress_update(idx+1, len(self))
+        try:
+            for idx, frame in enumerate(self.frames(prefetch, backlog, close=True)):
+                if y4m:
+                    write(b"FRAME\n")
+
+                constf = (<VideoFrame>frame).constf
+                fi = lib.getVideoFrameFormat(constf)
+                for p in range(fi.numPlanes):
+                    stride = lib.getStride(constf, p)
+                    readPtr = lib.getReadPtr(constf, p)
+                    rowSize = <size_t>lib.getFrameWidth(constf, p) * fi.bytesPerSample
+                    height = lib.getFrameHeight(constf, p)
+
+                    if stride == <ptrdiff_t>rowSize:
+                        write(PyMemoryView_FromMemory(<char *>readPtr, rowSize * height, PyBUF_READ))
+                    else:
+                        with nogil:
+                            bitblt(buffer, rowSize, readPtr, stride, rowSize, height)
+                        write(PyMemoryView_FromMemory(<char *>buffer, rowSize * height, PyBUF_READ))
+
+                alpha = frame.props.get("_Alpha")
+                if alpha is not None:
+                    if y4m:
+                        raise ValueError("Can only apply y4m headers to clips without alpha")
+
+                    constf = (<VideoFrame>alpha).constf
+                    fi = lib.getVideoFrameFormat(constf)
+                    for p in range(fi.numPlanes):
+                        stride = lib.getStride(constf, p)
+                        readPtr = lib.getReadPtr(constf, p)
+                        rowSize = <size_t>lib.getFrameWidth(constf, p) * fi.bytesPerSample
+                        height = lib.getFrameHeight(constf, p)
+
+                        if stride == <ptrdiff_t>rowSize:
+                            write(PyMemoryView_FromMemory(<char *>readPtr, rowSize * height, PyBUF_READ))
+                        else:
+                            with nogil:
+                                bitblt(buffer, rowSize, readPtr, stride, rowSize, height)
+                            write(PyMemoryView_FromMemory(<char *>buffer, rowSize * height, PyBUF_READ))
+
+                    alpha.close()
+
+                if progress_update is not None:
+                    progress_update(idx + 1, total)
+        finally:
+            free(buffer)
 
         if hasattr(fileobj, "flush"):
             fileobj.flush()

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2301,37 +2301,33 @@ cdef class VideoNode(RawNode):
 
         if y4m:
             if self.format.color_family == cfGray:
-                y4mformat = 'mono'
+                y4mformat = "mono"
                 if self.format.bits_per_sample > 8:
-                    y4mformat = y4mformat + str(self.format.bits_per_sample)
+                    y4mformat += str(self.format.bits_per_sample)
             elif self.format.color_family == cfYUV:
-                if self.format.subsampling_w == 1 and self.format.subsampling_h == 1:
-                    y4mformat = '420'
-                elif self.format.subsampling_w == 1 and self.format.subsampling_h == 0:
-                    y4mformat = '422'
-                elif self.format.subsampling_w == 0 and self.format.subsampling_h == 0:
-                    y4mformat = '444'
-                elif self.format.subsampling_w == 2 and self.format.subsampling_h == 2:
-                    y4mformat = '410'
-                elif self.format.subsampling_w == 2 and self.format.subsampling_h == 0:
-                    y4mformat = '411'
-                elif self.format.subsampling_w == 0 and self.format.subsampling_h == 1:
-                    y4mformat = '440'
+                if (self.format.subsampling_w, self.format.subsampling_h) == (1, 1):
+                    y4mformat = "420"
+                elif (self.format.subsampling_w, self.format.subsampling_h) == (1, 0):
+                    y4mformat = "422"
+                elif (self.format.subsampling_w, self.format.subsampling_h) == (0, 0):
+                    y4mformat = "444"
+                elif (self.format.subsampling_w, self.format.subsampling_h) == (2, 2):
+                    y4mformat = "410"
+                elif (self.format.subsampling_w, self.format.subsampling_h) == (2, 0):
+                    y4mformat = "411"
+                elif (self.format.subsampling_w, self.format.subsampling_h) == (0, 1):
+                    y4mformat = "440"
+                else:
+                    raise NotImplementedError("Unsupported subsampling for Y4M")
+
                 if self.format.bits_per_sample > 8:
-                    y4mformat = y4mformat + 'p' + str(self.format.bits_per_sample)
+                    y4mformat += f"p{self.format.bits_per_sample}"
             else:
-                raise ValueError("Can only use GRAY and YUV for V4M-Streams")
+                raise ValueError("Can only use GRAY and YUV for Y4M-Streams")
 
-            if len(y4mformat) > 0:
-                y4mformat = 'C' + y4mformat + ' '
-
-            data = 'YUV4MPEG2 {y4mformat}W{width} H{height} F{fps_num}:{fps_den} Ip A0:0 XLENGTH={length}\n'.format(
-                y4mformat=y4mformat,
-                width=self.width,
-                height=self.height,
-                fps_num=self.fps_num,
-                fps_den=self.fps_den,
-                length=len(self)
+            data = (
+                f"YUV4MPEG2 C{y4mformat} W{self.width} H{self.height} F{self.fps_num}:{self.fps_den} "
+                f"Ip A0:0 XLENGTH={self.num_frames}\n"
             )
             fileobj.write(data.encode("ascii"))
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2295,7 +2295,9 @@ cdef class VideoNode(RawNode):
                 fileobj = fileobj.buffer
 
         if progress_update is not None:
-            progress_update(0, len(self))
+            if not callable(progress_update):
+                raise TypeError("progress_update must be a callable")
+            progress_update(0, self.num_frames)
 
         if y4m:
             if self.format.color_family == cfGray:

--- a/src/cython/vshelper.pxd
+++ b/src/cython/vshelper.pxd
@@ -1,0 +1,2 @@
+cdef extern from "include/VSHelper4.h" nogil:
+    void bitblt "vsh::bitblt" (void *dstp, ptrdiff_t dst_stride, const void *srcp, ptrdiff_t src_stride, size_t row_size, size_t height)


### PR DESCRIPTION
This PR optimizes the performance of `VideoNode.output` by moving plane extraction and copy logic entirely to Cython/C.

- Replaced the Python level generator `VideoFrame.readchunks` with native C-API iteration. The function remains available but it's not used anymore.
- Pre-allocates a C buffer and uses a `nogil` `bitblt` to sequentially pack non-contiguous/cropped plane lines, which reduces Python object allocations from thousands of row-level memoryviews to a single view per plane.
- Wraps raw pointers directly into memoryviews using `PyMemoryView_FromMemory`.
- Adds output support for alpha channels.

I ran some benchmarks and for standard contiguous clips, the new implementation provides a 2 % speedup while for cropped/non-contiguous clips, it achieves a massive improvement of ~2.0x to 2.4x speedup.

| Scenario                                   |  Old FPS   |  New FPS   |  Speedup  |
| :----------------------------------------- | :--------: | :--------: | :-------: |
| **Contiguous Planes** (Standard BlankClip) | 12,956 FPS | 13,207 FPS | **1.02x** |
| **Strided/Cropped Planes** (CropRel)       | 2,125 FPS  | 5,069 FPS  | **2.39x** |
| **Contiguous Alpha Channel**               | 7,613 FPS  | 7,756 FPS  | **1.02x** |
| **Strided/Cropped Alpha Channel**          | 1,343 FPS  | 2,731 FPS  | **2.03x** |


