### PR TITLE
Release the GIL when freeing the core

### DIFF
--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -470,7 +470,8 @@ cdef class EnvironmentPolicyAPI:
         if c is not None:
             if c.core:
                 if c.funcs:
-                    c.funcs.freeCore(c.core)
+                    with nogil:
+                        c.funcs.freeCore(c.core)
                 c.core = NULL
 
         env.core = None
@@ -2986,7 +2987,8 @@ cdef class Core(object):
 
     def __dealloc__(self):
         if self.funcs and self.core != NULL:
-            self.funcs.freeCore(self.core)
+            with nogil:
+                self.funcs.freeCore(self.core)
 
     cdef ensure_valid(self):
         if self.core == NULL:


### PR DESCRIPTION
When releasing the GIL before calling `freeCore()`, this allows the threadpool threads to safely acquire the GIL and finish executing their Python callbacks.

This doesn't fix #1005 though.

Fixes https://github.com/vapoursynth/vapoursynth/issues/853