### PR TITLE
VideoFormat: add missing field to `_as_dict` method

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -1162,17 +1162,27 @@ cdef class VideoFormat(object):
 
     def _as_dict(self):
         return {
+            'id': self.id,
+            'name': self.name,
             'color_family': self.color_family,
             'sample_type': self.sample_type,
             'bits_per_sample': self.bits_per_sample,
+            'bytes_per_sample': self.bytes_per_sample,
             'subsampling_w': self.subsampling_w,
-            'subsampling_h': self.subsampling_h
+            'subsampling_h': self.subsampling_h,
+            'num_planes': self.num_planes
         }
 
     def replace(self, **kwargs):
         core = kwargs.pop("core", None) or _get_core()
-        vals = self._as_dict()
-        vals.update(**kwargs)
+        vals = {
+            'color_family': self.color_family,
+            'sample_type': self.sample_type,
+            'bits_per_sample': self.bits_per_sample,
+            'subsampling_w': self.subsampling_w,
+            'subsampling_h': self.subsampling_h,
+            **kwargs,
+        }
         return core.query_video_format(**vals)
 
     def __eq__(self, other):

--- a/src/py/vapoursynth.pyi
+++ b/src/py/vapoursynth.pyi
@@ -843,6 +843,7 @@ class VideoFormat:
 
     def replace(
         self, *,
+        core: Core | _CoreProxy | None = None,
         color_family: Union[ColorFamily, None] = None,
         sample_type: Union[SampleType, None] = None,
         bits_per_sample: Union[int, None] = None,


### PR DESCRIPTION
The `_VideoFormatInfo` TypeDict in the stubs are specifying id, name, bytes_per_sample and num_planes but are not passed at runtime.
Additionally, I fixed the function signature in the stubs by specifying the `core` parameter.