### PR TITLE
Fix environment validation in use_environment

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -652,7 +652,8 @@ cdef class Local:
 
 
 cdef Environment use_environment(EnvironmentData env):
-    if id is None: raise ValueError("id may not be None.")
+    if env is None:
+        raise ValueError("env may not be None.")
 
     cdef Environment instance = Environment.__new__(Environment)
     instance.env = weakref.ref(env)


### PR DESCRIPTION
Commit ae8f59aec661e1b229132106088a431d541358f1 refactored the parameter from `int id` to `EnvironmentData env` but forgot to update the `id is None` safety check. Since `id` resolved to Python's built-in `id()`, the check was always False.