### PR TITLE
Enable frame pool for all operating systems

### DIFF
--- a/src/core/memoryuse.cpp
+++ b/src/core/memoryuse.cpp
@@ -6,10 +6,10 @@
 #include "memoryuse.h"
 #include "VSHelper4.h"
 
-// Only confirmed needed on Windows.
-#ifdef _WIN32
+// Confirmed needed on Windows and Linux, primarily due to the impact
+// of memory fragmentation with default allocators
+// https://github.com/vapoursynth/vapoursynth/issues/1167
 #define USE_FRAME_POOL
-#endif
 
 // Print pool hit/miss stats on exit.
 #if 0


### PR DESCRIPTION
I noticed that this didn't make it into r77, so figured I'd just go ahead and put this PR together for convenience. 

---

This helps avoid memory bloat due to poor memory fragmentation handling by many OS' default allocators.

Ref: https://github.com/vapoursynth/vapoursynth/issues/1167