### PR TITLE
Add AArch64 SIMD kernels (NEON, SVE, SME2) for convolution and byte LUT

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         exclude_file: .codespellignore
         skip: ./src/avfs/include,./src/avisynth/avisynth.h,./src/avisynth/interface.cpp,./src/core/ter-116n.h,./src/core/expr/jitasm.h
-        ignore_words_list: indx
+        ignore_words_list: indx,sme

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,8 @@ x64/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 [Aa][Rr][Mm]64[Ee][Cc]/
+# The VS build-output patterns above must not hide the AArch64 kernel sources.
+!src/core/kernel/arm/
 bld/
 [Oo]bj/
 [Oo]ut/

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project('VapourSynth', 'c', 'cpp', 'cython',
 
 enable_guard_pattern = get_option('enable_guard_pattern')
 enable_x86_asm = get_option('enable_x86_asm')
+enable_arm_asm = get_option('enable_arm_asm')
 
 cxx = meson.get_compiler('cpp')
 
@@ -62,6 +63,10 @@ endif
 
 if not host_cpu_family.startswith('x86')
     enable_x86_asm = false
+endif
+
+if host_cpu_family != 'aarch64'
+    enable_arm_asm = false
 endif
 
 incdir = include_directories('include')
@@ -161,6 +166,95 @@ soversion = is_win ? '' : run_command(
 
 if enable_x86_asm
     add_project_arguments('-DVS_TARGET_CPU_X86', language: ['c', 'cpp'])
+endif
+
+# --- AArch64 SIMD tiers ------------------------------------------------------
+# NEON is the AArch64 baseline and its kernels ride along with the plain filter
+# sources. fp16/dotprod kernels get their own TUs with a raised -march; they are
+# runtime-dispatched. Non-streaming SVE exists only off Apple platforms. SME
+# kernels are compiled in a dedicated TU where every function is
+# __arm_locally_streaming: with +sme enabled the auto-vectoriser may otherwise
+# emit streaming-only SVE in regular functions, which faults outside streaming
+# mode; keeping the whole unit streaming prevents that.
+arm_have_sve = false
+arm_have_sme = false
+arm_have_i8mm = false
+arm_have_fhm = false
+if enable_arm_asm
+    add_project_arguments('-DVS_TARGET_CPU_ARM64', language: ['c', 'cpp'])
+
+    arm_fp16_args = ['-march=armv8.2-a+fp16']
+    arm_dotprod_args = ['-march=armv8.2-a+dotprod']
+    arm_i8mm_args = ['-march=armv8.2-a+i8mm']
+    arm_fhm_args = ['-march=armv8.2-a+fp16+fp16fml']
+    arm_sve_args = ['-march=armv8.2-a+sve']
+    arm_sve_i8mm_args = ['-march=armv8.2-a+sve+i8mm']
+    arm_sme_args = ['-march=armv8.6-a+sme2+sme-i16i64']
+
+    arm_have_i8mm = cxx.compiles('''
+#include <arm_neon.h>
+int32x4_t f(int32x4_t a, uint8x16_t b, int8x16_t c) { return vusdotq_s32(a, b, c); }
+''',
+        args: arm_i8mm_args,
+        name: 'AArch64 i8mm usdot intrinsics',
+    )
+
+    arm_have_fhm = cxx.compiles('''
+#include <arm_neon.h>
+float32x4_t f(float32x4_t r, float16x8_t a, float16x8_t b) { return vfmlalq_low_f16(r, a, b); }
+''',
+        args: arm_fhm_args,
+        name: 'AArch64 fp16fml (FEAT_FHM) intrinsics',
+    )
+
+    arm_have_sve_i8mm = false
+    if host_system != 'darwin'
+        arm_have_sve = cxx.compiles('''
+#include <arm_sve.h>
+svfloat32_t f(svfloat32_t a, svfloat32_t b) { return svmla_f32_x(svptrue_b32(), a, a, b); }
+''',
+            args: arm_sve_args,
+            name: 'AArch64 non-streaming SVE intrinsics',
+        )
+        if arm_have_sve
+            arm_have_sve_i8mm = cxx.compiles('''
+#include <arm_sve.h>
+svint32_t f(svint32_t a, svuint8_t b, svint8_t c) { return svusdot_s32(a, b, c); }
+''',
+                args: arm_sve_i8mm_args,
+                name: 'AArch64 SVE i8mm usdot intrinsics',
+            )
+        endif
+    endif
+
+    arm_have_sme = cxx.compiles('''
+#include <arm_sme.h>
+__arm_locally_streaming __arm_new("za") void f(const int16_t *p) {
+    svbool_t pg = svptrue_b16();
+    svint16_t v = svld1_s16(pg, p);
+    svmopa_za32_s16_m(0, pg, pg, v, v);
+    svmopa_za64_s16_m(0, pg, pg, v, v);
+}
+''',
+        args: arm_sme_args,
+        name: 'AArch64 SME2 streaming intrinsics',
+    )
+
+    if arm_have_i8mm
+        add_project_arguments('-DVS_TARGET_ARM_I8MM', language: ['c', 'cpp'])
+    endif
+    if arm_have_fhm
+        add_project_arguments('-DVS_TARGET_ARM_FHM', language: ['c', 'cpp'])
+    endif
+    if arm_have_sve
+        add_project_arguments('-DVS_TARGET_ARM_SVE', language: ['c', 'cpp'])
+    endif
+    if arm_have_sve_i8mm
+        add_project_arguments('-DVS_TARGET_ARM_SVE_I8MM', language: ['c', 'cpp'])
+    endif
+    if arm_have_sme
+        add_project_arguments('-DVS_TARGET_ARM_SME', language: ['c', 'cpp'])
+    endif
 endif
 
 libvapoursynth = library('libvapoursynth',
@@ -392,10 +486,83 @@ if enable_x86_asm
         )
     endforeach
 else
+    arm_filter_sources = []
+    arm_vlibs = []
+    if enable_arm_asm
+        # NEON is the AArch64 baseline; its kernels ride with the plugin proper.
+        arm_filter_sources += files(
+            'src/core/kernel/arm/convolution_neon.cpp',
+            'src/core/kernel/arm/lut_neon.cpp',
+            'src/core/kernel/arm/square_neon.cpp',
+        )
+        if arm_have_i8mm
+            # usdot byte square conv. Its own TU so the NEON baseline sources are
+            # never built with +i8mm.
+            arm_vlibs += static_library('vsfilters_i8mm',
+                files('src/core/kernel/arm/square_dot_neon.cpp'),
+                cpp_args: arm_i8mm_args,
+                gnu_symbol_visibility: 'hidden',
+                include_directories: incdir,
+            )
+        endif
+        if arm_have_fhm
+            # fmlal widening f16 MAC kernels. Separated so NEON baseline
+            # sources aren't built with +fp16fml.
+            # Kept out of LTO deliberately. Under gcc 13 + -flto, growing this
+            # unit changes how the link re-optimises the UNTOUCHED half
+            # scanlines in convolution_neon.cpp: adding the 1D kernels below
+            # cost half nof16 h25 -10..-13% and hv9 -14..-17% on V1/V2/V3, on
+            # a function whose source never changed (verified in the
+            # disassembly: same source, different codegen). Compiling to real
+            # object code keeps it out of the LTO partition and the regression
+            # disappears (nof16 back to +-0%). It costs the fhm kernels
+            # themselves almost nothing; the squares measure identical to the
+            # LTO build. Only f16 h25 gives up ~3% because they're
+            # self-contained with header inlines as helpers.
+            arm_vlibs += static_library('vsfilters_fhm',
+                files('src/core/kernel/arm/convolution_fhm_neon.cpp'),
+                cpp_args: arm_fhm_args,
+                gnu_symbol_visibility: 'hidden',
+                include_directories: incdir,
+                override_options: ['b_lto=false'],
+            )
+        endif
+        if arm_have_sve
+            arm_vlibs += static_library('vsfilters_sve',
+                files('src/core/kernel/arm/convolution_sve.cpp',
+                      'src/core/kernel/arm/lut_sve.cpp'),
+                cpp_args: arm_sve_args,
+                gnu_symbol_visibility: 'hidden',
+                include_directories: incdir,
+            )
+        endif
+        if arm_have_sve_i8mm
+            # A CPU may have SVE without I8MM (A64FX), so these live apart from
+            # the plain SVE kernels.
+            arm_vlibs += static_library('vsfilters_sve_i8mm',
+                files('src/core/kernel/arm/square_dot_sve.cpp'),
+                cpp_args: arm_sve_i8mm_args,
+                gnu_symbol_visibility: 'hidden',
+                include_directories: incdir,
+            )
+        endif
+        if arm_have_sme
+            # Every function in this TU is __arm_locally_streaming; nothing
+            # else may be compiled with +sme (see the SME notes above).
+            arm_vlibs += static_library('vsfilters_sme',
+                files('src/core/kernel/arm/convolution_sme.cpp'),
+                cpp_args: arm_sme_args,
+                gnu_symbol_visibility: 'hidden',
+                include_directories: incdir,
+            )
+        endif
+    endif
+
     shared_module('libvapoursynthfilters',
-        filters_sources,
+        filters_sources + arm_filter_sources,
         gnu_symbol_visibility: 'hidden',
         include_directories: incdir,
+        link_with: arm_vlibs,
         name_prefix: '',
         install: true,
         install_dir: install_dir,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,9 @@ option('enable_x86_asm',
     value: true,
     description: 'Enable assembler code for x86 CPUs',
 )
+
+option('enable_arm_asm',
+    type: 'boolean',
+    value: true,
+    description: 'Enable SIMD kernels (NEON/SVE/SME) for AArch64 CPUs',
+)

--- a/src/core/cpufeatures.cpp
+++ b/src/core/cpufeatures.cpp
@@ -141,6 +141,97 @@ int doGetX86ABILevel(void) {
     return 4;
 }
 
+#elif defined(VS_TARGET_CPU_ARM64)
+
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+
+static char vs_sysctl_flag(const char *name) {
+    int val = 0;
+    size_t len = sizeof(val);
+    if (sysctlbyname(name, &val, &len, nullptr, 0) != 0)
+        return 0;
+    return !!val;
+}
+
+static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
+    *cpuFeatures = {};
+    cpuFeatures->can_run_vs = 1;
+    cpuFeatures->dotprod = vs_sysctl_flag("hw.optional.arm.FEAT_DotProd");
+    cpuFeatures->fp16 = vs_sysctl_flag("hw.optional.arm.FEAT_FP16");
+    cpuFeatures->fhm = vs_sysctl_flag("hw.optional.arm.FEAT_FHM");
+    cpuFeatures->i8mm = vs_sysctl_flag("hw.optional.arm.FEAT_I8MM");
+    // Apple silicon has no non-streaming SVE; SVE instructions exist only inside
+    // SME streaming mode. Leave sve/sve2 unset so no non-streaming kernel is picked.
+    cpuFeatures->sme = vs_sysctl_flag("hw.optional.arm.FEAT_SME");
+    cpuFeatures->sme2 = vs_sysctl_flag("hw.optional.arm.FEAT_SME2");
+    cpuFeatures->sme_i16i64 = vs_sysctl_flag("hw.optional.arm.FEAT_SME_I16I64");
+    cpuFeatures->sme_f64f64 = vs_sysctl_flag("hw.optional.arm.FEAT_SME_F64F64");
+}
+
+#elif defined(__linux__)
+#include <sys/auxv.h>
+
+/* Bits from linux arch/arm64/include/uapi/asm/hwcap.h; defined here so old
+   toolchain headers don't limit runtime detection. */
+#ifndef HWCAP_FPHP
+#define HWCAP_FPHP (1UL << 9)
+#endif
+#ifndef HWCAP_ASIMDHP
+#define HWCAP_ASIMDHP (1UL << 10)
+#endif
+#ifndef HWCAP_ASIMDDP
+#define HWCAP_ASIMDDP (1UL << 20)
+#endif
+#ifndef HWCAP_ASIMDFHM
+#define HWCAP_ASIMDFHM (1UL << 23)
+#endif
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1UL << 22)
+#endif
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1UL << 1)
+#endif
+#ifndef HWCAP2_I8MM
+#define HWCAP2_I8MM (1UL << 13)
+#endif
+#ifndef HWCAP2_SME
+#define HWCAP2_SME (1UL << 23)
+#endif
+#ifndef HWCAP2_SME_I16I64
+#define HWCAP2_SME_I16I64 (1UL << 24)
+#endif
+#ifndef HWCAP2_SME_F64F64
+#define HWCAP2_SME_F64F64 (1UL << 25)
+#endif
+#ifndef HWCAP2_SME2
+#define HWCAP2_SME2 (1UL << 37)
+#endif
+
+static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
+    *cpuFeatures = {};
+    cpuFeatures->can_run_vs = 1;
+    unsigned long hwcap = getauxval(AT_HWCAP);
+    unsigned long hwcap2 = getauxval(AT_HWCAP2);
+    cpuFeatures->dotprod = !!(hwcap & HWCAP_ASIMDDP);
+    cpuFeatures->fp16 = !!(hwcap & HWCAP_FPHP) && !!(hwcap & HWCAP_ASIMDHP);
+    cpuFeatures->fhm = !!(hwcap & HWCAP_ASIMDFHM);
+    cpuFeatures->i8mm = !!(hwcap2 & HWCAP2_I8MM);
+    cpuFeatures->sve = !!(hwcap & HWCAP_SVE);
+    cpuFeatures->sve2 = !!(hwcap2 & HWCAP2_SVE2);
+    cpuFeatures->sme = !!(hwcap2 & HWCAP2_SME);
+    cpuFeatures->sme2 = !!(hwcap2 & HWCAP2_SME2);
+    cpuFeatures->sme_i16i64 = !!(hwcap2 & HWCAP2_SME_I16I64);
+    cpuFeatures->sme_f64f64 = !!(hwcap2 & HWCAP2_SME_F64F64);
+}
+
+#else
+static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
+    *cpuFeatures = {};
+    cpuFeatures->can_run_vs = 1;
+}
+#endif
+
 #elif defined(VS_TARGET_CPU_RISCV)
 static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
     *cpuFeatures = {};

--- a/src/core/cpufeatures.h
+++ b/src/core/cpufeatures.h
@@ -62,6 +62,18 @@ typedef struct CPUFeatures {
     char vaes;
     char rdseed;
     char avx512;
+#elif defined(VS_TARGET_CPU_ARM64)
+    // On AArch64, NEON (ASIMD) is part of the baseline and always present.
+    char dotprod;     /* FEAT_DotProd: sdot/udot */
+    char fp16;        /* FEAT_FP16: fullfp16 arithmetic */
+    char fhm;         /* FEAT_FHM: fmlal/fmlal2 widening f16 MAC */
+    char i8mm;        /* FEAT_I8MM: usdot/ummla */
+    char sve;         /* FEAT_SVE, non-streaming (not set on Apple silicon) */
+    char sve2;        /* FEAT_SVE2 */
+    char sme;         /* FEAT_SME */
+    char sme2;        /* FEAT_SME2 */
+    char sme_i16i64;  /* FEAT_SME_I16I64: 16-bit int outer products into ZA64 */
+    char sme_f64f64;  /* FEAT_SME_F64F64 */
 #endif
 } CPUFeatures;
 

--- a/src/core/genericfilters.cpp
+++ b/src/core/genericfilters.cpp
@@ -151,6 +151,7 @@ struct GenericDataExtra {
     float bias;
     bool saturate;
     bool conv_int8;   // all coefficients fit int8 -> byte square conv may take the VNNI path
+    bool conv_f16;    // all coefficients survive a round trip through half -> SME FMOPA is lossless
 
     int cpulevel;
 
@@ -534,6 +535,317 @@ static decltype(&vs_generic_3x3_conv_byte_c) genericSelectSSE2(const VSVideoForm
 }
 #endif
 
+#ifdef VS_TARGET_CPU_ARM64
+// The byte square usdot kernels are bit-exact fast paths, valid only when every
+// coefficient fits int8 and the CPU reports i8mm (the ARM analog of convByteVNNI).
+// They are ~2-3.5x the vmlal kernels, which rewrites the SVE and SME byte square
+// policies below -- but only where they actually apply, so wide-coefficient
+// convolutions keep the old (still correct) tier choices.
+#ifdef VS_TARGET_ARM_I8MM
+static bool convByteDot(const GenericData *d) {
+    return d->conv_int8 && getCPUFeatures()->i8mm;
+}
+#else
+static bool convByteDot(const GenericData *) { return false; }
+#endif
+
+// Only the convolution family has hand-written ARM kernels; every other op
+// falls through to the (auto-vectorised) C tier.
+template <GenericOperations op>
+static decltype(&vs_generic_3x3_conv_byte_c) genericSelectNEON(const VSVideoFormat *fi, GenericData *d) {
+    if (op != GenericConvolution)
+        return nullptr;
+
+    if (fi->sampleType == stInteger && fi->bytesPerSample == 1) {
+#ifdef VS_TARGET_ARM_I8MM
+        // usdot folds 4 taps per op with no byte->word widening; bit-exact with
+        // the vmlal kernels, but only valid when every coefficient fits int8.
+        if (convByteDot(d)) {
+            if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+                return vs_generic_3x3_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+                return vs_generic_5x5_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+                return vs_generic_7x7_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+                return vs_generic_9x9_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+                return vs_generic_11x11_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionHorizontal)
+                return vs_generic_1d_conv_h_byte_neon_dot;
+            // Separable runs its vertical half on vmlal and its horizontal half
+            // on usdot; the vertical taps run across rows, so there is no
+            // scanline window for dot to fold there.
+            else if (d->convolution_type == ConvolutionSeparable)
+                return vs_generic_2d_conv_sep_byte_neon_dot;
+        }
+#endif
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_byte_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_byte_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_byte_neon;
+    } else if (fi->sampleType == stInteger && fi->bytesPerSample == 2) {
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_word_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_word_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_word_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_word_neon;
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 4) {
+        // 3x3 float has no NEON kernel: its C tier autovectorises to a tighter
+        // loop (fewer vector ops/px) that NEON cannot beat at a full thread pool
+        // on M4 (0.89x), and the single-thread win it did hold on Neoverse was
+        // not worth carrying a shape that loses on the primary target. It falls
+        // through to the C tier. (See notes/.../3x3-float-diagnosis.md.)
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_float_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_float_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_float_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_float_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_float_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_float_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_float_neon;
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 2) {
+#ifdef VS_TARGET_ARM_FHM
+        // fmlal folds the f16->f32 convert into the MAC; the baseline half
+        // kernels are conversion-bound (3x3 only TIES C). Both fmlal operands
+        // are f16, so the coefficients must narrow exactly -- the SME FMOPA
+        // conv_f16 rule. Covers every half convolution shape: squares, and the
+        // 1D horizontal/vertical/separable scanlines.
+        if (d->conv_f16 && getCPUFeatures()->fhm) {
+            if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+                return vs_generic_3x3_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+                return vs_generic_5x5_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+                return vs_generic_7x7_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+                return vs_generic_9x9_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+                return vs_generic_11x11_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionHorizontal)
+                return vs_generic_1d_conv_h_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionVertical)
+                return vs_generic_1d_conv_v_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSeparable)
+                return vs_generic_2d_conv_sep_half_neon_fhm;
+        }
+#endif
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_half_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_half_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_half_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_half_neon;
+    }
+    return nullptr;
+}
+
+#ifdef VS_TARGET_ARM_SVE
+// The SVE kernels run at 32-bit lane density, so they only beat the NEON
+// kernels when vectors are wider than NEON's 128 bits (Graviton4/Neoverse V2
+// runs SVE2 at 128 bits and loses everywhere; Graviton3 at 256 bits wins the
+// shapes below). Within a wide-vector machine the winners measured on
+// Graviton3 are: integer squares (except word 7x7), float squares >= 9x9,
+// byte horizontal/separable, and word 3x3; vertical 1D and the small float
+// kernels stay on NEON.
+template <GenericOperations op>
+static decltype(&vs_generic_3x3_conv_byte_c) genericSelectSVE(const VSVideoFormat *fi, GenericData *d) {
+    if (op != GenericConvolution)
+        return nullptr;
+
+    if (vs_sve_vector_length() <= 16)
+        return nullptr;
+
+    // svdot_s64 word squares. SDOT folds 4 int16 products into a 64-bit lane, so
+    // its MAC density beats vmlal_s16 at any vector length -- but it accumulates
+    // into 64-bit lanes, so the scale/bias/round/clamp/narrow store is amortised
+    // over only svcntd() outputs (2 at a 128-bit VL, 4 at 256). That store cost is
+    // fixed per output and swamps the MAC saving unless the tap count is high,
+    // which is why this pays only from 7x7 up, and only on wide vectors:
+    //
+    //   Graviton3 (256-bit) vs NEON:  7x7 +17%, 9x9 +39%, 11x11 +57% (1 thread)
+    //                                 3x3 -19%, 5x5 -14%   -> left on the old kernels
+    //   Graviton4 (128-bit) vs NEON:  loses everywhere except 11x11 (parity), so
+    //                                 the VL gate above still sends it to NEON.
+    // 7x7 was a wash (won single-thread, lost contended) once the round-2 NEON
+    // lane-coefficient word squares landed, so it is pruned -> NEON; 9x9/11x11
+    // still win at every pool size.
+    if (fi->sampleType == stInteger && fi->bytesPerSample == 2 && d->convolution_type == ConvolutionSquare) {
+        if (d->matrix_elements == 81)
+            return vs_generic_9x9_conv_word_sve_dot;
+        else if (d->matrix_elements == 121)
+            return vs_generic_11x11_conv_word_sve_dot;
+    }
+
+    if (fi->sampleType == stInteger && fi->bytesPerSample == 1) {
+        // Where the usdot kernels apply they beat the lane-density SVE squares by
+        // ~2x, so those step aside. SVE has its own usdot kernels (2x the outputs
+        // per op at a 256-bit VL); prefer them, and otherwise fall through to the
+        // NEON tier. 3x3 has no SVE usdot kernel, but the NEON dot 3x3 beats the
+        // plain 256-bit SVE kernel anyway (804 vs 609 fps on Graviton3), so it
+        // yields through the nullptr below like everything else.
+        if (convByteDot(d) && d->convolution_type == ConvolutionSquare) {
+#ifdef VS_TARGET_ARM_SVE_I8MM
+            // A thread-count sweep on Graviton3 (SVE/NEON ratio, raw curves in
+            // bench/logs/sve_usdot_thread_sweep_g3.log) split the shapes: 7x7 and
+            // 9x9 win at every pool size (7x7 1.23-1.48x, 9x9 1.10-1.24x, only 9x9
+            // dips to ~0.97 at 16 which is within noise) and take SVE unconditionally.
+            // 5x5 and 11x11 won only while nearly unloaded (5x5 tie by 4t, 11x11 a
+            // loss by 4t), so they were thread-gated -- and have now been pruned:
+            // int8 5x5/11x11 fall through to the NEON usdot squares, which match SVE
+            // at a full pool anyway. usdot has no 3x3 SVE kernel either (NEON dot
+            // wins there, 804 vs 609 fps on Graviton3), so it also yields below.
+            if (d->matrix_elements == 49)
+                return vs_generic_7x7_conv_byte_sve_dot;
+            else if (d->matrix_elements == 81)
+                return vs_generic_9x9_conv_byte_sve_dot;
+#endif
+            return nullptr;
+        }
+
+        // wide-coefficient byte squares: SVE lane density wins through 7x7; 9x9
+        // and 11x11 lost to the round-2 NEON lane-coefficient squares and are
+        // pruned -> NEON. The byte separable path is pruned for the same reason
+        // (the round-2 usdot NEON separable wins).
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_byte_sve;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_byte_sve;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_byte_sve;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            // The NEON usdot h kernel beats the 256-bit SVE one on Graviton3
+            // (388 vs 215 fps, h25 byte int8 1080p t1) -- yield to it when it
+            // applies. Revisit if wider-than-256 SVE hardware ever ships.
+            return convByteDot(d) ? nullptr : vs_generic_1d_conv_h_byte_sve;
+    } else if (fi->sampleType == stInteger && fi->bytesPerSample == 2) {
+        // word 5x5 lost to the round-2 NEON word squares and is pruned; 3x3 still
+        // wins. (9x9/11x11 are served by the svdot block above.)
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_word_sve;
+    }
+    // float SVE squares (9x9/11x11) lost to the round-2 NEON lane-coefficient
+    // float squares on Graviton3 (the only SVE-conv machine), so they are pruned
+    // and float falls through to NEON.
+    return nullptr;
+}
+#endif // VS_TARGET_ARM_SVE
+
+#ifdef VS_TARGET_ARM_SME
+// SME covers the compute-dense shapes where the outer-product unit pays off:
+// the larger square NxN convolutions and vertical 1D.
+//
+// The SME unit is shared per core cluster, so with a full thread pool the
+// aggregate throughput of the cheaper shapes is better on NEON even though SME
+// wins them decisively single-threaded (measured on M4 Max: 5x5 byte 4.1x
+// single-thread vs 0.63x at 16 threads). Those thread-contested shapes were
+// only ever dispatched on tiny thread pools, which are false by default on the
+// only hardware that has SME (hardware_concurrency() is 10-16 on an M4), so
+// they have been pruned entirely and fall back to the NEON tier -- SME only
+// keeps the shapes that win even fully contended: the >= 7x7 squares and the
+// vertical 1D kernels. Byte squares here serve WIDE coefficients only; int8
+// coefficients go to the NEON usdot kernels, which win outright.
+template <GenericOperations op>
+static decltype(&vs_generic_3x3_conv_byte_c) genericSelectSME(const VSVideoFormat *fi, GenericData *d) {
+    if (op != GenericConvolution)
+        return nullptr;
+
+    if (fi->sampleType == stInteger && fi->bytesPerSample == 1) {
+        // int8 coefficients: NEON usdot wins every byte square outright (it scales
+        // per core while SME is a shared per-cluster unit), so yield the squares to
+        // it. The SME byte squares below exist for WIDE coefficients only. Vertical
+        // 1D still takes SME for both coefficient kinds (usdot has no vertical form).
+        if (convByteDot(d) && d->convolution_type == ConvolutionSquare)
+            return nullptr;
+
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_byte_sme;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_byte_sme;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_byte_sme;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_byte_sme;
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 2) {
+        // Native 2-way f16 FMOPA: one outer product folds two source rows, and the
+        // pixels are consumed as f16 with no widening load. It wins the >= 7x7
+        // squares and the vertical kernel on a full pool; 3x3/5x5 half are pruned
+        // (break-even to thread-contested) and fall back to NEON.
+        //
+        // FMOPA takes both operands in f16, so it is only correct to use where the
+        // coefficients survive that narrowing exactly (conv_f16) -- the same rule
+        // the VNNI byte path follows with conv_int8. Otherwise the coefficients
+        // would be silently degraded, which no other tier does, so those clips stay
+        // on NEON and its float32 coefficients. In practice the usual matrices are
+        // integers or dyadic fractions and pass the gate.
+        if (!d->conv_f16)
+            return nullptr;
+
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_half_sme;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_half_sme;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_half_sme;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_half_sme;
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 4) {
+        // float FMOPA wins the >= 7x7 squares and vertical even fully contended;
+        // 3x3/5x5 float are pruned (thread-contested) and fall back to NEON.
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_float_sme;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_float_sme;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_float_sme;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_float_sme;
+    }
+    // word: all SME word kernels were thread-contested and are pruned -> NEON.
+    return nullptr;
+}
+#endif // VS_TARGET_ARM_SME
+#endif // VS_TARGET_CPU_ARM64
+
 template <GenericOperations op>
 static decltype(&vs_generic_3x3_conv_byte_c) genericSelectC(const VSVideoFormat *fi, GenericData *d) {
     if (fi->sampleType == stInteger && fi->bytesPerSample == 1) {
@@ -824,6 +1136,7 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
             float matrix_sumf = 0;
             const double *matrix = vsapi->mapGetFloatArray(in, "matrix", nullptr);
             d->conv_int8 = true;
+            d->conv_f16 = true;
             for (int i = 0; i < d->matrix_elements; i++) {
                 double c = matrix[i];
                 if (!std::isfinite(c))
@@ -840,6 +1153,13 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
                 } else {
                     d->matrixf[i] = static_cast<float>(c);
                 }
+
+                // Kernels that must take their coefficients in a narrower type may
+                // only do so when the value survives the trip exactly -- same rule
+                // conv_int8 applies to the VNNI path. Rounding a coefficient to buy
+                // speed is not on the table.
+                if (halfToFloat(floatToHalf(d->matrixf[i])) != d->matrixf[i])
+                    d->conv_f16 = false;
 
                 matrix_sumf += d->matrixf[i];
             }
@@ -873,6 +1193,19 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
             d->func = genericSelectAVX2<op>(fi, d.get());
         if (!d->func && d->cpulevel >= VS_CPU_LEVEL_SSE2)
             d->func = genericSelectSSE2<op>(fi, d.get());
+#elif defined(VS_TARGET_CPU_ARM64)
+        const CPUFeatures *cpu = getCPUFeatures();
+        (void)cpu;
+#ifdef VS_TARGET_ARM_SME
+        if (cpu->sme2 && d->cpulevel >= VS_CPU_LEVEL_SME)
+            d->func = genericSelectSME<op>(fi, d.get());
+#endif
+#ifdef VS_TARGET_ARM_SVE
+        if (!d->func && cpu->sve && d->cpulevel >= VS_CPU_LEVEL_SVE)
+            d->func = genericSelectSVE<op>(fi, d.get());
+#endif
+        if (!d->func && d->cpulevel >= VS_CPU_LEVEL_NEON)
+            d->func = genericSelectNEON<op>(fi, d.get());
 #endif
         if (!d->func)
             d->func = genericSelectC<op>(fi, d.get());

--- a/src/core/kernel/arm/conv_scalar.h
+++ b/src/core/kernel/arm/conv_scalar.h
@@ -1,0 +1,146 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* Scalar helpers shared by the AArch64 kernel TUs (NEON, SVE, SME). No SIMD
+* includes here: the SME TU is compiled with +sme2 and keeps its non-streaming
+* code free of vector types. These replicate kernel/generic.cpp expressions
+* exactly, so the SIMD kernels' scalar edge columns match the C tier.
+*/
+
+#ifndef ARM_CONV_SCALAR_H
+#define ARM_CONV_SCALAR_H
+
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <type_traits>
+
+namespace {
+
+inline unsigned nc_mirror(int pos, int len)
+{
+    if (pos < 0) pos = -pos - 1;
+    else if (pos >= len) pos = 2 * len - 1 - pos;
+    if (pos < 0) pos = 0;
+    else if (pos >= len) pos = len - 1;
+    return static_cast<unsigned>(pos);
+}
+
+inline float nc_half_to_float(uint16_t bits)
+{
+    __fp16 h;
+    __builtin_memcpy(&h, &bits, sizeof(h));
+    return static_cast<float>(h);
+}
+
+inline uint16_t nc_float_to_half(float x)
+{
+    __fp16 h = static_cast<__fp16>(x);
+    uint16_t bits;
+    __builtin_memcpy(&bits, &h, sizeof(bits));
+    return bits;
+}
+
+// Scalar reference for a single pixel of square NxN convolution; bit-exact
+// with kernel/generic.cpp conv_plane_square (same (tap-column outer, row
+// inner) order, same mirror, same rounding/clamp). Used for edge columns.
+template <class T, class Acc, class Weight, unsigned N>
+inline T nc_sq_scalar_px(const T *const *rows, unsigned j, unsigned S, unsigned W,
+                         const Weight *coeffs, float div, float bias, bool saturate, uint16_t maxval)
+{
+    Acc accum = 0;
+    for (unsigned k = 0; k < N; ++k) {
+        unsigned col = nc_mirror(static_cast<int>(j) + static_cast<int>(k) - static_cast<int>(S), static_cast<int>(W));
+        for (unsigned r = 0; r < N; ++r)
+            accum += coeffs[r * N + k] * static_cast<Acc>(rows[r][col]);
+    }
+    float tmp = static_cast<float>(accum) * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    if constexpr (std::is_integral<T>::value) {
+        float c = std::min(std::max(tmp, 0.0f), static_cast<float>(sizeof(T) == 1 ? 255 : 65535));
+        long v = std::lrint(c);
+        return static_cast<T>(std::min<long>(v, maxval));
+    } else {
+        return static_cast<T>(tmp);
+    }
+}
+
+// Runtime-N variant of nc_sq_scalar_px for kernels that do not template on
+// the matrix size (SME). Identical math and accumulation order.
+template <class T, class Acc, class Weight>
+inline T nc_sq_scalar_px_rt(const T *const *rows, unsigned j, unsigned N, unsigned W,
+                            const Weight *coeffs, float div, float bias, bool saturate, uint16_t maxval)
+{
+    const unsigned S = N / 2;
+    Acc accum = 0;
+    for (unsigned k = 0; k < N; ++k) {
+        unsigned col = nc_mirror(static_cast<int>(j) + static_cast<int>(k) - static_cast<int>(S), static_cast<int>(W));
+        for (unsigned r = 0; r < N; ++r)
+            accum += coeffs[r * N + k] * static_cast<Acc>(rows[r][col]);
+    }
+    float tmp = static_cast<float>(accum) * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    if constexpr (std::is_integral<T>::value) {
+        float c = std::min(std::max(tmp, 0.0f), static_cast<float>(sizeof(T) == 1 ? 255 : 65535));
+        long v = std::lrint(c);
+        return static_cast<T>(std::min<long>(v, maxval));
+    } else {
+        return static_cast<T>(tmp);
+    }
+}
+
+// Runtime-N variant of nc_sq_scalar_px_half (SME does not template on N).
+inline uint16_t nc_sq_scalar_px_half_rt(const uint16_t *const *rows, unsigned j, unsigned N, unsigned W,
+                                        const float *coeffs, float div, float bias, bool saturate)
+{
+    const unsigned S = N / 2;
+    float accum = 0.0f;
+    for (unsigned k = 0; k < N; ++k) {
+        unsigned col = nc_mirror(static_cast<int>(j) + static_cast<int>(k) - static_cast<int>(S), static_cast<int>(W));
+        for (unsigned r = 0; r < N; ++r)
+            accum += coeffs[r * N + k] * nc_half_to_float(rows[r][col]);
+    }
+    float tmp = accum * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    return nc_float_to_half(tmp);
+}
+
+// Scalar edge reference for half (binary16) planes: samples widen to float32
+// for the arithmetic and the result narrows back to half, mirroring the C
+// fallback's HalfOp/conv paths.
+template <unsigned N>
+inline uint16_t nc_sq_scalar_px_half(const uint16_t *const *rows, unsigned j, unsigned S, unsigned W,
+                                     const float *coeffs, float div, float bias, bool saturate)
+{
+    float accum = 0.0f;
+    for (unsigned k = 0; k < N; ++k) {
+        unsigned col = nc_mirror(static_cast<int>(j) + static_cast<int>(k) - static_cast<int>(S), static_cast<int>(W));
+        for (unsigned r = 0; r < N; ++r)
+            accum += coeffs[r * N + k] * nc_half_to_float(rows[r][col]);
+    }
+    float tmp = accum * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    return nc_float_to_half(tmp);
+}
+
+} // namespace
+
+#endif // ARM_CONV_SCALAR_H

--- a/src/core/kernel/arm/convolution_fhm_neon.cpp
+++ b/src/core/kernel/arm/convolution_fhm_neon.cpp
@@ -1,0 +1,514 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* FEAT_FHM half (binary16) convolution: 3x3, NxN squares, and the 1D
+* horizontal/vertical/separable shapes -- fmlal/fmlal2 do the f16->f32
+* widening MAC in one instruction, replacing the fcvtl+fmla pairs of the
+* baseline half path (half_tap16: 2 loads + 4 converts + 4 FMAs per 16 px per
+* tap becomes 2 loads + 4 fmlal). The baseline 3x3 half kernel only ties the
+* autovectorised C tier (1.02-1.07x), and it is conversion-bound, which is
+* exactly what fmlal removes.
+*
+* fmlal takes BOTH operands in f16, so the coefficient must survive f32->f16
+* narrowing exactly -- the same conv_f16 gate the SME FMOPA half kernels use.
+* Under that gate results are identical to the baseline half kernel: the f16
+* product is exact in f32 (11x11-bit significands), and fmlal accumulates it
+* into f32 with a single rounding, the same as vfmaq_f32 on the converted
+* values.
+*
+* Compiled in its own TU with -march=...+fp16+fp16fml (see meson.build); the
+* NEON baseline sources must not be built with +fp16fml.
+*/
+
+#include <cstdint>
+#include <cstring>
+#include "VSHelper4.h"
+#include "../generic.h"
+#include "conv_scalar.h"
+#include "neon_common.h"
+
+namespace {
+
+// Scalar replicate-edge pixel; mirrors conv_plane_3x3_neon's scalar_px for
+// half exactly (same accumulation order, same store expression).
+inline uint16_t h3x3_scalar_px(const uint16_t *const rows[3], const float *coeffs,
+                               unsigned a, unsigned b, unsigned c,
+                               float div, float bias, bool saturate)
+{
+    float accum = 0.0f;
+    for (unsigned r = 0; r < 3; ++r) {
+        accum += coeffs[r * 3 + 0] * nc_half_to_float(rows[r][a]);
+        accum += coeffs[r * 3 + 1] * nc_half_to_float(rows[r][b]);
+        accum += coeffs[r * 3 + 2] * nc_half_to_float(rows[r][c]);
+    }
+    float tmp = accum * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    return nc_float_to_half(tmp);
+}
+
+void conv_plane_3x3_half_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                             const vs_generic_params &p, unsigned width, unsigned height)
+{
+    const float *coeffs = p.matrixf;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    // Both fmlal operands are f16; the dispatch gate (conv_f16) guarantees the
+    // narrowing is exact. Broadcast once per plane, as the float 3x3 does.
+    float16x8_t cf[9];
+    for (unsigned i = 0; i < 9; ++i)
+        cf[i] = vdupq_n_f16(static_cast<float16_t>(coeffs[i]));
+
+    for (unsigned i = 0; i < height; ++i) {
+        unsigned above_idx = i == 0 ? 0 : i - 1;
+        unsigned below_idx = i == height - 1 ? height - 1 : i + 1;
+        const uint16_t *rows[3] = {
+            reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(above_idx) * src_stride),
+            reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(i) * src_stride),
+            reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(below_idx) * src_stride),
+        };
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+
+        dstp[0] = h3x3_scalar_px(rows, coeffs, 0, 0, width > 1 ? 1 : 0, p.div, p.bias, p.saturate);
+
+        unsigned end = width > 1 ? width - 1 : 0;
+        unsigned j = 1;
+        auto block = [&](unsigned jj) {
+            float32x4_t a0 = vdupq_n_f32(0), a1 = vdupq_n_f32(0), a2 = vdupq_n_f32(0), a3 = vdupq_n_f32(0);
+            for (unsigned r = 0; r < 3; ++r) {
+                for (unsigned k = 0; k < 3; ++k) {
+                    const uint16_t *q = rows[r] + jj - 1 + k;
+                    float16x8_t w = cf[r * 3 + k];
+                    float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(q));
+                    float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(q + 8));
+                    a0 = vfmlalq_low_f16(a0, x0, w);
+                    a1 = vfmlalq_high_f16(a1, x0, w);
+                    a2 = vfmlalq_low_f16(a2, x1, w);
+                    a3 = vfmlalq_high_f16(a3, x1, w);
+                }
+            }
+            nc_store_h16x8(dstp + jj, a0, a1, sc, bi, sm);
+            nc_store_h16x8(dstp + jj + 8, a2, a3, sc, bi, sm);
+        };
+        if (end > 1) {
+            for (; j + 16 <= end; j += 16) block(j);
+            if (j < end && end >= 1 + 16) { block(end - 16); j = end; }
+            for (; j < end; ++j)
+                dstp[j] = h3x3_scalar_px(rows, coeffs, j - 1, j, j + 1, p.div, p.bias, p.saturate);
+        }
+
+        if (width > 1)
+            dstp[width - 1] = h3x3_scalar_px(rows, coeffs, width - 2, width - 1, width - 1, p.div, p.bias, p.saturate);
+    }
+}
+
+// ---- half NxN squares (mirror edges, sq_plane semantics), N in {5,7,9,11} ----
+// Same interior as sq_interior_half with the fcvtl+fmla pairs replaced by
+// fmlal; the per-tap coefficient stays a per-tap ld1r dup (hoisting 25+
+// broadcasts is the exact gcc 13.3 spill trap square_neon.cpp documents).
+
+template <unsigned N>
+unsigned sq_interior_half_fhm(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                              const float *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    auto block = [&](unsigned jj) {
+        float32x4_t a0 = vdupq_n_f32(0), a1 = vdupq_n_f32(0), a2 = vdupq_n_f32(0), a3 = vdupq_n_f32(0);
+        for (unsigned r = 0; r < N; ++r) {
+            const uint16_t *row = rows[r] + (jj - S);
+            for (unsigned k = 0; k < N; ++k) {
+                float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(row + k));
+                float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(row + k + 8));
+                float16x8_t w = vdupq_n_f16(static_cast<float16_t>(m[r * N + k]));
+                a0 = vfmlalq_low_f16(a0, x0, w);
+                a1 = vfmlalq_high_f16(a1, x0, w);
+                a2 = vfmlalq_low_f16(a2, x1, w);
+                a3 = vfmlalq_high_f16(a3, x1, w);
+            }
+        }
+        nc_store_h16x8(dst + jj, a0, a1, sc, bi, sm);
+        nc_store_h16x8(dst + jj + 8, a2, a3, sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+template <unsigned N>
+void sq_plane_half_fhm(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                       const vs_generic_params &p, unsigned W, unsigned H)
+{
+    constexpr unsigned S = N / 2;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint16_t *rows[N];
+        for (unsigned r = 0; r < N; ++r)
+            rows[r] = reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) +
+                static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(i) + static_cast<int>(r) - static_cast<int>(S), static_cast<int>(H))) * ss);
+        uint16_t *d = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * ds);
+
+        unsigned aend = sq_interior_half_fhm<N>(rows, d, S, W, p.matrixf, sc, bi, sm);
+
+        for (unsigned j = 0; j < S && j < W; ++j)
+            d[j] = nc_sq_scalar_px_half<N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate);
+        for (unsigned j = (aend > S ? aend : S); j < W; ++j)
+            d[j] = nc_sq_scalar_px_half<N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate);
+    }
+}
+
+// ---- half 1D horizontal / vertical / separable on fmlal ---------------------
+//
+// The fmlal counterpart of convolution_neon.cpp's half h/v/x scanlines, and it
+// mirrors their structure exactly: templated on a compile-time tap count FW
+// (odd 3..25, FW == 0 the runtime fallback), coefficients staged once per
+// scanline in lane form, and taps emitted in GROUPS OF 4 with the group loop
+// left ROLLED. The group size is the load-bearing part -- widening the group
+// past one coefficient vector is what cost the baseline scanlines -10..-20%
+// under gcc 13.3 (see convolution_neon.cpp's cv_lanes comment); fmlal changes
+// the MAC, not the scheduling budget it has to fit in.
+//
+// Edge columns/rows go through the same scalar float code as the baseline, so
+// only the interior changes -- and there the values are identical too, since
+// the conv_f16 gate makes the f16 coefficient equal to the f32 one.
+
+struct fhm_acc16 {
+    float32x4_t a0, a1, a2, a3;
+    void clear() { a0 = a1 = a2 = a3 = vdupq_n_f32(0); }
+};
+
+// fmlal has no widening-multiply form, so unlike the other formats' scanlines
+// there is no first-tap vmul init to skip the zero fill with.
+inline void fhm_tap16(fhm_acc16 &a, const uint16_t *p, float16x8_t w)
+{
+    float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(p));
+    float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(p + 8));
+    a.a0 = vfmlalq_low_f16(a.a0, x0, w);
+    a.a1 = vfmlalq_high_f16(a.a1, x0, w);
+    a.a2 = vfmlalq_low_f16(a.a2, x1, w);
+    a.a3 = vfmlalq_high_f16(a.a3, x1, w);
+}
+
+template <unsigned L>
+inline void fhm_tap16_lane(fhm_acc16 &a, const uint16_t *p, float16x4_t c)
+{
+    float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(p));
+    float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(p + 8));
+    a.a0 = vfmlalq_lane_low_f16(a.a0, x0, c, L);
+    a.a1 = vfmlalq_lane_high_f16(a.a1, x0, c, L);
+    a.a2 = vfmlalq_lane_low_f16(a.a2, x1, c, L);
+    a.a3 = vfmlalq_lane_high_f16(a.a3, x1, c, L);
+}
+
+// 4 f16 coefficients per lane vector; >= 1 vector so the FW == 0 path can still
+// declare the array.
+template <unsigned FW>
+constexpr unsigned fhm_nq() { return FW ? (FW + 3) / 4 : 1; }
+
+template <unsigned FW>
+inline void fhm_stage_coeffs(float16x4_t *cq, const float *m)
+{
+    constexpr unsigned NQ = fhm_nq<FW>();
+    float16_t pad[NQ * 4] = {};
+    for (unsigned i = 0; i < FW; ++i)
+        pad[i] = static_cast<float16_t>(m[i]);
+    for (unsigned i = 0; i < NQ; ++i)
+        cq[i] = vld1_f16(pad + 4 * i);
+}
+
+// CNT taps from one coefficient vector starting at lane L; tap i reads p + i.
+template <unsigned CNT, unsigned L>
+inline void fhm_tap_group_h(fhm_acc16 &a, const uint16_t *p, float16x4_t c)
+{
+    fhm_tap16_lane<L>(a, p + L, c);
+    if constexpr (L + 1 < CNT)
+        fhm_tap_group_h<CNT, L + 1>(a, p, c);
+}
+
+// Same, but tap i reads row pointer srcs[i].
+template <unsigned CNT, unsigned L>
+inline void fhm_tap_group_v(fhm_acc16 &a, const void *const *srcs, unsigned jj, float16x4_t c)
+{
+    fhm_tap16_lane<L>(a, static_cast<const uint16_t *>(srcs[L]) + jj, c);
+    if constexpr (L + 1 < CNT)
+        fhm_tap_group_v<CNT, L + 1>(a, srcs, jj, c);
+}
+
+template <unsigned FW>
+inline void fhm_taps_h(fhm_acc16 &a, const uint16_t *base, const float16x4_t *cq)
+{
+    constexpr unsigned NG = FW / 4;
+    constexpr unsigned TAIL = FW - NG * 4;
+    constexpr unsigned FIRST = FW < 4 ? FW : 4;
+
+    a.clear();
+    fhm_tap_group_h<FIRST, 0>(a, base, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        fhm_tap_group_h<4, 0>(a, base + g * 4, cq[g]);
+    if constexpr (TAIL > 0 && FW > 4)
+        fhm_tap_group_h<TAIL, 0>(a, base + NG * 4, cq[NG]);
+}
+
+template <unsigned FW>
+inline void fhm_taps_v(fhm_acc16 &a, const void *const *srcs, unsigned jj, const float16x4_t *cq)
+{
+    constexpr unsigned NG = FW / 4;
+    constexpr unsigned TAIL = FW - NG * 4;
+    constexpr unsigned FIRST = FW < 4 ? FW : 4;
+
+    a.clear();
+    fhm_tap_group_v<FIRST, 0>(a, srcs, jj, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        fhm_tap_group_v<4, 0>(a, srcs + g * 4, jj, cq[g]);
+    if constexpr (TAIL > 0 && FW > 4)
+        fhm_tap_group_v<TAIL, 0>(a, srcs + NG * 4, jj, cq[NG]);
+}
+
+// Scalar mirror-edge pixel; replicates conv_scanline_h's formulas verbatim, in
+// float with the float coefficients, exactly as the baseline half scanline's
+// conv_h_edge_px<Half> does.
+inline uint16_t fhm_h_edge_px(const uint16_t *srcp, unsigned j, unsigned width, const vs_generic_params &p)
+{
+    const float *coeffs = p.matrixf;
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    unsigned dist_from_right = width - 1 - j;
+
+    float accum = 0.0f;
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned idx = j < support - k ? std::min(support - k - j - 1, width - 1) : j - support + k;
+        accum += coeffs[k] * nc_half_to_float(srcp[idx]);
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned idx = dist_from_right < k - support ? width - std::min(k - support - dist_from_right, width) : j - support + k;
+        accum += coeffs[k] * nc_half_to_float(srcp[idx]);
+    }
+    float tmp = accum * p.div + p.bias;
+    tmp = p.saturate ? tmp : std::fabs(tmp);
+    return nc_float_to_half(tmp);
+}
+
+template <unsigned FW>
+void fhm_h_scanline(const uint16_t *srcp, uint16_t *dstp, unsigned width,
+                    const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    const float *coeffs = p.matrixf;
+    unsigned fwidth = FW ? FW : p.matrixsize;
+    unsigned support = fwidth / 2;
+
+    [[maybe_unused]] float16x4_t cq[fhm_nq<FW>()];
+    if constexpr (FW)
+        fhm_stage_coeffs<FW>(cq, coeffs);
+
+    for (unsigned j = 0; j < std::min(width, support); ++j)
+        dstp[j] = fhm_h_edge_px(srcp, j, width, p);
+
+    unsigned end = width - std::min(width, support);
+    unsigned j = support;
+    auto block = [&](unsigned jj) {
+        fhm_acc16 a;
+        if constexpr (FW) {
+            fhm_taps_h<FW>(a, srcp + jj - support, cq);
+        } else {
+            a.clear();
+            for (unsigned k = 0; k < fwidth; ++k)
+                fhm_tap16(a, srcp + jj - support + k, vdupq_n_f16(static_cast<float16_t>(coeffs[k])));
+        }
+        nc_store_h16x8(dstp + jj, a.a0, a.a1, sc, bi, sm);
+        nc_store_h16x8(dstp + jj + 8, a.a2, a.a3, sc, bi, sm);
+    };
+    if (end > support) {
+        for (; j + 16 <= end; j += 16) block(j);
+        if (j < end && end >= support + 16) { block(end - 16); j = end; }
+        for (; j < end; ++j)
+            dstp[j] = fhm_h_edge_px(srcp, j, width, p);
+    }
+
+    for (unsigned jj = std::max(support, end); jj < width; ++jj)
+        dstp[jj] = fhm_h_edge_px(srcp, jj, width, p);
+}
+
+template <unsigned FW>
+void fhm_v_scanline(const void *const *srcs, uint16_t *dstp, unsigned width,
+                    const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    const float *coeffs = p.matrixf;
+    unsigned fwidth = FW ? FW : p.matrixsize;
+
+    [[maybe_unused]] float16x4_t cq[fhm_nq<FW>()];
+    if constexpr (FW)
+        fhm_stage_coeffs<FW>(cq, coeffs);
+
+    unsigned j = 0;
+    auto block = [&](unsigned jj) {
+        fhm_acc16 a;
+        if constexpr (FW) {
+            fhm_taps_v<FW>(a, srcs, jj, cq);
+        } else {
+            a.clear();
+            for (unsigned k = 0; k < fwidth; ++k)
+                fhm_tap16(a, static_cast<const uint16_t *>(srcs[k]) + jj, vdupq_n_f16(static_cast<float16_t>(coeffs[k])));
+        }
+        nc_store_h16x8(dstp + jj, a.a0, a.a1, sc, bi, sm);
+        nc_store_h16x8(dstp + jj + 8, a.a2, a.a3, sc, bi, sm);
+    };
+    for (; j + 16 <= width; j += 16) block(j);
+    if (j < width && width >= 16) { block(width - 16); j = width; }
+    for (; j < width; ++j) {
+        float accum = 0.0f;
+        for (unsigned k = 0; k < fwidth; ++k)
+            accum += coeffs[k] * nc_half_to_float(static_cast<const uint16_t *>(srcs[k])[j]);
+        float tmp = accum * p.div + p.bias;
+        tmp = p.saturate ? tmp : std::fabs(tmp);
+        dstp[j] = nc_float_to_half(tmp);
+    }
+}
+
+// Mirror row-pointer selection of conv_plane_v / conv_plane_x, verbatim.
+inline void fhm_v_select_rows(const void *src, ptrdiff_t src_stride, const void *srcp[25],
+                              unsigned i, unsigned height, unsigned fwidth)
+{
+    unsigned support = fwidth / 2;
+    unsigned dist_from_bottom = height - 1 - i;
+
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned row = i < support - k ? std::min(support - k - i - 1, height - 1) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned row = dist_from_bottom < k - support ? height - std::min(k - support - dist_from_bottom, i) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+}
+
+template <unsigned FW>
+void fhm_plane_h_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                      const vs_generic_params &p, unsigned width, unsigned height)
+{
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const uint16_t *srcp = reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(i) * src_stride);
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        fhm_h_scanline<FW>(srcp, dstp, width, p, sc, bi, sm);
+    }
+}
+
+template <unsigned FW>
+void fhm_plane_v_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                      const vs_generic_params &p, unsigned width, unsigned height)
+{
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        fhm_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        fhm_v_scanline<FW>(srcp, dstp, width, p, sc, bi, sm);
+    }
+}
+
+// Separable: both halves are half-format, so unlike the byte separable (whose
+// vertical half stays on vmlal and calls an exported usdot scanline for the
+// horizontal half) the whole driver lives here and inlines both fmlal
+// scanlines. Quantises through a plane-typed tmp scanline, like conv_plane_x.
+template <unsigned FW>
+void fhm_plane_x_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                      const vs_generic_params &p, unsigned width, unsigned height)
+{
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    uint16_t *tmp = static_cast<uint16_t *>(vsh::vsh_aligned_malloc(width * sizeof(uint16_t), 64));
+    if (!tmp) {
+        // Deterministic zeros rather than whatever the frame allocator handed
+        // out; see conv_plane_x_impl.
+        for (unsigned i = 0; i < height; ++i)
+            std::memset(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride, 0, width * sizeof(uint16_t));
+        return;
+    }
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        fhm_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        fhm_v_scanline<FW>(srcp, tmp, width, p, sc, bi, sm);
+        fhm_h_scanline<FW>(tmp, dstp, width, p, sc, bi, sm);
+    }
+
+    vsh::vsh_aligned_free(tmp);
+}
+
+// Same tap-count switch as convolution_neon.cpp's VS_CONV_PLANE_SELECT: runs
+// once per plane, FW = 0 kept reachable as the correctness fallback for any
+// shape not enumerated here.
+#define VS_FHM_PLANE_SELECT(dir)                                                                    \
+void fhm_plane_##dir(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,        \
+                     const vs_generic_params &p, unsigned width, unsigned height)                   \
+{                                                                                                   \
+    switch (p.matrixsize) {                                                                         \
+    case 3:  return fhm_plane_##dir##_impl<3>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 5:  return fhm_plane_##dir##_impl<5>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 7:  return fhm_plane_##dir##_impl<7>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 9:  return fhm_plane_##dir##_impl<9>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 11: return fhm_plane_##dir##_impl<11>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 13: return fhm_plane_##dir##_impl<13>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 15: return fhm_plane_##dir##_impl<15>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 17: return fhm_plane_##dir##_impl<17>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 19: return fhm_plane_##dir##_impl<19>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 21: return fhm_plane_##dir##_impl<21>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 23: return fhm_plane_##dir##_impl<23>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 25: return fhm_plane_##dir##_impl<25>(src, src_stride, dst, dst_stride, p, width, height); \
+    default: return fhm_plane_##dir##_impl<0>(src, src_stride, dst, dst_stride, p, width, height);  \
+    }                                                                                               \
+}
+
+VS_FHM_PLANE_SELECT(h)
+VS_FHM_PLANE_SELECT(v)
+VS_FHM_PLANE_SELECT(x)
+
+} // namespace
+
+void vs_generic_1d_conv_h_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ fhm_plane_h(src, src_stride, dst, dst_stride, *params, width, height); }
+
+void vs_generic_1d_conv_v_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ fhm_plane_v(src, src_stride, dst, dst_stride, *params, width, height); }
+
+void vs_generic_2d_conv_sep_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ fhm_plane_x(src, src_stride, dst, dst_stride, *params, width, height); }
+
+void vs_generic_3x3_conv_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{
+    conv_plane_3x3_half_fhm(src, src_stride, dst, dst_stride, *params, width, height);
+}
+
+#define VS_SQUARE_FHM_ENTRY(SZ, N) \
+    void vs_generic_##SZ##_conv_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sq_plane_half_fhm<N>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SQUARE_FHM_ENTRY(5x5, 5)
+VS_SQUARE_FHM_ENTRY(7x7, 7)
+VS_SQUARE_FHM_ENTRY(9x9, 9)
+VS_SQUARE_FHM_ENTRY(11x11, 11)

--- a/src/core/kernel/arm/convolution_neon.cpp
+++ b/src/core/kernel/arm/convolution_neon.cpp
@@ -1,0 +1,901 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* NEON 1D (horizontal/vertical/separable) and 3x3 square convolution.
+*
+* Semantics track kernel/generic.cpp exactly:
+*  - 1D edges use the half-sample mirror formulas of conv_scanline_h /
+*    conv_plane_v (replicated verbatim in the scalar edge paths).
+*  - 3x3 uses replicate edges (filter_plane_3x3 row/column selection).
+*  - The separable path quantises the vertical pass into a plane-typed tmp
+*    scanline before the horizontal pass, like conv_plane_x.
+*
+* Integer accumulation:
+*  - byte: u8 widens to s16, per-tap vmlal_s16 into int32. 25 * 1023 * 255
+*    never overflows. Bit-exact with the int32 C reference.
+*  - word: u16 biased by INT16_MIN into s16; biased worst case
+*    25 * 1023 * 32768 fits int32, and the coefficient*bias sum is subtracted
+*    afterwards. int32 wraparound arithmetic makes this exact, so results are
+*    bit-exact with the (unbiased) int32 C reference.
+*  - float/half: FMA, not bit-exact with C (allowed for float formats).
+*/
+
+#include <cstdint>
+#include <cstring>
+#include "VSHelper4.h"
+#include "../generic.h"
+#include "neon_common.h"
+
+namespace {
+
+enum class CvType { Byte, Word, Float, Half };
+
+template <CvType TY>
+struct cv_traits;
+
+template <> struct cv_traits<CvType::Byte>  { typedef uint8_t T; typedef int32_t Acc; typedef int16_t Weight; };
+template <> struct cv_traits<CvType::Word>  { typedef uint16_t T; typedef int32_t Acc; typedef int16_t Weight; };
+template <> struct cv_traits<CvType::Float> { typedef float T; typedef float Acc; typedef float Weight; };
+template <> struct cv_traits<CvType::Half>  { typedef uint16_t T; typedef float Acc; typedef float Weight; };
+
+template <CvType TY>
+inline const typename cv_traits<TY>::Weight *cv_coeffs(const vs_generic_params &p)
+{
+    if constexpr (TY == CvType::Byte || TY == CvType::Word)
+        return p.matrix;
+    else
+        return p.matrixf;
+}
+
+template <CvType TY>
+inline typename cv_traits<TY>::Acc cv_sample(typename cv_traits<TY>::T x)
+{
+    if constexpr (TY == CvType::Half)
+        return nc_half_to_float(x);
+    else
+        return static_cast<typename cv_traits<TY>::Acc>(x);
+}
+
+// Final scalar store; matches limit(xrint<T>(tmp), maxval) in the C reference.
+template <CvType TY>
+inline typename cv_traits<TY>::T cv_scalar_store(float accum, float div, float bias, bool saturate, uint16_t maxval)
+{
+    float tmp = accum * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    if constexpr (TY == CvType::Byte) {
+        float c = std::min(std::max(tmp, 0.0f), 255.0f);
+        long v = std::lrint(c);
+        return static_cast<uint8_t>(std::min<long>(v, maxval));
+    } else if constexpr (TY == CvType::Word) {
+        float c = std::min(std::max(tmp, 0.0f), 65535.0f);
+        long v = std::lrint(c);
+        return static_cast<uint16_t>(std::min<long>(v, maxval));
+    } else if constexpr (TY == CvType::Float) {
+        return tmp;
+    } else {
+        return nc_float_to_half(tmp);
+    }
+}
+
+// ---- vectorised tap accumulation over one 16-pixel block --------------------
+// Each *_tap16 accumulates coefficient k of a row pointer into 4 chains.
+
+struct acc16_i32 {
+    int32x4_t a0, a1, a2, a3;
+    void clear() { a0 = a1 = a2 = a3 = vdupq_n_s32(0); }
+};
+
+struct acc16_f32 {
+    float32x4_t a0, a1, a2, a3;
+    void clear() { a0 = a1 = a2 = a3 = vdupq_n_f32(0); }
+};
+
+inline void byte_tap16(acc16_i32 &a, const uint8_t *p, int16_t w)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmlal_s16(a.a0, vget_low_s16(x.lo), wv);
+    a.a1 = vmlal_s16(a.a1, vget_high_s16(x.lo), wv);
+    a.a2 = vmlal_s16(a.a2, vget_low_s16(x.hi), wv);
+    a.a3 = vmlal_s16(a.a3, vget_high_s16(x.hi), wv);
+}
+
+inline void word_tap16(acc16_i32 &a, const uint16_t *p, int16_t w)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmlal_s16(a.a0, vget_low_s16(x0), wv);
+    a.a1 = vmlal_s16(a.a1, vget_high_s16(x0), wv);
+    a.a2 = vmlal_s16(a.a2, vget_low_s16(x1), wv);
+    a.a3 = vmlal_s16(a.a3, vget_high_s16(x1), wv);
+}
+
+inline void float_tap16(acc16_f32 &a, const float *p, float w)
+{
+    float32x4_t wv = vdupq_n_f32(w);
+    a.a0 = vfmaq_f32(a.a0, vld1q_f32(p), wv);
+    a.a1 = vfmaq_f32(a.a1, vld1q_f32(p + 4), wv);
+    a.a2 = vfmaq_f32(a.a2, vld1q_f32(p + 8), wv);
+    a.a3 = vfmaq_f32(a.a3, vld1q_f32(p + 12), wv);
+}
+
+inline void half_tap16(acc16_f32 &a, const uint16_t *p, float w)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    float32x4_t wv = vdupq_n_f32(w);
+    a.a0 = vfmaq_f32(a.a0, x0.lo, wv);
+    a.a1 = vfmaq_f32(a.a1, x0.hi, wv);
+    a.a2 = vfmaq_f32(a.a2, x1.lo, wv);
+    a.a3 = vfmaq_f32(a.a3, x1.hi, wv);
+}
+
+// First tap of a block: plain multiply instead of clear() + accumulate. The
+// autovectorised C tier starts its chain with fmul, so a zero-init mov per
+// accumulator is density we pay and it does not. Bit-exact for the integer
+// forms (0 + x*w == x*w) and value-identical for float/half.
+
+inline void byte_tap16_init(acc16_i32 &a, const uint8_t *p, int16_t w)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmull_s16(vget_low_s16(x.lo), wv);
+    a.a1 = vmull_s16(vget_high_s16(x.lo), wv);
+    a.a2 = vmull_s16(vget_low_s16(x.hi), wv);
+    a.a3 = vmull_s16(vget_high_s16(x.hi), wv);
+}
+
+inline void word_tap16_init(acc16_i32 &a, const uint16_t *p, int16_t w)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmull_s16(vget_low_s16(x0), wv);
+    a.a1 = vmull_s16(vget_high_s16(x0), wv);
+    a.a2 = vmull_s16(vget_low_s16(x1), wv);
+    a.a3 = vmull_s16(vget_high_s16(x1), wv);
+}
+
+inline void float_tap16_init(acc16_f32 &a, const float *p, float32x4_t wv)
+{
+    a.a0 = vmulq_f32(vld1q_f32(p), wv);
+    a.a1 = vmulq_f32(vld1q_f32(p + 4), wv);
+    a.a2 = vmulq_f32(vld1q_f32(p + 8), wv);
+    a.a3 = vmulq_f32(vld1q_f32(p + 12), wv);
+}
+
+inline void half_tap16_init(acc16_f32 &a, const uint16_t *p, float w)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    float32x4_t wv = vdupq_n_f32(w);
+    a.a0 = vmulq_f32(x0.lo, wv);
+    a.a1 = vmulq_f32(x0.hi, wv);
+    a.a2 = vmulq_f32(x1.lo, wv);
+    a.a3 = vmulq_f32(x1.hi, wv);
+}
+
+template <CvType TY>
+inline void store16(typename cv_traits<TY>::T *dst,
+                    typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                    int32_t wb, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    if constexpr (TY == CvType::Byte) {
+        nc_store_u8x8(dst, a.a0, a.a1, sc, bi, sm);
+        nc_store_u8x8(dst + 8, a.a2, a.a3, sc, bi, sm);
+    } else if constexpr (TY == CvType::Word) {
+        int32x4_t wbv = vdupq_n_s32(wb);
+        nc_store_u16x8(dst, vsubq_s32(a.a0, wbv), vsubq_s32(a.a1, wbv), sc, bi, sm, mv);
+        nc_store_u16x8(dst + 8, vsubq_s32(a.a2, wbv), vsubq_s32(a.a3, wbv), sc, bi, sm, mv);
+    } else if constexpr (TY == CvType::Float) {
+        nc_store_f32x4(dst, a.a0, sc, bi, sm);
+        nc_store_f32x4(dst + 4, a.a1, sc, bi, sm);
+        nc_store_f32x4(dst + 8, a.a2, sc, bi, sm);
+        nc_store_f32x4(dst + 12, a.a3, sc, bi, sm);
+    } else {
+        nc_store_h16x8(dst, a.a0, a.a1, sc, bi, sm);
+        nc_store_h16x8(dst + 8, a.a2, a.a3, sc, bi, sm);
+    }
+}
+
+template <CvType TY>
+inline void tap16(typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                  const typename cv_traits<TY>::T *p, typename cv_traits<TY>::Weight w)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16(a, p, w);
+    else if constexpr (TY == CvType::Word)
+        word_tap16(a, p, w);
+    else if constexpr (TY == CvType::Float)
+        float_tap16(a, p, w);
+    else
+        half_tap16(a, p, w);
+}
+
+template <CvType TY>
+inline void tap16_init(typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                       const typename cv_traits<TY>::T *p, typename cv_traits<TY>::Weight w)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16_init(a, p, w);
+    else if constexpr (TY == CvType::Word)
+        word_tap16_init(a, p, w);
+    else if constexpr (TY == CvType::Float)
+        float_tap16_init(a, p, vdupq_n_f32(w));
+    else
+        half_tap16_init(a, p, w);
+}
+
+// ---- compile-time tap counts + lane-form coefficients -----------------------
+//
+// With a runtime fwidth the tap loop reloads and re-broadcasts coeffs[k] every
+// tap (an `ld1r` per tap; the compiler cannot hoist it, since p.matrix is
+// caller memory the dstp stores may alias) and pays loop overhead per tap on
+// top. Templating fwidth makes the count compile-time, which both unrolls the
+// loop and lets coefficients live in register lanes instead.
+//
+// Taps are emitted in GROUPS of one coefficient vector (8 int16 lanes / 4 f32
+// lanes) with the group loop left ROLLED. That cap is deliberate: the square
+// kernels measured -35..-47% under gcc 13.3 when all N*N taps were unrolled
+// against a fully staged matrix, because the scheduler hoists every tap's
+// loads to the top of the block and spills (see square_neon.cpp). x86 caps the
+// same way, at 13 taps per pass (VS_CONV_SELECT / conv_scanline_*_pass).
+// For fwidth <= 8 (int) or <= 4 (float) there is exactly one group, so small
+// filters still unroll completely.
+//
+// Bit-exact: the lane forms compute the same MLA/FMA as a dup'd scalar, tap
+// order is unchanged, and tap 0 keeps the vmull/vmul first-tap init.
+
+// 4 taps per group for every type. Integer coefficients could hold 8 lanes in
+// an int16x8_t, but an 8-tap group measured WORSE under gcc 13.3 on exactly
+// the horizontal integer shapes (word h25 -10..-20%, separable byte/word
+// hv9 -4..-18% on V1/V2/V3) while float/half -- which only ever had 4 lanes --
+// won everywhere. Same unroll-cap lesson as the squares, one level finer.
+template <CvType TY>
+constexpr unsigned cv_lanes() { return 4; }
+
+template <CvType TY>
+using cv_cvec = typename std::conditional<TY == CvType::Byte || TY == CvType::Word, int16x4_t, float32x4_t>::type;
+
+template <CvType TY>
+using cv_acc = typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type;
+
+template <unsigned L>
+inline void byte_tap16_lane(acc16_i32 &a, const uint8_t *p, int16x4_t c)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    a.a0 = vmlal_lane_s16(a.a0, vget_low_s16(x.lo), c, L);
+    a.a1 = vmlal_lane_s16(a.a1, vget_high_s16(x.lo), c, L);
+    a.a2 = vmlal_lane_s16(a.a2, vget_low_s16(x.hi), c, L);
+    a.a3 = vmlal_lane_s16(a.a3, vget_high_s16(x.hi), c, L);
+}
+
+template <unsigned L>
+inline void word_tap16_lane(acc16_i32 &a, const uint16_t *p, int16x4_t c)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    a.a0 = vmlal_lane_s16(a.a0, vget_low_s16(x0), c, L);
+    a.a1 = vmlal_lane_s16(a.a1, vget_high_s16(x0), c, L);
+    a.a2 = vmlal_lane_s16(a.a2, vget_low_s16(x1), c, L);
+    a.a3 = vmlal_lane_s16(a.a3, vget_high_s16(x1), c, L);
+}
+
+template <unsigned L>
+inline void float_tap16_lane(acc16_f32 &a, const float *p, float32x4_t c)
+{
+    a.a0 = vfmaq_laneq_f32(a.a0, vld1q_f32(p), c, L);
+    a.a1 = vfmaq_laneq_f32(a.a1, vld1q_f32(p + 4), c, L);
+    a.a2 = vfmaq_laneq_f32(a.a2, vld1q_f32(p + 8), c, L);
+    a.a3 = vfmaq_laneq_f32(a.a3, vld1q_f32(p + 12), c, L);
+}
+
+template <unsigned L>
+inline void half_tap16_lane(acc16_f32 &a, const uint16_t *p, float32x4_t c)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    a.a0 = vfmaq_laneq_f32(a.a0, x0.lo, c, L);
+    a.a1 = vfmaq_laneq_f32(a.a1, x0.hi, c, L);
+    a.a2 = vfmaq_laneq_f32(a.a2, x1.lo, c, L);
+    a.a3 = vfmaq_laneq_f32(a.a3, x1.hi, c, L);
+}
+
+template <unsigned L>
+inline void byte_tap16_init_lane(acc16_i32 &a, const uint8_t *p, int16x4_t c)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    a.a0 = vmull_lane_s16(vget_low_s16(x.lo), c, L);
+    a.a1 = vmull_lane_s16(vget_high_s16(x.lo), c, L);
+    a.a2 = vmull_lane_s16(vget_low_s16(x.hi), c, L);
+    a.a3 = vmull_lane_s16(vget_high_s16(x.hi), c, L);
+}
+
+template <unsigned L>
+inline void word_tap16_init_lane(acc16_i32 &a, const uint16_t *p, int16x4_t c)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    a.a0 = vmull_lane_s16(vget_low_s16(x0), c, L);
+    a.a1 = vmull_lane_s16(vget_high_s16(x0), c, L);
+    a.a2 = vmull_lane_s16(vget_low_s16(x1), c, L);
+    a.a3 = vmull_lane_s16(vget_high_s16(x1), c, L);
+}
+
+template <unsigned L>
+inline void float_tap16_init_lane(acc16_f32 &a, const float *p, float32x4_t c)
+{
+    a.a0 = vmulq_laneq_f32(vld1q_f32(p), c, L);
+    a.a1 = vmulq_laneq_f32(vld1q_f32(p + 4), c, L);
+    a.a2 = vmulq_laneq_f32(vld1q_f32(p + 8), c, L);
+    a.a3 = vmulq_laneq_f32(vld1q_f32(p + 12), c, L);
+}
+
+template <unsigned L>
+inline void half_tap16_init_lane(acc16_f32 &a, const uint16_t *p, float32x4_t c)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    a.a0 = vmulq_laneq_f32(x0.lo, c, L);
+    a.a1 = vmulq_laneq_f32(x0.hi, c, L);
+    a.a2 = vmulq_laneq_f32(x1.lo, c, L);
+    a.a3 = vmulq_laneq_f32(x1.hi, c, L);
+}
+
+template <CvType TY, unsigned L>
+inline void tap16_lane(cv_acc<TY> &a, const typename cv_traits<TY>::T *p, cv_cvec<TY> c)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Word)
+        word_tap16_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Float)
+        float_tap16_lane<L>(a, p, c);
+    else
+        half_tap16_lane<L>(a, p, c);
+}
+
+template <CvType TY, unsigned L>
+inline void tap16_init_lane(cv_acc<TY> &a, const typename cv_traits<TY>::T *p, cv_cvec<TY> c)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16_init_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Word)
+        word_tap16_init_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Float)
+        float_tap16_init_lane<L>(a, p, c);
+    else
+        half_tap16_init_lane<L>(a, p, c);
+}
+
+// Number of coefficient vectors for FW taps (>= 1 so the FW == 0 runtime path
+// can still declare the array).
+template <CvType TY, unsigned FW>
+constexpr unsigned cv_nq() { return FW ? (FW + cv_lanes<TY>() - 1) / cv_lanes<TY>() : 1; }
+
+template <CvType TY, unsigned FW>
+inline void stage_coeffs(cv_cvec<TY> *cq, const typename cv_traits<TY>::Weight *m)
+{
+    constexpr unsigned G = cv_lanes<TY>();
+    constexpr unsigned NQ = cv_nq<TY, FW>();
+    typename cv_traits<TY>::Weight pad[NQ * G] = {};
+    for (unsigned i = 0; i < FW; ++i)
+        pad[i] = m[i];
+    for (unsigned i = 0; i < NQ; ++i) {
+        if constexpr (TY == CvType::Byte || TY == CvType::Word)
+            cq[i] = vld1_s16(pad + 4 * i);
+        else
+            cq[i] = vld1q_f32(pad + 4 * i);
+    }
+}
+
+// CNT taps from one coefficient vector, starting at lane L. Contiguous source
+// (horizontal / separable): tap i reads p + i.
+template <CvType TY, unsigned CNT, unsigned L>
+inline void tap_group_h(cv_acc<TY> &a, const typename cv_traits<TY>::T *p, cv_cvec<TY> c)
+{
+    tap16_lane<TY, L>(a, p + L, c);
+    if constexpr (L + 1 < CNT)
+        tap_group_h<TY, CNT, L + 1>(a, p, c);
+}
+
+// Same, but tap i reads row pointer srcs[i] (vertical).
+template <CvType TY, unsigned CNT, unsigned L>
+inline void tap_group_v(cv_acc<TY> &a, const void *const *srcs, unsigned jj, cv_cvec<TY> c)
+{
+    tap16_lane<TY, L>(a, static_cast<const typename cv_traits<TY>::T *>(srcs[L]) + jj, c);
+    if constexpr (L + 1 < CNT)
+        tap_group_v<TY, CNT, L + 1>(a, srcs, jj, c);
+}
+
+// All FW taps: group 0 (init + rest), rolled middle groups, compile-time tail.
+template <CvType TY, unsigned FW>
+inline void conv_taps_h(cv_acc<TY> &a, const typename cv_traits<TY>::T *base, const cv_cvec<TY> *cq)
+{
+    constexpr unsigned G = cv_lanes<TY>();
+    constexpr unsigned NG = FW / G;
+    constexpr unsigned TAIL = FW - NG * G;
+    constexpr unsigned FIRST = FW < G ? FW : G;
+
+    tap16_init_lane<TY, 0>(a, base, cq[0]);
+    if constexpr (FIRST > 1)
+        tap_group_h<TY, FIRST, 1>(a, base, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        tap_group_h<TY, G, 0>(a, base + g * G, cq[g]);
+    if constexpr (TAIL > 0 && FW > G)
+        tap_group_h<TY, TAIL, 0>(a, base + NG * G, cq[NG]);
+}
+
+template <CvType TY, unsigned FW>
+inline void conv_taps_v(cv_acc<TY> &a, const void *const *srcs, unsigned jj, const cv_cvec<TY> *cq)
+{
+    constexpr unsigned G = cv_lanes<TY>();
+    constexpr unsigned NG = FW / G;
+    constexpr unsigned TAIL = FW - NG * G;
+    constexpr unsigned FIRST = FW < G ? FW : G;
+
+    tap16_init_lane<TY, 0>(a, static_cast<const typename cv_traits<TY>::T *>(srcs[0]) + jj, cq[0]);
+    if constexpr (FIRST > 1)
+        tap_group_v<TY, FIRST, 1>(a, srcs, jj, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        tap_group_v<TY, G, 0>(a, srcs + g * G, jj, cq[g]);
+    if constexpr (TAIL > 0 && FW > G)
+        tap_group_v<TY, TAIL, 0>(a, srcs + NG * G, jj, cq[NG]);
+}
+
+// store16, minus the fabs mask when it is a guaranteed no-op. The C tier
+// unswitches saturate into masked/unmasked loop copies; matching it costs one
+// predictable branch per block instead of 4 no-op ands. Float only: the mask
+// is a smaller fraction of the integer/half store pipelines.
+//
+// GATED ON !__clang__: measured +2% (3x3) / +3.5% (h25) float on
+// Neoverse-V3 gcc 13.3, but -4.5% (3x3) / -11% (5x5, since reverted) on
+// Apple M4 clang 17 -- the branch defeats clang's store scheduling, while its
+// branchless masked store was already fine. Same one-compiler story as
+// VS_SQ_FLOAT_HOIST in square_neon.cpp, opposite direction.
+template <CvType TY>
+inline void store16_sat(typename cv_traits<TY>::T *dst,
+                        typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                        [[maybe_unused]] bool saturate, int32_t wb, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+#if !defined(__clang__)
+    if constexpr (TY == CvType::Float) {
+        if (saturate) {
+            vst1q_f32(dst, vfmaq_f32(bi, a.a0, sc));
+            vst1q_f32(dst + 4, vfmaq_f32(bi, a.a1, sc));
+            vst1q_f32(dst + 8, vfmaq_f32(bi, a.a2, sc));
+            vst1q_f32(dst + 12, vfmaq_f32(bi, a.a3, sc));
+            return;
+        }
+    }
+#endif
+    store16<TY>(dst, a, wb, sc, bi, sm, mv);
+}
+
+// Sum of coeff * INT16_MIN over the taps in use; subtracted from biased word
+// accumulators before the store. Zero for the other formats.
+template <CvType TY>
+inline int32_t word_bias_sum(const typename cv_traits<TY>::Weight *coeffs, unsigned n)
+{
+    if constexpr (TY == CvType::Word) {
+        int32_t wb = 0;
+        for (unsigned i = 0; i < n; ++i)
+            wb += static_cast<int32_t>(INT16_MIN) * coeffs[i];
+        return wb;
+    } else {
+        (void)coeffs; (void)n;
+        return 0;
+    }
+}
+
+// ---- 1D horizontal ----------------------------------------------------------
+
+// Scalar mirror-edge pixel; replicates the conv_scanline_h formulas verbatim.
+template <CvType TY>
+inline typename cv_traits<TY>::T conv_h_edge_px(const typename cv_traits<TY>::T *srcp, unsigned j, unsigned width,
+                                                const vs_generic_params &p)
+{
+    typedef typename cv_traits<TY>::Acc Acc;
+    const auto *coeffs = cv_coeffs<TY>(p);
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    unsigned dist_from_right = width - 1 - j;
+
+    Acc accum = 0;
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned idx = j < support - k ? std::min(support - k - j - 1, width - 1) : j - support + k;
+        accum += coeffs[k] * cv_sample<TY>(srcp[idx]);
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned idx = dist_from_right < k - support ? width - std::min(k - support - dist_from_right, width) : j - support + k;
+        accum += coeffs[k] * cv_sample<TY>(srcp[idx]);
+    }
+    return cv_scalar_store<TY>(static_cast<float>(accum), p.div, p.bias, p.saturate, p.maxval);
+}
+
+// FW == 0 keeps the runtime-fwidth loop (the fallback for tap counts the
+// dispatch below does not instantiate); FW > 0 is the templated form.
+template <CvType TY, unsigned FW = 0>
+void conv_h_scanline(const typename cv_traits<TY>::T *srcp, typename cv_traits<TY>::T *dstp, unsigned width,
+                     const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv, int32_t wb)
+{
+    const auto *coeffs = cv_coeffs<TY>(p);
+    unsigned fwidth = FW ? FW : p.matrixsize;
+    unsigned support = fwidth / 2;
+    // Local copy: p is caller memory, so reading p.saturate inside the block
+    // would reload (and branch on) it every 16 pixels -- the optimizer cannot
+    // hoist it past the dstp stores it might alias.
+    const bool satur = p.saturate != 0;
+
+    // Same reason: staged once here, not re-read per tap inside the block.
+    [[maybe_unused]] cv_cvec<TY> cq[cv_nq<TY, FW>()];
+    if constexpr (FW)
+        stage_coeffs<TY, FW>(cq, coeffs);
+
+    for (unsigned j = 0; j < std::min(width, support); ++j)
+        dstp[j] = conv_h_edge_px<TY>(srcp, j, width, p);
+
+    unsigned end = width - std::min(width, support);
+    unsigned j = support;
+    auto block = [&](unsigned jj) {
+        cv_acc<TY> a;
+        if constexpr (FW) {
+            conv_taps_h<TY, FW>(a, srcp + jj - support, cq);
+        } else {
+            tap16_init<TY>(a, srcp + jj - support, coeffs[0]);
+            for (unsigned k = 1; k < fwidth; ++k)
+                tap16<TY>(a, srcp + jj - support + k, coeffs[k]);
+        }
+        store16_sat<TY>(dstp + jj, a, satur, wb, sc, bi, sm, mv);
+    };
+    if (end > support) {
+        for (; j + 16 <= end; j += 16) block(j);
+        if (j < end && end >= support + 16) { block(end - 16); j = end; }
+        for (; j < end; ++j)
+            dstp[j] = conv_h_edge_px<TY>(srcp, j, width, p);
+    }
+
+    for (unsigned jj = std::max(support, end); jj < width; ++jj)
+        dstp[jj] = conv_h_edge_px<TY>(srcp, jj, width, p);
+}
+
+// ---- 1D vertical --------------------------------------------------------------
+
+template <CvType TY, unsigned FW = 0>
+void conv_v_scanline(const void *const *srcs, typename cv_traits<TY>::T *dstp, unsigned width,
+                     const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv, int32_t wb)
+{
+    typedef typename cv_traits<TY>::T T;
+    typedef typename cv_traits<TY>::Acc Acc;
+    const auto *coeffs = cv_coeffs<TY>(p);
+    unsigned fwidth = FW ? FW : p.matrixsize;
+    const bool satur = p.saturate != 0;   // local copy; see conv_h_scanline
+
+    [[maybe_unused]] cv_cvec<TY> cq[cv_nq<TY, FW>()];
+    if constexpr (FW)
+        stage_coeffs<TY, FW>(cq, coeffs);
+
+    unsigned j = 0;
+    auto block = [&](unsigned jj) {
+        cv_acc<TY> a;
+        if constexpr (FW) {
+            conv_taps_v<TY, FW>(a, srcs, jj, cq);
+        } else {
+            tap16_init<TY>(a, static_cast<const T *>(srcs[0]) + jj, coeffs[0]);
+            for (unsigned k = 1; k < fwidth; ++k)
+                tap16<TY>(a, static_cast<const T *>(srcs[k]) + jj, coeffs[k]);
+        }
+        store16_sat<TY>(dstp + jj, a, satur, wb, sc, bi, sm, mv);
+    };
+    for (; j + 16 <= width; j += 16) block(j);
+    if (j < width && width >= 16) { block(width - 16); j = width; }
+    for (; j < width; ++j) {
+        Acc accum = 0;
+        for (unsigned k = 0; k < fwidth; ++k)
+            accum += coeffs[k] * cv_sample<TY>(static_cast<const T *>(srcs[k])[j]);
+        dstp[j] = cv_scalar_store<TY>(static_cast<float>(accum), p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+// Mirror row-pointer selection of conv_plane_v / conv_plane_x, verbatim.
+inline void conv_v_select_rows(const void *src, ptrdiff_t src_stride, const void *srcp[25],
+                               unsigned i, unsigned height, unsigned fwidth)
+{
+    unsigned support = fwidth / 2;
+    unsigned dist_from_bottom = height - 1 - i;
+
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned row = i < support - k ? std::min(support - k - i - 1, height - 1) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned row = dist_from_bottom < k - support ? height - std::min(k - support - dist_from_bottom, i) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+}
+
+// ---- plane drivers ------------------------------------------------------------
+
+template <CvType TY, unsigned FW>
+void conv_plane_h_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                       const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename cv_traits<TY>::T T;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(cv_coeffs<TY>(p), p.matrixsize);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const T *srcp = reinterpret_cast<const T *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(i) * src_stride);
+        T *dstp = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        conv_h_scanline<TY, FW>(srcp, dstp, width, p, sc, bi, sm, mv, wb);
+    }
+}
+
+template <CvType TY, unsigned FW>
+void conv_plane_v_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                       const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename cv_traits<TY>::T T;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(cv_coeffs<TY>(p), p.matrixsize);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        conv_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        T *dstp = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        conv_v_scanline<TY, FW>(srcp, dstp, width, p, sc, bi, sm, mv, wb);
+    }
+}
+
+// dot_h routes the horizontal half through the i8mm usdot scanline (byte only,
+// and only when the caller has checked conv_int8 + i8mm). It is a runtime flag,
+// not a template parameter, deliberately: it is read once per row, and
+// templating it would double this driver's instantiations for nothing.
+template <CvType TY, unsigned FW>
+void conv_plane_x_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                       const vs_generic_params &p, unsigned width, unsigned height,
+                       [[maybe_unused]] bool dot_h = false)
+{
+    typedef typename cv_traits<TY>::T T;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(cv_coeffs<TY>(p), p.matrixsize);
+
+    T *tmp = static_cast<T *>(vsh::vsh_aligned_malloc(width * sizeof(T), 64));
+    if (!tmp) {
+        // Returning quietly would leave the destination plane as whatever the
+        // frame allocator handed out (possibly other frames' data). Zero is
+        // still wrong output, but deterministic and not an information leak.
+        for (unsigned i = 0; i < height; ++i)
+            std::memset(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride, 0, width * sizeof(T));
+        return;
+    }
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        conv_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        T *dstp = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        conv_v_scanline<TY, FW>(srcp, tmp, width, p, sc, bi, sm, mv, wb);
+#ifdef VS_TARGET_ARM_I8MM
+        if constexpr (TY == CvType::Byte) {
+            if (dot_h) {
+                vs_generic_1d_conv_h_byte_scanline_neon_dot(tmp, dstp, &p, width);
+                continue;
+            }
+        }
+#endif
+        conv_h_scanline<TY, FW>(tmp, dstp, width, p, sc, bi, sm, mv, wb);
+    }
+
+    vsh::vsh_aligned_free(tmp);
+}
+
+// Compile-time tap counts for the fwidths the filter actually accepts (odd,
+// 3..25), mirroring x86's VS_CONV_SELECT. The switch runs once per plane, so
+// the row loop below it is fully specialised. FW = 0 is the runtime fallback
+// and stays reachable: matrixsize is validated elsewhere, but a shape this does
+// not enumerate must still produce correct output rather than fall off the end.
+#define VS_CONV_PLANE_SELECT(dir)                                                                  \
+template <CvType TY>                                                                               \
+void conv_plane_##dir##_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, \
+                             const vs_generic_params &p, unsigned width, unsigned height)          \
+{                                                                                                  \
+    switch (p.matrixsize) {                                                                        \
+    case 3:  return conv_plane_##dir##_impl<TY, 3>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 5:  return conv_plane_##dir##_impl<TY, 5>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 7:  return conv_plane_##dir##_impl<TY, 7>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 9:  return conv_plane_##dir##_impl<TY, 9>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 11: return conv_plane_##dir##_impl<TY, 11>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 13: return conv_plane_##dir##_impl<TY, 13>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 15: return conv_plane_##dir##_impl<TY, 15>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 17: return conv_plane_##dir##_impl<TY, 17>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 19: return conv_plane_##dir##_impl<TY, 19>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 21: return conv_plane_##dir##_impl<TY, 21>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 23: return conv_plane_##dir##_impl<TY, 23>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 25: return conv_plane_##dir##_impl<TY, 25>(src, src_stride, dst, dst_stride, p, width, height); \
+    default: return conv_plane_##dir##_impl<TY, 0>(src, src_stride, dst, dst_stride, p, width, height);  \
+    }                                                                                              \
+}
+
+VS_CONV_PLANE_SELECT(h)
+VS_CONV_PLANE_SELECT(v)
+VS_CONV_PLANE_SELECT(x)
+
+#ifdef VS_TARGET_ARM_I8MM
+// Separable byte with the horizontal half on usdot. Same tap-count switch as
+// above; only the trailing dot_h differs, so it shares every instantiation of
+// conv_plane_x_impl<Byte, FW> with the plain separable entry.
+void conv_plane_x_byte_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                           const vs_generic_params &p, unsigned width, unsigned height)
+{
+    constexpr CvType TY = CvType::Byte;
+    switch (p.matrixsize) {
+    case 3:  return conv_plane_x_impl<TY, 3>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 5:  return conv_plane_x_impl<TY, 5>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 7:  return conv_plane_x_impl<TY, 7>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 9:  return conv_plane_x_impl<TY, 9>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 11: return conv_plane_x_impl<TY, 11>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 13: return conv_plane_x_impl<TY, 13>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 15: return conv_plane_x_impl<TY, 15>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 17: return conv_plane_x_impl<TY, 17>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 19: return conv_plane_x_impl<TY, 19>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 21: return conv_plane_x_impl<TY, 21>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 23: return conv_plane_x_impl<TY, 23>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 25: return conv_plane_x_impl<TY, 25>(src, src_stride, dst, dst_stride, p, width, height, true);
+    default: return conv_plane_x_impl<TY, 0>(src, src_stride, dst, dst_stride, p, width, height, true);
+    }
+}
+#endif
+
+// ---- 3x3 square (replicate edges, filter_plane_3x3 semantics) ------------------
+
+template <CvType TY>
+void conv_plane_3x3_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                         const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename cv_traits<TY>::T T;
+    typedef typename cv_traits<TY>::Acc Acc;
+    const auto *coeffs = cv_coeffs<TY>(p);
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(coeffs, 9);
+    const bool satur = p.saturate != 0;   // local copy; see conv_h_scanline
+
+    // Float taps are 1 load : 1 FMA -- the only format with no arithmetic to hide
+    // a stray load behind (byte is 1:4, word/half 1:2) -- so a per-block coefficient
+    // reload lands on the FMA's critical path. Broadcasting once per plane is +21%
+    // on M4 and +2-7% on Graviton3/4/5, and is what puts this kernel back ahead of
+    // the C tier, whose autovectoriser was already hoisting. Float only: the same
+    // change on half measured -1.2% (it is conversion-bound, not load-starved).
+    [[maybe_unused]] float32x4_t cf[9];
+    if constexpr (TY == CvType::Float) {
+        for (unsigned i = 0; i < 9; ++i)
+            cf[i] = vdupq_n_f32(coeffs[i]);
+    }
+
+    auto src_row = [&](unsigned r) {
+        return reinterpret_cast<const T *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(r) * src_stride);
+    };
+    auto dst_row = [&](unsigned r) {
+        return reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(r) * dst_stride);
+    };
+    auto scalar_px3 = [&](const T *rt, const T *rm, const T *rb, unsigned a, unsigned b, unsigned c) -> T {
+        const T *rows[3] = { rt, rm, rb };
+        Acc accum = 0;
+        for (unsigned r = 0; r < 3; ++r) {
+            accum += coeffs[r * 3 + 0] * cv_sample<TY>(rows[r][a]);
+            accum += coeffs[r * 3 + 1] * cv_sample<TY>(rows[r][b]);
+            accum += coeffs[r * 3 + 2] * cv_sample<TY>(rows[r][c]);
+        }
+        return cv_scalar_store<TY>(static_cast<float>(accum), p.div, p.bias, p.saturate, p.maxval);
+    };
+
+    auto do_row = [&](unsigned i) {
+        unsigned above_idx = i == 0 ? 0 : i - 1;
+        unsigned below_idx = i == height - 1 ? height - 1 : i + 1;
+        const T *rows[3] = { src_row(above_idx), src_row(i), src_row(below_idx) };
+        T *dstp = dst_row(i);
+
+        auto scalar_px = [&](unsigned a, unsigned b, unsigned c) -> T {
+            return scalar_px3(rows[0], rows[1], rows[2], a, b, c);
+        };
+
+        dstp[0] = scalar_px(0, 0, width > 1 ? 1 : 0);
+
+        unsigned end = width > 1 ? width - 1 : 0;
+        unsigned j = 1;
+        auto block = [&](unsigned jj) {
+            typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type a;
+            if constexpr (TY == CvType::Float) {
+                float_tap16_init(a, rows[0] + jj - 1, cf[0]);
+                for (unsigned r = 0; r < 3; ++r) {
+                    for (unsigned k = r == 0 ? 1 : 0; k < 3; ++k) {
+                        const float *q = rows[r] + jj - 1 + k;
+                        float32x4_t w = cf[r * 3 + k];
+                        a.a0 = vfmaq_f32(a.a0, vld1q_f32(q), w);
+                        a.a1 = vfmaq_f32(a.a1, vld1q_f32(q + 4), w);
+                        a.a2 = vfmaq_f32(a.a2, vld1q_f32(q + 8), w);
+                        a.a3 = vfmaq_f32(a.a3, vld1q_f32(q + 12), w);
+                    }
+                }
+            } else {
+                tap16_init<TY>(a, rows[0] + jj - 1, coeffs[0]);
+                for (unsigned r = 0; r < 3; ++r)
+                    for (unsigned k = r == 0 ? 1 : 0; k < 3; ++k)
+                        tap16<TY>(a, rows[r] + jj - 1 + k, coeffs[r * 3 + k]);
+            }
+            store16_sat<TY>(dstp + jj, a, satur, wb, sc, bi, sm, mv);
+        };
+        if (end > 1) {
+            for (; j + 16 <= end; j += 16) block(j);
+            if (j < end && end >= 1 + 16) { block(end - 16); j = end; }
+            for (; j < end; ++j) {
+                unsigned a = j - 1, b = j, c = j + 1;
+                dstp[j] = scalar_px(a, b, c);
+            }
+        }
+
+        if (width > 1)
+            dstp[width - 1] = scalar_px(width - 2, width - 1, width - 1);
+    };
+
+    for (unsigned i = 0; i < height; ++i)
+        do_row(i);
+}
+
+} // namespace
+
+#define VS_CONV_NEON_ENTRY(KERNEL, FN, TY, TN) \
+    void vs_generic_##KERNEL##_##TN##_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { FN<CvType::TY>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+// 3x3 float has no NEON entry: it loses to its autovectorised C tier at a full
+// thread pool on M4, so it is dispatched to C (see genericSelectNEON).
+VS_CONV_NEON_ENTRY(3x3_conv, conv_plane_3x3_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(3x3_conv, conv_plane_3x3_neon, Word, word)
+VS_CONV_NEON_ENTRY(3x3_conv, conv_plane_3x3_neon, Half, half)
+
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Word, word)
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Float, float)
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Half, half)
+
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Word, word)
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Float, float)
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Half, half)
+
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Word, word)
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Float, float)
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Half, half)
+
+#ifdef VS_TARGET_ARM_I8MM
+void vs_generic_2d_conv_sep_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ conv_plane_x_byte_dot(src, src_stride, dst, dst_stride, *params, width, height); }
+#endif

--- a/src/core/kernel/arm/convolution_sme.cpp
+++ b/src/core/kernel/arm/convolution_sme.cpp
@@ -1,0 +1,888 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* SME2 streaming-mode convolution kernels: square NxN and vertical 1D.
+*
+* Formulation: a convolution over a block of TR output rows is a banded
+* (Toeplitz) matrix product. For every contributing source row, one outer
+* product accumulates coeff-band x pixel-row into ZA tiles:
+*
+*   out[i][j] = sum_s sum_k coeff[s - i][k] * src_row(s)[j + k - S]
+*   ZA[i][j] += band(s)[i] (x) row(s)[j + k - S]     (one MOPA per (s, k))
+*
+* Integer paths pack two adjacent taps (k, k+1) into the inherent 2-way
+* int16 dot product of SMOPA za32, so each MOPA covers two taps. Pixels
+* widen to int16 (byte: zero-extended, always non-negative; word: biased by
+* INT16_MIN, with the coefficient*bias sum subtracted on store -- the same
+* trick the x86 kernels use). Sums are integer and order-independent, so
+* results are bit-exact with the C reference. word 9x9/11x11 would overflow
+* int32 in the biased domain, so they use the 4-way int16 SMOPA za64
+* (FEAT_SME_I16I64) with int64 accumulators, again bit-exact. Float uses
+* FMOPA za32 (fused, not bit-exact with C by design, like x86 AVX2+).
+*
+* Structure per plane: a non-streaming wrapper precomputes mirrored row
+* pointers, the coefficient band vectors and the scalar mirror-edge columns,
+* then enters ONE __arm_locally_streaming __arm_new("za") function for the
+* whole interior. Everything vector-length-agnostic (svcnt*), so any SVL
+* works. Every function that touches vectors in this TU is streaming: with
+* +sme enabled the auto-vectoriser could otherwise emit streaming-only SVE in
+* regular functions, which faults outside streaming mode.
+*
+* The vertical 1D row selection collapses to a pure function of (i + k) only
+* when height > support; smaller planes take the C kernel instead.
+*/
+
+#include <arm_sme.h>
+#include <cstdint>
+#include <vector>
+#include "../generic.h"
+#include "conv_scalar.h"
+
+namespace {
+
+// ---- streaming helpers -------------------------------------------------------
+
+// Immediate-operand dispatch for ZA32 tiles 0-3.
+__attribute__((always_inline))
+inline void mopa32_i16(unsigned t, svbool_t pn, svbool_t pm, svint16_t zn, svint16_t zm) __arm_streaming __arm_inout("za")
+{
+    switch (t) {
+    case 0: svmopa_za32_s16_m(0, pn, pm, zn, zm); break;
+    case 1: svmopa_za32_s16_m(1, pn, pm, zn, zm); break;
+    case 2: svmopa_za32_s16_m(2, pn, pm, zn, zm); break;
+    default: svmopa_za32_s16_m(3, pn, pm, zn, zm); break;
+    }
+}
+
+__attribute__((always_inline))
+inline void mopa32_f32(unsigned t, svbool_t pn, svbool_t pm, svfloat32_t zn, svfloat32_t zm) __arm_streaming __arm_inout("za")
+{
+    switch (t) {
+    case 0: svmopa_za32_f32_m(0, pn, pm, zn, zm); break;
+    case 1: svmopa_za32_f32_m(1, pn, pm, zn, zm); break;
+    case 2: svmopa_za32_f32_m(2, pn, pm, zn, zm); break;
+    default: svmopa_za32_f32_m(3, pn, pm, zn, zm); break;
+    }
+}
+
+__attribute__((always_inline))
+inline void mopa32_f16(unsigned t, svbool_t pn, svbool_t pm, svfloat16_t zn, svfloat16_t zm) __arm_streaming __arm_inout("za")
+{
+    switch (t) {
+    case 0: svmopa_za32_f16_m(0, pn, pm, zn, zm); break;
+    case 1: svmopa_za32_f16_m(1, pn, pm, zn, zm); break;
+    case 2: svmopa_za32_f16_m(2, pn, pm, zn, zm); break;
+    default: svmopa_za32_f16_m(3, pn, pm, zn, zm); break;
+    }
+}
+
+__attribute__((always_inline))
+inline void mopa64_i16(unsigned t, svbool_t pn, svbool_t pm, svint16_t zn, svint16_t zm) __arm_streaming __arm_inout("za")
+{
+    switch (t) {
+    case 0: svmopa_za64_s16_m(0, pn, pm, zn, zm); break;
+    case 1: svmopa_za64_s16_m(1, pn, pm, zn, zm); break;
+    case 2: svmopa_za64_s16_m(2, pn, pm, zn, zm); break;
+    default: svmopa_za64_s16_m(3, pn, pm, zn, zm); break;
+    }
+}
+
+__attribute__((always_inline))
+inline svint32_t read_za32_s32(unsigned t, uint32_t slice) __arm_streaming __arm_in("za")
+{
+    svbool_t pg = svptrue_b32();
+    svint32_t z = svdup_s32(0);
+    switch (t) {
+    case 0: return svread_hor_za32_s32_m(z, pg, 0, slice);
+    case 1: return svread_hor_za32_s32_m(z, pg, 1, slice);
+    case 2: return svread_hor_za32_s32_m(z, pg, 2, slice);
+    default: return svread_hor_za32_s32_m(z, pg, 3, slice);
+    }
+}
+
+__attribute__((always_inline))
+inline svfloat32_t read_za32_f32(unsigned t, uint32_t slice) __arm_streaming __arm_in("za")
+{
+    svbool_t pg = svptrue_b32();
+    svfloat32_t z = svdup_f32(0.0f);
+    switch (t) {
+    case 0: return svread_hor_za32_f32_m(z, pg, 0, slice);
+    case 1: return svread_hor_za32_f32_m(z, pg, 1, slice);
+    case 2: return svread_hor_za32_f32_m(z, pg, 2, slice);
+    default: return svread_hor_za32_f32_m(z, pg, 3, slice);
+    }
+}
+
+__attribute__((always_inline))
+inline svint64_t read_za64_s64(unsigned t, uint32_t slice) __arm_streaming __arm_in("za")
+{
+    svbool_t pg = svptrue_b64();
+    svint64_t z = svdup_s64(0);
+    switch (t) {
+    case 0: return svread_hor_za64_s64_m(z, pg, 0, slice);
+    case 1: return svread_hor_za64_s64_m(z, pg, 1, slice);
+    case 2: return svread_hor_za64_s64_m(z, pg, 2, slice);
+    default: return svread_hor_za64_s64_m(z, pg, 3, slice);
+    }
+}
+
+// SME2 multi-vector ZA reads: one instruction pulls four consecutive
+// horizontal slices (output rows) of a tile, cutting the store-side ZA
+// readout instruction count 4x versus the slice-at-a-time reads above. This
+// pays off in the vertical 1D kernels, where the readout is a large share of
+// the per-block work; the square kernels see no benefit (the outer products
+// dominate) and are left on the single-slice path.
+__attribute__((always_inline))
+inline svint32x4_t read_za32_s32_x4(unsigned t, uint32_t base) __arm_streaming __arm_in("za")
+{
+    switch (t) {
+    case 0: return svread_hor_za32_s32_vg4(0, base);
+    case 1: return svread_hor_za32_s32_vg4(1, base);
+    case 2: return svread_hor_za32_s32_vg4(2, base);
+    default: return svread_hor_za32_s32_vg4(3, base);
+    }
+}
+
+__attribute__((always_inline))
+inline svfloat32x4_t read_za32_f32_x4(unsigned t, uint32_t base) __arm_streaming __arm_in("za")
+{
+    switch (t) {
+    case 0: return svread_hor_za32_f32_vg4(0, base);
+    case 1: return svread_hor_za32_f32_vg4(1, base);
+    case 2: return svread_hor_za32_f32_vg4(2, base);
+    default: return svread_hor_za32_f32_vg4(3, base);
+    }
+}
+
+// Pixel row loads, widened to the int16 MOPA input domain.
+__attribute__((always_inline))
+inline svint16_t load_px_i16(const uint8_t *p, svbool_t pg, bool word) __arm_streaming
+{
+    if (word)
+        return svreinterpret_s16_u16(sveor_n_u16_x(pg, svld1_u16(pg, reinterpret_cast<const uint16_t *>(p)), 0x8000u));
+    else
+        return svld1ub_s16(pg, p);
+}
+
+// scale/bias/saturate + round + clamp + narrowing store of one int32 tile row.
+__attribute__((always_inline))
+inline void store_row_int(uint8_t *dst, svbool_t pgw, svint32_t acc, int32_t weight_bias,
+                          float div, float bias, uint32_t satmask, int32_t maxclamp, bool word) __arm_streaming
+{
+    svbool_t pt = svptrue_b32();
+    acc = svsub_n_s32_x(pt, acc, weight_bias);
+    svfloat32_t f = svcvt_f32_s32_x(pt, acc);
+    f = svmad_n_f32_x(pt, f, svdup_f32(div), bias);
+    f = svreinterpret_f32_u32(svand_n_u32_x(pt, svreinterpret_u32_f32(f), satmask));
+    f = svrintn_f32_x(pt, f);
+    svint32_t r = svcvt_s32_f32_x(pt, f);
+    r = svmax_n_s32_x(pt, r, 0);
+    r = svmin_n_s32_x(pt, r, maxclamp);
+    if (word)
+        svst1h_s32(pgw, reinterpret_cast<int16_t *>(dst), r);
+    else
+        svst1b_s32(pgw, reinterpret_cast<int8_t *>(dst), r);
+}
+
+// ---- square NxN, int paths, ZA32 (byte all N; word N <= 7) --------------------
+
+__arm_locally_streaming __arm_new("za")
+void sme_sq_int32_interior(const uint8_t *const *rows, ptrdiff_t elem_size, uint8_t *dst, ptrdiff_t dst_stride,
+                           const int16_t *band, unsigned N, unsigned W, unsigned H,
+                           int32_t weight_bias, float div, float fbias, uint32_t satmask, int32_t maxclamp)
+{
+    const bool word = elem_size == 2;
+    const unsigned S = N / 2;
+    const unsigned P = (N + 1) / 2;
+    const unsigned TR = static_cast<unsigned>(svcntw());
+    const unsigned Wend = W - S;
+    const svbool_t pt16 = svptrue_b16();
+
+    for (unsigned y = 0; y < H; y += TR) {
+        unsigned vr = std::min(TR, H - y);
+        for (unsigned cb = S; cb < Wend; cb += 4 * TR) {
+            unsigned v[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                unsigned base = cb + t * TR;
+                v[t] = base < Wend ? std::min(TR, Wend - base) : 0;
+            }
+            svzero_za();
+            for (unsigned d = 0; d < vr + N - 1; ++d) {
+                const uint8_t *row = rows[y + d];
+                for (unsigned p = 0; p < P; ++p) {
+                    svint16_t zn = svld1_s16(pt16, band + (static_cast<size_t>(d) * P + p) * 2 * TR);
+                    unsigned k0 = 2 * p;
+                    for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                        svbool_t pgh = svwhilelt_b16_u32(0, v[t]);
+                        const uint8_t *base = row + (static_cast<size_t>(cb) + t * TR + k0 - S) * elem_size;
+                        svint16_t va = load_px_i16(base, pgh, word);
+                        svint16_t vb = k0 + 1 < N ? load_px_i16(base + elem_size, pgh, word) : svdup_s16(0);
+                        mopa32_i16(t, pt16, pt16, zn, svzip1_s16(va, vb));
+                    }
+                }
+            }
+            for (unsigned i = 0; i < vr; ++i) {
+                uint8_t *drow = dst + static_cast<ptrdiff_t>(y + i) * dst_stride;
+                for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                    svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                    store_row_int(drow + (static_cast<size_t>(cb) + t * TR) * elem_size, pgw,
+                                  read_za32_s32(t, i), weight_bias, div, fbias, satmask, maxclamp, word);
+                }
+            }
+        }
+    }
+}
+
+// ---- square NxN, word with int64 accumulation, ZA64 (N >= 9) ------------------
+
+__arm_locally_streaming __arm_new("za")
+void sme_sq_int64_interior(const uint8_t *const *rows, uint8_t *dst, ptrdiff_t dst_stride,
+                           const int16_t *band, unsigned N, unsigned W, unsigned H,
+                           int64_t weight_bias, float div, float fbias, uint32_t satmask, int32_t maxclamp)
+{
+    const unsigned S = N / 2;
+    const unsigned Q = (N + 3) / 4;
+    const unsigned TD = static_cast<unsigned>(svcntd());
+    const unsigned Wend = W - S;
+    const svbool_t pt16 = svptrue_b16();
+    const svbool_t pt32 = svptrue_b32();
+    const svbool_t pt64 = svptrue_b64();
+
+    for (unsigned y = 0; y < H; y += TD) {
+        unsigned vr = std::min(TD, H - y);
+        for (unsigned cb = S; cb < Wend; cb += 4 * TD) {
+            unsigned v[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                unsigned base = cb + t * TD;
+                v[t] = base < Wend ? std::min(TD, Wend - base) : 0;
+            }
+            svzero_za();
+            for (unsigned d = 0; d < vr + N - 1; ++d) {
+                const uint16_t *row = reinterpret_cast<const uint16_t *>(rows[y + d]);
+                for (unsigned q = 0; q < Q; ++q) {
+                    svint16_t zn = svld1_s16(pt16, band + (static_cast<size_t>(d) * Q + q) * 4 * TD);
+                    unsigned k0 = 4 * q;
+                    for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                        svbool_t pgh = svwhilelt_b16_u32(0, v[t]);
+                        const uint16_t *base = row + cb + t * TD + k0 - S;
+                        svint16_t v0 = load_px_i16(reinterpret_cast<const uint8_t *>(base), pgh, true);
+                        svint16_t v1 = k0 + 1 < N ? load_px_i16(reinterpret_cast<const uint8_t *>(base + 1), pgh, true) : svdup_s16(0);
+                        svint16_t v2 = k0 + 2 < N ? load_px_i16(reinterpret_cast<const uint8_t *>(base + 2), pgh, true) : svdup_s16(0);
+                        svint16_t v3 = k0 + 3 < N ? load_px_i16(reinterpret_cast<const uint8_t *>(base + 3), pgh, true) : svdup_s16(0);
+                        svint16_t z01 = svzip1_s16(v0, v1);
+                        svint16_t z23 = svzip1_s16(v2, v3);
+                        svint16_t zm = svreinterpret_s16_s32(svzip1_s32(svreinterpret_s32_s16(z01), svreinterpret_s32_s16(z23)));
+                        mopa64_i16(t, pt16, pt16, zn, zm);
+                    }
+                }
+            }
+            for (unsigned i = 0; i < vr; ++i) {
+                uint16_t *drow = reinterpret_cast<uint16_t *>(dst + static_cast<ptrdiff_t>(y + i) * dst_stride);
+                for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                    svbool_t pgd = svwhilelt_b64_u32(0, v[t]);
+                    svint64_t acc = svsub_n_s64_x(pt64, read_za64_s64(t, i), weight_bias);
+                    // int64 -> float32 in the even float lane of each doubleword;
+                    // the f32 math runs on all lanes (odd lanes are garbage) and
+                    // the halfword store picks the low 16 bits of each doubleword.
+                    svfloat32_t f = svcvt_f32_s64_x(pt64, acc);
+                    f = svmad_n_f32_x(pt32, f, svdup_f32(div), fbias);
+                    f = svreinterpret_f32_u32(svand_n_u32_x(pt32, svreinterpret_u32_f32(f), satmask));
+                    f = svrintn_f32_x(pt32, f);
+                    svint32_t r = svcvt_s32_f32_x(pt32, f);
+                    r = svmax_n_s32_x(pt32, r, 0);
+                    r = svmin_n_s32_x(pt32, r, maxclamp);
+                    svst1h_s64(pgd, reinterpret_cast<int16_t *>(drow + cb + t * TD), svreinterpret_s64_s32(r));
+                }
+            }
+        }
+    }
+}
+
+// ---- half (binary16) store ----------------------------------------------------
+// ZA accumulates in f32; a half sample sits in the bottom 16 bits of its 32-bit
+// container, so svcvt + a narrowing halfword store writes svcntw() halves.
+
+inline void st_f32_half(svbool_t pg, uint16_t *p, svfloat32_t f) __arm_streaming
+{
+    svst1h_u32(pg, p, svreinterpret_u32_f16(svcvt_f16_f32_x(pg, f)));
+}
+
+// scale/bias/saturate + store of one f32 tile row (float and half outputs).
+__attribute__((always_inline))
+inline void store_row_float(float *dst, svbool_t pgw, svfloat32_t f, float div, float fbias, uint32_t satmask) __arm_streaming
+{
+    svbool_t pt = svptrue_b32();
+    f = svmad_n_f32_x(pt, f, svdup_f32(div), fbias);
+    f = svreinterpret_f32_u32(svand_n_u32_x(pt, svreinterpret_u32_f32(f), satmask));
+    svst1_f32(pgw, dst, f);
+}
+
+__attribute__((always_inline))
+inline void store_row_half(uint16_t *dst, svbool_t pgw, svfloat32_t f, float div, float fbias, uint32_t satmask) __arm_streaming
+{
+    svbool_t pt = svptrue_b32();
+    f = svmad_n_f32_x(pt, f, svdup_f32(div), fbias);
+    f = svreinterpret_f32_u32(svand_n_u32_x(pt, svreinterpret_u32_f32(f), satmask));
+    st_f32_half(pgw, dst, f);
+}
+
+// ---- square NxN, half, native 2-way f16 FMOPA ---------------------------------
+//
+// The widening FMOPA reduces over adjacent element pairs:
+//     ZA32[i][j] += Zn.h[2i]*Zm.h[2j] + Zn.h[2i+1]*Zm.h[2j+1]
+// so one instruction folds *two* source rows into the tile instead of one, which
+// halves the outer-product count versus the f32 path, and the pixels are consumed
+// as f16 with no widening load and no convert.
+//
+// The pairing is over source rows: for pair dp, element 2j of Zm is the pixel from
+// row 2dp and element 2j+1 the pixel from row 2dp+1, at the same column -- exactly
+// svzip1_f16 of two ordinary row loads. The band is pre-interleaved to match
+// (element 2i+p holds the coefficient for source row 2dp+p, output row i), so the
+// odd element of a trailing unpaired row is simply zero and the phantom row reads
+// harmlessly from its partner.
+//
+// PRECISION: FMOPA takes both operands in f16, so the coefficients are rounded to
+// half here, where every other tier (C, NEON, x86) keeps them in float32. Products
+// are still exact in f32 (an f16*f16 product fits the f32 mantissa) and ZA
+// accumulates in f32, so the only loss is that coefficient rounding: ~2^-11
+// relative, roughly one ulp of the half output.
+
+std::vector<uint16_t> build_sq_band_f16(const float *m, unsigned N, unsigned TR)
+{
+    const unsigned band_rows = TR + N - 1;
+    const unsigned npair = (band_rows + 1) / 2;
+    std::vector<uint16_t> band(static_cast<size_t>(npair) * N * 2 * TR, 0);
+    for (unsigned dp = 0; dp < npair; ++dp) {
+        for (unsigned k = 0; k < N; ++k) {
+            uint16_t *b = band.data() + (static_cast<size_t>(dp) * N + k) * 2 * TR;
+            for (unsigned i = 0; i < TR; ++i) {
+                for (unsigned p = 0; p < 2; ++p) {
+                    const int r = static_cast<int>(2 * dp + p) - static_cast<int>(i);
+                    const float c = (r >= 0 && r < static_cast<int>(N)) ? m[static_cast<unsigned>(r) * N + k] : 0.0f;
+                    b[2 * i + p] = nc_float_to_half(c);
+                }
+            }
+        }
+    }
+    return band;
+}
+
+__arm_locally_streaming __arm_new("za")
+void sme_sq_half_fmopa_interior(const uint8_t *const *rows, uint8_t *dst, ptrdiff_t dst_stride,
+                                const uint16_t *band, unsigned N, unsigned W, unsigned H,
+                                float div, float fbias, uint32_t satmask)
+{
+    const unsigned S = N / 2;
+    const unsigned TR = static_cast<unsigned>(svcntw());
+    const unsigned Wend = W - S;
+    const svbool_t pt32 = svptrue_b32();
+    const svbool_t pt16 = svptrue_b16();
+
+    for (unsigned y = 0; y < H; y += TR) {
+        const unsigned vr = std::min(TR, H - y);
+        const unsigned nrows = vr + N - 1;
+        const unsigned npair = (nrows + 1) / 2;
+        for (unsigned cb = S; cb < Wend; cb += 4 * TR) {
+            unsigned v[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                unsigned base = cb + t * TR;
+                v[t] = base < Wend ? std::min(TR, Wend - base) : 0;
+            }
+            svzero_za();
+            for (unsigned dp = 0; dp < npair; ++dp) {
+                const unsigned d0 = 2 * dp, d1 = d0 + 1;
+                const uint16_t *r0 = reinterpret_cast<const uint16_t *>(rows[y + d0]);
+                // Trailing odd row: its band coefficients are zero, so pointing at
+                // the partner keeps the load in bounds and contributes nothing.
+                const uint16_t *r1 = d1 < nrows ? reinterpret_cast<const uint16_t *>(rows[y + d1]) : r0;
+                for (unsigned k = 0; k < N; ++k) {
+                    svfloat16_t zn = svld1_f16(pt16, reinterpret_cast<const float16_t *>(band + (static_cast<size_t>(dp) * N + k) * 2 * TR));
+                    for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                        const svbool_t pld = svwhilelt_b16_u32(0u, v[t]);
+                        const svbool_t pcol = svwhilelt_b16_u32(0u, 2u * v[t]);
+                        const unsigned off = cb + t * TR + k - S;
+                        svfloat16_t a = svld1_f16(pld, reinterpret_cast<const float16_t *>(r0 + off));
+                        svfloat16_t b = svld1_f16(pld, reinterpret_cast<const float16_t *>(r1 + off));
+                        mopa32_f16(t, pt16, pcol, zn, svzip1_f16(a, b));
+                    }
+                }
+            }
+            for (unsigned i = 0; i < vr; ++i) {
+                uint16_t *drow = reinterpret_cast<uint16_t *>(dst + static_cast<ptrdiff_t>(y + i) * dst_stride);
+                for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                    const svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                    svfloat32_t f = read_za32_f32(t, i);
+                    f = svmad_n_f32_x(pt32, f, svdup_f32(div), fbias);
+                    f = svreinterpret_f32_u32(svand_n_u32_x(pt32, svreinterpret_u32_f32(f), satmask));
+                    st_f32_half(pgw, drow + cb + t * TR, f);
+                }
+            }
+        }
+    }
+}
+
+// ---- square NxN, float, ZA32 FMOPA --------------------------------------------
+
+__arm_locally_streaming __arm_new("za")
+void sme_sq_float_interior(const uint8_t *const *rows, uint8_t *dst, ptrdiff_t dst_stride,
+                           const float *band, unsigned N, unsigned W, unsigned H,
+                           float div, float fbias, uint32_t satmask)
+{
+    const unsigned S = N / 2;
+    const unsigned TR = static_cast<unsigned>(svcntw());
+    const unsigned Wend = W - S;
+    const svbool_t pt32 = svptrue_b32();
+
+    for (unsigned y = 0; y < H; y += TR) {
+        unsigned vr = std::min(TR, H - y);
+        for (unsigned cb = S; cb < Wend; cb += 4 * TR) {
+            unsigned v[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                unsigned base = cb + t * TR;
+                v[t] = base < Wend ? std::min(TR, Wend - base) : 0;
+            }
+            svzero_za();
+            for (unsigned d = 0; d < vr + N - 1; ++d) {
+                const float *row = reinterpret_cast<const float *>(rows[y + d]);
+                for (unsigned k = 0; k < N; ++k) {
+                    svfloat32_t zn = svld1_f32(pt32, band + (static_cast<size_t>(d) * N + k) * TR);
+                    for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                        svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                        svfloat32_t zm = svld1_f32(pgw, row + cb + t * TR + k - S);
+                        mopa32_f32(t, pt32, pgw, zn, zm);
+                    }
+                }
+            }
+            for (unsigned i = 0; i < vr; ++i) {
+                float *drow = reinterpret_cast<float *>(dst + static_cast<ptrdiff_t>(y + i) * dst_stride);
+                for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                    svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                    svfloat32_t f = read_za32_f32(t, i);
+                    f = svmad_n_f32_x(pt32, f, svdup_f32(div), fbias);
+                    f = svreinterpret_f32_u32(svand_n_u32_x(pt32, svreinterpret_u32_f32(f), satmask));
+                    svst1_f32(pgw, drow + cb + t * TR, f);
+                }
+            }
+        }
+    }
+}
+
+
+// ---- vertical 1D, int paths, ZA32 ---------------------------------------------
+
+__arm_locally_streaming __arm_new("za")
+void sme_v_int32_plane(const uint8_t *const *rows, ptrdiff_t elem_size, uint8_t *dst, ptrdiff_t dst_stride,
+                       const int16_t *band, unsigned fwidth, unsigned W, unsigned H,
+                       int32_t weight_bias, float div, float fbias, uint32_t satmask, int32_t maxclamp)
+{
+    const bool word = elem_size == 2;
+    const unsigned TR = static_cast<unsigned>(svcntw());
+    const svbool_t pt16 = svptrue_b16();
+
+    for (unsigned y = 0; y < H; y += TR) {
+        unsigned vr = std::min(TR, H - y);
+        unsigned nrows = vr + fwidth - 1;
+        unsigned NP = (nrows + 1) / 2;
+        for (unsigned cb = 0; cb < W; cb += 4 * TR) {
+            unsigned v[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                unsigned base = cb + t * TR;
+                v[t] = base < W ? std::min(TR, W - base) : 0;
+            }
+            svzero_za();
+            for (unsigned p = 0; p < NP; ++p) {
+                svint16_t zn = svld1_s16(pt16, band + static_cast<size_t>(p) * 2 * TR);
+                const uint8_t *r0 = rows[y + 2 * p];
+                const uint8_t *r1 = 2 * p + 1 < nrows ? rows[y + 2 * p + 1] : nullptr;
+                for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                    svbool_t pgh = svwhilelt_b16_u32(0, v[t]);
+                    size_t off = (static_cast<size_t>(cb) + t * TR) * elem_size;
+                    svint16_t va = load_px_i16(r0 + off, pgh, word);
+                    svint16_t vb = r1 ? load_px_i16(r1 + off, pgh, word) : svdup_s16(0);
+                    mopa32_i16(t, pt16, pt16, zn, svzip1_s16(va, vb));
+                }
+            }
+            for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                size_t coff = (static_cast<size_t>(cb) + t * TR) * elem_size;
+                unsigned i = 0;
+                for (; i + 4 <= vr; i += 4) {
+                    svint32x4_t z = read_za32_s32_x4(t, i);
+                    store_row_int(dst + static_cast<ptrdiff_t>(y + i + 0) * dst_stride + coff, pgw, svget4_s32(z, 0), weight_bias, div, fbias, satmask, maxclamp, word);
+                    store_row_int(dst + static_cast<ptrdiff_t>(y + i + 1) * dst_stride + coff, pgw, svget4_s32(z, 1), weight_bias, div, fbias, satmask, maxclamp, word);
+                    store_row_int(dst + static_cast<ptrdiff_t>(y + i + 2) * dst_stride + coff, pgw, svget4_s32(z, 2), weight_bias, div, fbias, satmask, maxclamp, word);
+                    store_row_int(dst + static_cast<ptrdiff_t>(y + i + 3) * dst_stride + coff, pgw, svget4_s32(z, 3), weight_bias, div, fbias, satmask, maxclamp, word);
+                }
+                for (; i < vr; ++i)
+                    store_row_int(dst + static_cast<ptrdiff_t>(y + i) * dst_stride + coff, pgw,
+                                  read_za32_s32(t, i), weight_bias, div, fbias, satmask, maxclamp, word);
+            }
+        }
+    }
+}
+
+// ---- vertical 1D, float, ZA32 FMOPA --------------------------------------------
+
+__arm_locally_streaming __arm_new("za")
+void sme_v_float_plane(const uint8_t *const *rows, uint8_t *dst, ptrdiff_t dst_stride,
+                       const float *band, unsigned fwidth, unsigned W, unsigned H,
+                       float div, float fbias, uint32_t satmask)
+{
+    const unsigned TR = static_cast<unsigned>(svcntw());
+    const svbool_t pt32 = svptrue_b32();
+
+    for (unsigned y = 0; y < H; y += TR) {
+        unsigned vr = std::min(TR, H - y);
+        unsigned nrows = vr + fwidth - 1;
+        for (unsigned cb = 0; cb < W; cb += 4 * TR) {
+            unsigned v[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                unsigned base = cb + t * TR;
+                v[t] = base < W ? std::min(TR, W - base) : 0;
+            }
+            svzero_za();
+            for (unsigned d = 0; d < nrows; ++d) {
+                svfloat32_t zn = svld1_f32(pt32, band + static_cast<size_t>(d) * TR);
+                const float *row = reinterpret_cast<const float *>(rows[y + d]);
+                for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                    svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                    mopa32_f32(t, pt32, pgw, zn, svld1_f32(pgw, row + cb + t * TR));
+                }
+            }
+            for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                const unsigned col = cb + t * TR;
+                unsigned i = 0;
+                for (; i + 4 <= vr; i += 4) {
+                    svfloat32x4_t z = read_za32_f32_x4(t, i);
+                    store_row_float(reinterpret_cast<float *>(dst + static_cast<ptrdiff_t>(y + i + 0) * dst_stride) + col, pgw, svget4_f32(z, 0), div, fbias, satmask);
+                    store_row_float(reinterpret_cast<float *>(dst + static_cast<ptrdiff_t>(y + i + 1) * dst_stride) + col, pgw, svget4_f32(z, 1), div, fbias, satmask);
+                    store_row_float(reinterpret_cast<float *>(dst + static_cast<ptrdiff_t>(y + i + 2) * dst_stride) + col, pgw, svget4_f32(z, 2), div, fbias, satmask);
+                    store_row_float(reinterpret_cast<float *>(dst + static_cast<ptrdiff_t>(y + i + 3) * dst_stride) + col, pgw, svget4_f32(z, 3), div, fbias, satmask);
+                }
+                for (; i < vr; ++i)
+                    store_row_float(reinterpret_cast<float *>(dst + static_cast<ptrdiff_t>(y + i) * dst_stride) + col, pgw, read_za32_f32(t, i), div, fbias, satmask);
+            }
+        }
+    }
+}
+
+std::vector<uint16_t> build_v_band_f16(const float *m, unsigned fwidth, unsigned TR)
+{
+    const unsigned band_rows = TR + fwidth - 1;
+    const unsigned npair = (band_rows + 1) / 2;
+    std::vector<uint16_t> band(static_cast<size_t>(npair) * 2 * TR, 0);
+    for (unsigned dp = 0; dp < npair; ++dp) {
+        uint16_t *b = band.data() + static_cast<size_t>(dp) * 2 * TR;
+        for (unsigned i = 0; i < TR; ++i) {
+            for (unsigned p = 0; p < 2; ++p) {
+                const int r = static_cast<int>(2 * dp + p) - static_cast<int>(i);
+                const float c = (r >= 0 && r < static_cast<int>(fwidth)) ? m[r] : 0.0f;
+                b[2 * i + p] = nc_float_to_half(c);
+            }
+        }
+    }
+    return band;
+}
+
+// Vertical 1D, native f16 FMOPA: same row-pairing as the square kernel.
+__arm_locally_streaming __arm_new("za")
+void sme_v_half_fmopa_plane(const uint8_t *const *rows, uint8_t *dst, ptrdiff_t dst_stride,
+                            const uint16_t *band, unsigned fwidth, unsigned W, unsigned H,
+                            float div, float fbias, uint32_t satmask)
+{
+    const unsigned TR = static_cast<unsigned>(svcntw());
+    const svbool_t pt16 = svptrue_b16();
+
+    for (unsigned y = 0; y < H; y += TR) {
+        const unsigned vr = std::min(TR, H - y);
+        const unsigned nrows = vr + fwidth - 1;
+        const unsigned npair = (nrows + 1) / 2;
+        for (unsigned cb = 0; cb < W; cb += 4 * TR) {
+            unsigned v[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                unsigned base = cb + t * TR;
+                v[t] = base < W ? std::min(TR, W - base) : 0;
+            }
+            svzero_za();
+            for (unsigned dp = 0; dp < npair; ++dp) {
+                const unsigned d0 = 2 * dp, d1 = d0 + 1;
+                const uint16_t *r0 = reinterpret_cast<const uint16_t *>(rows[y + d0]);
+                const uint16_t *r1 = d1 < nrows ? reinterpret_cast<const uint16_t *>(rows[y + d1]) : r0;
+                svfloat16_t zn = svld1_f16(pt16, reinterpret_cast<const float16_t *>(band + static_cast<size_t>(dp) * 2 * TR));
+                for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                    const svbool_t pld = svwhilelt_b16_u32(0u, v[t]);
+                    const svbool_t pcol = svwhilelt_b16_u32(0u, 2u * v[t]);
+                    const unsigned off = cb + t * TR;
+                    svfloat16_t a = svld1_f16(pld, reinterpret_cast<const float16_t *>(r0 + off));
+                    svfloat16_t b = svld1_f16(pld, reinterpret_cast<const float16_t *>(r1 + off));
+                    mopa32_f16(t, pt16, pcol, zn, svzip1_f16(a, b));
+                }
+            }
+            for (unsigned t = 0; t < 4 && v[t]; ++t) {
+                const svbool_t pgw = svwhilelt_b32_u32(0, v[t]);
+                const unsigned col = cb + t * TR;
+                unsigned i = 0;
+                for (; i + 4 <= vr; i += 4) {
+                    svfloat32x4_t z = read_za32_f32_x4(t, i);
+                    store_row_half(reinterpret_cast<uint16_t *>(dst + static_cast<ptrdiff_t>(y + i + 0) * dst_stride) + col, pgw, svget4_f32(z, 0), div, fbias, satmask);
+                    store_row_half(reinterpret_cast<uint16_t *>(dst + static_cast<ptrdiff_t>(y + i + 1) * dst_stride) + col, pgw, svget4_f32(z, 1), div, fbias, satmask);
+                    store_row_half(reinterpret_cast<uint16_t *>(dst + static_cast<ptrdiff_t>(y + i + 2) * dst_stride) + col, pgw, svget4_f32(z, 2), div, fbias, satmask);
+                    store_row_half(reinterpret_cast<uint16_t *>(dst + static_cast<ptrdiff_t>(y + i + 3) * dst_stride) + col, pgw, svget4_f32(z, 3), div, fbias, satmask);
+                }
+                for (; i < vr; ++i)
+                    store_row_half(reinterpret_cast<uint16_t *>(dst + static_cast<ptrdiff_t>(y + i) * dst_stride) + col, pgw, read_za32_f32(t, i), div, fbias, satmask);
+            }
+        }
+    }
+}
+
+
+// ---- non-streaming wrappers ----------------------------------------------------
+
+// Square coefficient bands. band[d][p] is a 2*TR int16 vector whose pair 2i
+// holds coeff[(d - i)*N + 2p] and pair 2i+1 coeff[(d - i)*N + 2p + 1], zero
+// outside the valid band. d = (src row) - (block top) + S.
+std::vector<int16_t> build_sq_band_i16(const int16_t *m, unsigned N, unsigned TR, unsigned KW)
+{
+    unsigned P = (N + KW - 1) / KW;
+    std::vector<int16_t> band(static_cast<size_t>(TR + N - 1) * P * KW * TR, 0);
+    for (unsigned d = 0; d < TR + N - 1; ++d) {
+        for (unsigned p = 0; p < P; ++p) {
+            int16_t *b = band.data() + (static_cast<size_t>(d) * P + p) * KW * TR;
+            for (unsigned i = 0; i < TR; ++i) {
+                int r = static_cast<int>(d) - static_cast<int>(i);
+                if (r < 0 || r >= static_cast<int>(N))
+                    continue;
+                for (unsigned t = 0; t < KW; ++t) {
+                    unsigned k = p * KW + t;
+                    if (k < N)
+                        b[KW * i + t] = m[static_cast<unsigned>(r) * N + k];
+                }
+            }
+        }
+    }
+    return band;
+}
+
+std::vector<float> build_sq_band_f32(const float *m, unsigned N, unsigned TR)
+{
+    std::vector<float> band(static_cast<size_t>(TR + N - 1) * N * TR, 0.0f);
+    for (unsigned d = 0; d < TR + N - 1; ++d) {
+        for (unsigned k = 0; k < N; ++k) {
+            float *b = band.data() + (static_cast<size_t>(d) * N + k) * TR;
+            for (unsigned i = 0; i < TR; ++i) {
+                int r = static_cast<int>(d) - static_cast<int>(i);
+                if (r >= 0 && r < static_cast<int>(N))
+                    b[i] = m[static_cast<unsigned>(r) * N + k];
+            }
+        }
+    }
+    return band;
+}
+
+// Vertical 1D bands: independent of the block row because the row window is a
+// pure function of (i + k). Pair 2i of band[p] holds coeff[2p - i], pair
+// 2i+1 holds coeff[2p + 1 - i].
+std::vector<int16_t> build_v_band_i16(const int16_t *c, unsigned fwidth, unsigned TR)
+{
+    unsigned NP = (TR + fwidth) / 2;
+    std::vector<int16_t> band(static_cast<size_t>(NP) * 2 * TR, 0);
+    for (unsigned p = 0; p < NP; ++p) {
+        int16_t *b = band.data() + static_cast<size_t>(p) * 2 * TR;
+        for (unsigned i = 0; i < TR; ++i) {
+            int r0 = 2 * static_cast<int>(p) - static_cast<int>(i);
+            int r1 = r0 + 1;
+            if (r0 >= 0 && r0 < static_cast<int>(fwidth))
+                b[2 * i] = c[r0];
+            if (r1 >= 0 && r1 < static_cast<int>(fwidth))
+                b[2 * i + 1] = c[r1];
+        }
+    }
+    return band;
+}
+
+std::vector<float> build_v_band_f32(const float *c, unsigned fwidth, unsigned TR)
+{
+    std::vector<float> band(static_cast<size_t>(TR + fwidth - 1) * TR, 0.0f);
+    for (unsigned d = 0; d < TR + fwidth - 1; ++d) {
+        float *b = band.data() + static_cast<size_t>(d) * TR;
+        for (unsigned i = 0; i < TR; ++i) {
+            int r = static_cast<int>(d) - static_cast<int>(i);
+            if (r >= 0 && r < static_cast<int>(fwidth))
+                b[i] = c[static_cast<unsigned>(r)];
+        }
+    }
+    return band;
+}
+
+// Mirrored row pointer table covering every (block row + band offset) access:
+// rows[t] = plane row mirror(t - S) for t in [0, H + 2*S).
+template <class T>
+std::vector<const uint8_t *> build_mirror_rows(const void *src, ptrdiff_t src_stride, unsigned H, unsigned S)
+{
+    std::vector<const uint8_t *> rows(H + 2 * S);
+    for (unsigned t = 0; t < H + 2 * S; ++t)
+        rows[t] = static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(t) - static_cast<int>(S), static_cast<int>(H))) * src_stride;
+    return rows;
+}
+
+enum class SmeType { Byte, Word, Float, Half };
+
+template <SmeType TY>
+typename std::conditional<TY == SmeType::Byte, uint8_t, typename std::conditional<TY == SmeType::Float, float, uint16_t>::type>::type
+sme_sq_edge_px(const typename std::conditional<TY == SmeType::Byte, uint8_t, typename std::conditional<TY == SmeType::Float, float, uint16_t>::type>::type *const *r,
+               unsigned j, unsigned N, unsigned W, const vs_generic_params &p)
+{
+    if constexpr (TY == SmeType::Byte) {
+        return nc_sq_scalar_px_rt<uint8_t, int32_t, int16_t>(r, j, N, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+    } else if constexpr (TY == SmeType::Word) {
+        if (N > 5)
+            return nc_sq_scalar_px_rt<uint16_t, int64_t, int16_t>(r, j, N, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+        else
+            return nc_sq_scalar_px_rt<uint16_t, int32_t, int16_t>(r, j, N, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+    } else if constexpr (TY == SmeType::Half) {
+        return nc_sq_scalar_px_half_rt(r, j, N, W, p.matrixf, p.div, p.bias, p.saturate);
+    } else {
+        return nc_sq_scalar_px_rt<float, float, float>(r, j, N, W, p.matrixf, p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+template <SmeType TY>
+void sme_sq_plane(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                  const vs_generic_params &p, unsigned W, unsigned H, unsigned N)
+{
+    typedef typename std::conditional<TY == SmeType::Byte, uint8_t, typename std::conditional<TY == SmeType::Float, float, uint16_t>::type>::type T;
+    const unsigned S = N / 2;
+    const uint32_t satmask = p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu;
+
+    std::vector<const uint8_t *> rows = build_mirror_rows<T>(src, src_stride, H, S);
+
+    // Interior columns.
+    if (W > 2 * S) {
+        if constexpr (TY == SmeType::Float) {
+            unsigned TR = static_cast<unsigned>(svcntsw());
+            std::vector<float> band = build_sq_band_f32(p.matrixf, N, TR);
+            sme_sq_float_interior(rows.data(), static_cast<uint8_t *>(dst), dst_stride, band.data(), N, W, H, p.div, p.bias, satmask);
+        } else if constexpr (TY == SmeType::Half) {
+            unsigned TR = static_cast<unsigned>(svcntsw());
+            std::vector<uint16_t> band = build_sq_band_f16(p.matrixf, N, TR);
+            sme_sq_half_fmopa_interior(rows.data(), static_cast<uint8_t *>(dst), dst_stride, band.data(), N, W, H, p.div, p.bias, satmask);
+        } else if (TY == SmeType::Word && N > 7) {
+            unsigned TD = static_cast<unsigned>(svcntsd());
+            std::vector<int16_t> band = build_sq_band_i16(p.matrix, N, TD, 4);
+            int64_t weight_bias = 0;
+            for (unsigned i = 0; i < N * N; ++i) weight_bias += static_cast<int64_t>(INT16_MIN) * p.matrix[i];
+            sme_sq_int64_interior(rows.data(), static_cast<uint8_t *>(dst), dst_stride, band.data(), N, W, H,
+                                  weight_bias, p.div, p.bias, satmask, p.maxval);
+        } else {
+            unsigned TR = static_cast<unsigned>(svcntsw());
+            std::vector<int16_t> band = build_sq_band_i16(p.matrix, N, TR, 2);
+            int32_t weight_bias = 0;
+            if (TY == SmeType::Word)
+                for (unsigned i = 0; i < N * N; ++i) weight_bias += static_cast<int32_t>(INT16_MIN) * p.matrix[i];
+            sme_sq_int32_interior(rows.data(), sizeof(T), static_cast<uint8_t *>(dst), dst_stride, band.data(), N, W, H,
+                                  weight_bias, p.div, p.bias, satmask, p.maxval);
+        }
+    }
+
+    // Mirror edge columns, scalar, bit-exact with the C reference.
+    const unsigned edge = std::min(W, S);
+    for (unsigned i = 0; i < H; ++i) {
+        const T *const *r = reinterpret_cast<const T *const *>(rows.data() + i);
+        T *d = reinterpret_cast<T *>(static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        for (unsigned j = 0; j < edge; ++j)
+            d[j] = sme_sq_edge_px<TY>(r, j, N, W, p);
+        for (unsigned j = std::max(S, W > edge ? W - edge : 0); j < W; ++j)
+            d[j] = sme_sq_edge_px<TY>(r, j, N, W, p);
+    }
+}
+
+// Vertical 1D. For H > support the C row selection reduces to
+// mirror(i + k - support), which is what the banded formulation needs; the
+// tiny-plane case falls back to the C kernel.
+template <SmeType TY>
+void sme_v_plane(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                 const vs_generic_params &p, unsigned W, unsigned H)
+{
+    typedef typename std::conditional<TY == SmeType::Byte, uint8_t, typename std::conditional<TY == SmeType::Float, float, uint16_t>::type>::type T;
+    const unsigned fwidth = p.matrixsize;
+    const unsigned support = fwidth / 2;
+    const uint32_t satmask = p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu;
+
+    if (H <= support || W == 0) {
+        if constexpr (TY == SmeType::Byte)
+            vs_generic_1d_conv_v_byte_c(src, src_stride, dst, dst_stride, &p, W, H);
+        else if constexpr (TY == SmeType::Word)
+            vs_generic_1d_conv_v_word_c(src, src_stride, dst, dst_stride, &p, W, H);
+        else if constexpr (TY == SmeType::Half)
+            vs_generic_1d_conv_v_half_c(src, src_stride, dst, dst_stride, &p, W, H);
+        else
+            vs_generic_1d_conv_v_float_c(src, src_stride, dst, dst_stride, &p, W, H);
+        return;
+    }
+
+    std::vector<const uint8_t *> rows = build_mirror_rows<T>(src, src_stride, H, support);
+    unsigned TR = static_cast<unsigned>(svcntsw());
+
+    if constexpr (TY == SmeType::Float) {
+        std::vector<float> band = build_v_band_f32(p.matrixf, fwidth, TR);
+        sme_v_float_plane(rows.data(), static_cast<uint8_t *>(dst), dst_stride, band.data(), fwidth, W, H, p.div, p.bias, satmask);
+    } else if constexpr (TY == SmeType::Half) {
+        std::vector<uint16_t> band = build_v_band_f16(p.matrixf, fwidth, TR);
+        sme_v_half_fmopa_plane(rows.data(), static_cast<uint8_t *>(dst), dst_stride, band.data(), fwidth, W, H, p.div, p.bias, satmask);
+    } else {
+        std::vector<int16_t> band = build_v_band_i16(p.matrix, fwidth, TR);
+        int32_t weight_bias = 0;
+        if (TY == SmeType::Word)
+            for (unsigned i = 0; i < fwidth; ++i) weight_bias += static_cast<int32_t>(INT16_MIN) * p.matrix[i];
+        sme_v_int32_plane(rows.data(), sizeof(T), static_cast<uint8_t *>(dst), dst_stride, band.data(), fwidth, W, H,
+                          weight_bias, p.div, p.bias, satmask, p.maxval);
+    }
+}
+
+} // namespace
+
+#define VS_SME_SQUARE_ENTRY(SZ, N, TY, TN) \
+    void vs_generic_##SZ##_conv_##TN##_sme(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sme_sq_plane<SmeType::TY>(src, src_stride, dst, dst_stride, *params, width, height, N); }
+
+// Only the shapes that win even fully contended are dispatched (see
+// genericSelectSME); the smaller/thread-contested squares and all word squares
+// were pruned and fall back to NEON, so their entries are gone. Byte squares
+// serve WIDE coefficients only (int8 goes to NEON usdot).
+VS_SME_SQUARE_ENTRY(7x7,   7,  Byte,  byte)
+VS_SME_SQUARE_ENTRY(9x9,   9,  Byte,  byte)
+VS_SME_SQUARE_ENTRY(11x11, 11, Byte,  byte)
+VS_SME_SQUARE_ENTRY(7x7,   7,  Half,  half)
+VS_SME_SQUARE_ENTRY(9x9,   9,  Half,  half)
+VS_SME_SQUARE_ENTRY(11x11, 11, Half,  half)
+VS_SME_SQUARE_ENTRY(7x7,   7,  Float, float)
+VS_SME_SQUARE_ENTRY(9x9,   9,  Float, float)
+VS_SME_SQUARE_ENTRY(11x11, 11, Float, float)
+
+#define VS_SME_V_ENTRY(TY, TN) \
+    void vs_generic_1d_conv_v_##TN##_sme(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sme_v_plane<SmeType::TY>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SME_V_ENTRY(Byte, byte)
+VS_SME_V_ENTRY(Float, float)
+VS_SME_V_ENTRY(Half, half)

--- a/src/core/kernel/arm/convolution_sve.cpp
+++ b/src/core/kernel/arm/convolution_sve.cpp
@@ -1,0 +1,558 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* Non-streaming SVE (VLA) convolution kernels: square NxN (3x3..11x11),
+* 1D horizontal/vertical and separable, for byte/word/float. Never built on
+* Apple platforms (no non-streaming SVE there) and requires only base SVE
+* (Graviton3 / Neoverse V1 upward; SVE2 not assumed).
+*
+* Everything runs at int32/float32 lane density with predicated loads and
+* stores, so there is no scalar interior tail; only the mirror/replicate edge
+* columns use the scalar reference paths.
+*
+* Integer math: pixels widen to 32-bit lanes on load. byte accumulates
+* unbiased (worst case 121 * 1023 * 255 fits int32). word subtracts 32768 on
+* load; the biased worst case fits int32 through 7x7 and 1D (25 taps), and
+* the coefficient*bias sum is added back exactly, so results are bit-exact
+* with the C reference. word 9x9/11x11 sums each row in int32 and spills to
+* int64 lanes (unpklo/unpkhi), matching the int64 C reference bit-exactly.
+* float uses fused MLA (not bit-exact with C, as on the other SIMD tiers).
+*/
+
+#include <arm_sve.h>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include "../generic.h"
+#include "conv_scalar.h"
+
+namespace {
+
+enum class SvType { Byte, Word, Float };
+
+template <SvType TY>
+struct sv_traits;
+template <> struct sv_traits<SvType::Byte>  { typedef uint8_t T; typedef int32_t Acc; typedef int16_t Weight; };
+template <> struct sv_traits<SvType::Word>  { typedef uint16_t T; typedef int32_t Acc; typedef int16_t Weight; };
+template <> struct sv_traits<SvType::Float> { typedef float T; typedef float Acc; typedef float Weight; };
+
+template <SvType TY>
+inline const typename sv_traits<TY>::Weight *sv_coeffs(const vs_generic_params &p)
+{
+    if constexpr (TY == SvType::Float)
+        return p.matrixf;
+    else
+        return p.matrix;
+}
+
+// Pixel load widened to 32-bit lanes; word pixels come back biased by -32768.
+template <SvType TY>
+inline svint32_t sv_load_px(svbool_t pg, const typename sv_traits<TY>::T *p)
+{
+    if constexpr (TY == SvType::Byte)
+        return svreinterpret_s32_u32(svld1ub_u32(pg, p));
+    else
+        return svsub_n_s32_x(pg, svreinterpret_s32_u32(svld1uh_u32(pg, p)), 32768);
+}
+
+// scale/bias/saturate + round + clamp + narrowing store of one int32 vector.
+template <SvType TY>
+inline void sv_store_int(typename sv_traits<TY>::T *dst, svbool_t pg, svint32_t acc, int32_t weight_bias,
+                         float div, float bias, uint32_t satmask, int32_t maxclamp)
+{
+    svbool_t pt = svptrue_b32();
+    acc = svsub_n_s32_x(pt, acc, weight_bias);
+    svfloat32_t f = svcvt_f32_s32_x(pt, acc);
+    f = svmad_n_f32_x(pt, f, svdup_f32(div), bias);
+    f = svreinterpret_f32_u32(svand_n_u32_x(pt, svreinterpret_u32_f32(f), satmask));
+    f = svrintn_f32_x(pt, f);
+    svint32_t r = svcvt_s32_f32_x(pt, f);
+    r = svmax_n_s32_x(pt, r, 0);
+    r = svmin_n_s32_x(pt, r, maxclamp);
+    if constexpr (TY == SvType::Byte)
+        svst1b_s32(pg, reinterpret_cast<int8_t *>(dst), r);
+    else
+        svst1h_s32(pg, reinterpret_cast<int16_t *>(dst), r);
+}
+
+inline void sv_store_float(float *dst, svbool_t pg, svfloat32_t acc, float div, float bias, uint32_t satmask)
+{
+    svbool_t pt = svptrue_b32();
+    svfloat32_t f = svmad_n_f32_x(pt, acc, svdup_f32(div), bias);
+    f = svreinterpret_f32_u32(svand_n_u32_x(pt, svreinterpret_u32_f32(f), satmask));
+    svst1_f32(pg, dst, f);
+}
+
+// Store one int64-accumulated half (svcntd pixels) of a word vector strip.
+// int64 -> float32 lands in the even float lane of each doubleword; the f32
+// pipeline runs on all lanes (odd lanes garbage) and st1h writes the low 16
+// bits of each doubleword.
+inline void sv_store_word_i64_half(uint16_t *dst, unsigned valid, svint64_t acc, int64_t weight_bias,
+                                   float div, float bias, uint32_t satmask, int32_t maxclamp)
+{
+    if (!valid)
+        return;
+    svbool_t pt32 = svptrue_b32();
+    svbool_t pt64 = svptrue_b64();
+    svbool_t pgd = svwhilelt_b64_u32(0, valid);
+    acc = svsub_n_s64_x(pt64, acc, weight_bias);
+    svfloat32_t f = svcvt_f32_s64_x(pt64, acc);
+    f = svmad_n_f32_x(pt32, f, svdup_f32(div), bias);
+    f = svreinterpret_f32_u32(svand_n_u32_x(pt32, svreinterpret_u32_f32(f), satmask));
+    f = svrintn_f32_x(pt32, f);
+    svint32_t r = svcvt_s32_f32_x(pt32, f);
+    r = svmax_n_s32_x(pt32, r, 0);
+    r = svmin_n_s32_x(pt32, r, maxclamp);
+    svst1h_s64(pgd, reinterpret_cast<int16_t *>(dst), svreinterpret_s64_s32(r));
+}
+
+template <SvType TY>
+inline int32_t sv_word_bias_sum(const typename sv_traits<TY>::Weight *coeffs, unsigned n)
+{
+    if constexpr (TY == SvType::Word) {
+        int32_t weight_bias = 0;
+        for (unsigned i = 0; i < n; ++i)
+            weight_bias += -32768 * static_cast<int32_t>(coeffs[i]);
+        return weight_bias;
+    } else {
+        (void)coeffs; (void)n;
+        return 0;
+    }
+}
+
+// ---- square NxN ---------------------------------------------------------------
+
+template <SvType TY>
+typename sv_traits<TY>::T sv_sq_edge_px(const typename sv_traits<TY>::T *const *rows, unsigned j, unsigned N, unsigned W,
+                                        const vs_generic_params &p)
+{
+    if constexpr (TY == SvType::Byte) {
+        return nc_sq_scalar_px_rt<uint8_t, int32_t, int16_t>(rows, j, N, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+    } else if constexpr (TY == SvType::Word) {
+        if (N > 5)
+            return nc_sq_scalar_px_rt<uint16_t, int64_t, int16_t>(rows, j, N, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+        else
+            return nc_sq_scalar_px_rt<uint16_t, int32_t, int16_t>(rows, j, N, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+    } else {
+        return nc_sq_scalar_px_rt<float, float, float>(rows, j, N, W, p.matrixf, p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+template <SvType TY>
+void sv_sq_plane(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                 const vs_generic_params &p, unsigned W, unsigned H, unsigned N)
+{
+    typedef typename sv_traits<TY>::T T;
+    const auto *m = sv_coeffs<TY>(p);
+    const unsigned S = N / 2;
+    const uint32_t satmask = p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu;
+    const unsigned lanes32 = static_cast<unsigned>(svcntw());
+    const bool word64 = TY == SvType::Word && N > 7;
+    const unsigned Wend = W > S ? W - S : 0;
+
+    int32_t weight_bias32 = sv_word_bias_sum<TY>(m, N * N);
+    int64_t weight_bias64 = 0;
+    if (word64)
+        for (unsigned i = 0; i < N * N; ++i) weight_bias64 += -32768 * static_cast<int64_t>(m[i]);
+
+    std::vector<const uint8_t *> rows_all(H + 2 * S);
+    for (unsigned t = 0; t < H + 2 * S; ++t)
+        rows_all[t] = static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(t) - static_cast<int>(S), static_cast<int>(H))) * src_stride;
+
+    for (unsigned i = 0; i < H; ++i) {
+        const T *const *rows = reinterpret_cast<const T *const *>(rows_all.data() + i);
+        T *d = reinterpret_cast<T *>(static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+
+        for (unsigned j = S; j < Wend; j += lanes32) {
+            unsigned valid = std::min(lanes32, Wend - j);
+            svbool_t pg = svwhilelt_b32_u32(0, valid);
+            if constexpr (TY == SvType::Float) {
+                svfloat32_t acc = svdup_f32(0.0f);
+                for (unsigned r = 0; r < N; ++r) {
+                    const float *row = rows[r] + (j - S);
+                    for (unsigned k = 0; k < N; ++k)
+                        acc = svmla_n_f32_x(svptrue_b32(), acc, svld1_f32(pg, row + k), m[r * N + k]);
+                }
+                sv_store_float(d + j, pg, acc, p.div, p.bias, satmask);
+            } else if (word64) {
+                svint64_t accum_lo = svdup_s64(0), accum_hi = svdup_s64(0);
+                for (unsigned r = 0; r < N; ++r) {
+                    const T *row = rows[r] + (j - S);
+                    svint32_t row_sum = svdup_s32(0);
+                    for (unsigned k = 0; k < N; ++k)
+                        row_sum = svmla_n_s32_x(svptrue_b32(), row_sum, sv_load_px<TY>(pg, row + k), m[r * N + k]);
+                    accum_lo = svadd_s64_x(svptrue_b64(), accum_lo, svunpklo_s64(row_sum));
+                    accum_hi = svadd_s64_x(svptrue_b64(), accum_hi, svunpkhi_s64(row_sum));
+                }
+                unsigned lanes64 = static_cast<unsigned>(svcntd());
+                uint16_t *dw = reinterpret_cast<uint16_t *>(d) + j;
+                sv_store_word_i64_half(dw, std::min(valid, lanes64), accum_lo, weight_bias64, p.div, p.bias, satmask, p.maxval);
+                sv_store_word_i64_half(dw + lanes64, valid > lanes64 ? valid - lanes64 : 0, accum_hi, weight_bias64, p.div, p.bias, satmask, p.maxval);
+            } else {
+                svint32_t acc = svdup_s32(0);
+                for (unsigned r = 0; r < N; ++r) {
+                    const T *row = rows[r] + (j - S);
+                    for (unsigned k = 0; k < N; ++k)
+                        acc = svmla_n_s32_x(svptrue_b32(), acc, sv_load_px<TY>(pg, row + k), m[r * N + k]);
+                }
+                sv_store_int<TY>(d + j, pg, acc, weight_bias32, p.div, p.bias, satmask, p.maxval);
+            }
+        }
+
+        // Mirror edge columns via the scalar reference.
+        const unsigned edge = std::min(W, S);
+        for (unsigned j = 0; j < edge; ++j)
+            d[j] = sv_sq_edge_px<TY>(rows, j, N, W, p);
+        for (unsigned j = std::max(S, W > edge ? W - edge : 0); j < W; ++j)
+            d[j] = sv_sq_edge_px<TY>(rows, j, N, W, p);
+    }
+}
+
+// ---- square NxN, word, svdot_s64 ----------------------------------------------
+//
+// SDOT with 16-bit operands reduces 4 int16 products into a 64-bit lane in one
+// op, so one svdot retires svcntd() outputs x 4 taps = 8 MACs at a 128-bit VL
+// where vmlal_s16 (and the svmla u32-lane form above) retire 4. svtbl builds the
+// sliding window, exactly as the usdot byte kernels do, one 16-bit element at a
+// time: element i of the table result feeds 64-bit lane i/4 at tap i%4, so it
+// must come from pixel (i/4 + i%4).
+//
+// Measured against the NEON vmlal word kernels on a 25-tap row: +60% at 128-bit
+// (Graviton4) and +118% at 256-bit (Graviton3). It is the only integer SVE form
+// that beats NEON at 128 bits, so unlike the rest of this file it is dispatched
+// regardless of vector length.
+//
+// Bit-exact: pixels are biased by -32768 into int16 exactly as sv_load_px does,
+// the int64 sum is exact (121 * 32768 * 1023 fits easily), and the accumulated
+// coefficient*bias term is removed by the shared word store. Taps are zero-padded
+// to a multiple of 4, so the padding contributes nothing and needs no bias term.
+
+void sv_sq_word_dot_plane(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                          const vs_generic_params &p, unsigned W, unsigned H, unsigned N)
+{
+    const unsigned S = N / 2;
+    const unsigned G = (N + 3) / 4;
+    const unsigned lanes64 = static_cast<unsigned>(svcntd());   // outputs per vector
+    const unsigned lanes16 = static_cast<unsigned>(svcnth());
+    const uint32_t satmask = p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu;
+    const int16_t *m = p.matrix;
+
+    std::vector<uint16_t> idxbuf(lanes16);
+    for (unsigned i = 0; i < lanes16; ++i)
+        idxbuf[i] = static_cast<uint16_t>(i / 4 + i % 4);
+    const svuint16_t vidx = svld1_u16(svptrue_b16(), idxbuf.data());
+    const svbool_t pgld = svwhilelt_b16_u32(0u, lanes64 + 3u);
+
+    std::vector<int64_t> coeff_groups(static_cast<size_t>(N) * G);
+    for (unsigned r = 0; r < N; ++r) {
+        for (unsigned g = 0; g < G; ++g) {
+            int16_t b[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                const unsigned k = 4 * g + t;
+                b[t] = k < N ? m[r * N + k] : static_cast<int16_t>(0);
+            }
+            std::memcpy(&coeff_groups[static_cast<size_t>(r) * G + g], b, 8);
+        }
+    }
+
+    int64_t weight_bias = 0;
+    for (unsigned i = 0; i < N * N; ++i)
+        weight_bias += -32768 * static_cast<int64_t>(m[i]);
+
+    const unsigned Wend = W > S ? W - S : 0;
+    // Furthest element the window touches is row[(j - S) + 4(G-1) + lanes64 + 2];
+    // past this the scalar edge takes over rather than read off the row.
+    const long maxjj = static_cast<long>(W) + static_cast<long>(S) - 4L * static_cast<long>(G) - static_cast<long>(lanes64);
+
+    std::vector<const uint8_t *> rows_all(H + 2 * S);
+    for (unsigned t = 0; t < H + 2 * S; ++t)
+        rows_all[t] = static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(t) - static_cast<int>(S), static_cast<int>(H))) * src_stride;
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint16_t *const *rows = reinterpret_cast<const uint16_t *const *>(rows_all.data() + i);
+        uint16_t *d = reinterpret_cast<uint16_t *>(static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+
+        unsigned j = S;
+        for (; j + lanes64 <= Wend && static_cast<long>(j) <= maxjj; j += lanes64) {
+            svint64_t acc = svdup_s64(0);
+            for (unsigned r = 0; r < N; ++r) {
+                const uint16_t *row = rows[r] + (j - S);
+                for (unsigned g = 0; g < G; ++g) {
+                    svuint16_t pu = svld1_u16(pgld, row + 4 * g);
+                    svint16_t x = svreinterpret_s16_u16(svsub_n_u16_x(pgld, pu, 32768));
+                    svint16_t t = svtbl_s16(x, vidx);
+                    svint16_t w = svreinterpret_s16_s64(svdup_n_s64(coeff_groups[static_cast<size_t>(r) * G + g]));
+                    acc = svdot_s64(acc, t, w);
+                }
+            }
+            sv_store_word_i64_half(d + j, lanes64, acc, weight_bias, p.div, p.bias, satmask, p.maxval);
+        }
+
+        for (unsigned e = 0; e < S && e < W; ++e)
+            d[e] = nc_sq_scalar_px_rt<uint16_t, int64_t, int16_t>(rows, e, N, W, m, p.div, p.bias, p.saturate, p.maxval);
+        for (unsigned e = (j > S ? j : S); e < W; ++e)
+            d[e] = nc_sq_scalar_px_rt<uint16_t, int64_t, int16_t>(rows, e, N, W, m, p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+// ---- 1D -----------------------------------------------------------------------
+
+// Scalar mirror-edge pixel replicating conv_scanline_h verbatim.
+template <SvType TY>
+typename sv_traits<TY>::T sv_h_edge_px(const typename sv_traits<TY>::T *srcp, unsigned j, unsigned width,
+                                       const vs_generic_params &p)
+{
+    typedef typename sv_traits<TY>::Acc Acc;
+    const auto *coeffs = sv_coeffs<TY>(p);
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    unsigned dist_from_right = width - 1 - j;
+
+    Acc accum = 0;
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned idx = j < support - k ? std::min(support - k - j - 1, width - 1) : j - support + k;
+        accum += coeffs[k] * static_cast<Acc>(srcp[idx]);
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned idx = dist_from_right < k - support ? width - std::min(k - support - dist_from_right, width) : j - support + k;
+        accum += coeffs[k] * static_cast<Acc>(srcp[idx]);
+    }
+    float tmp = static_cast<float>(accum) * p.div + p.bias;
+    tmp = p.saturate ? tmp : std::fabs(tmp);
+    if constexpr (TY == SvType::Float) {
+        return tmp;
+    } else {
+        float c = std::min(std::max(tmp, 0.0f), static_cast<float>(sizeof(typename sv_traits<TY>::T) == 1 ? 255 : 65535));
+        long v = std::lrint(c);
+        return static_cast<typename sv_traits<TY>::T>(std::min<long>(v, p.maxval));
+    }
+}
+
+template <SvType TY>
+void sv_h_scanline(const typename sv_traits<TY>::T *srcp, typename sv_traits<TY>::T *dstp, unsigned width,
+                   const vs_generic_params &p, uint32_t satmask, int32_t weight_bias)
+{
+    const auto *coeffs = sv_coeffs<TY>(p);
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    const unsigned lanes32 = static_cast<unsigned>(svcntw());
+
+    for (unsigned j = 0; j < std::min(width, support); ++j)
+        dstp[j] = sv_h_edge_px<TY>(srcp, j, width, p);
+
+    unsigned end = width - std::min(width, support);
+    for (unsigned j = support; j < end; j += lanes32) {
+        unsigned valid = std::min(lanes32, end - j);
+        svbool_t pg = svwhilelt_b32_u32(0, valid);
+        if constexpr (TY == SvType::Float) {
+            svfloat32_t acc = svdup_f32(0.0f);
+            for (unsigned k = 0; k < fwidth; ++k)
+                acc = svmla_n_f32_x(svptrue_b32(), acc, svld1_f32(pg, srcp + j - support + k), coeffs[k]);
+            sv_store_float(dstp + j, pg, acc, p.div, p.bias, satmask);
+        } else {
+            svint32_t acc = svdup_s32(0);
+            for (unsigned k = 0; k < fwidth; ++k)
+                acc = svmla_n_s32_x(svptrue_b32(), acc, sv_load_px<TY>(pg, srcp + j - support + k), coeffs[k]);
+            sv_store_int<TY>(dstp + j, pg, acc, weight_bias, p.div, p.bias, satmask, p.maxval);
+        }
+    }
+
+    for (unsigned j = std::max(support, end); j < width; ++j)
+        dstp[j] = sv_h_edge_px<TY>(srcp, j, width, p);
+}
+
+template <SvType TY>
+void sv_v_scanline(const void *const *srcs, typename sv_traits<TY>::T *dstp, unsigned width,
+                   const vs_generic_params &p, uint32_t satmask, int32_t weight_bias)
+{
+    typedef typename sv_traits<TY>::T T;
+    const auto *coeffs = sv_coeffs<TY>(p);
+    unsigned fwidth = p.matrixsize;
+    const unsigned lanes32 = static_cast<unsigned>(svcntw());
+
+    for (unsigned j = 0; j < width; j += lanes32) {
+        unsigned valid = std::min(lanes32, width - j);
+        svbool_t pg = svwhilelt_b32_u32(0, valid);
+        if constexpr (TY == SvType::Float) {
+            svfloat32_t acc = svdup_f32(0.0f);
+            for (unsigned k = 0; k < fwidth; ++k)
+                acc = svmla_n_f32_x(svptrue_b32(), acc, svld1_f32(pg, static_cast<const float *>(srcs[k]) + j), coeffs[k]);
+            sv_store_float(dstp + j, pg, acc, p.div, p.bias, satmask);
+        } else {
+            svint32_t acc = svdup_s32(0);
+            for (unsigned k = 0; k < fwidth; ++k)
+                acc = svmla_n_s32_x(svptrue_b32(), acc, sv_load_px<TY>(pg, static_cast<const T *>(srcs[k]) + j), coeffs[k]);
+            sv_store_int<TY>(dstp + j, pg, acc, weight_bias, p.div, p.bias, satmask, p.maxval);
+        }
+    }
+}
+
+// Row-pointer selection replicating conv_plane_v / conv_plane_x verbatim.
+inline void sv_select_rows(const void *src, ptrdiff_t src_stride, const void *srcp[25],
+                           unsigned i, unsigned height, unsigned fwidth)
+{
+    unsigned support = fwidth / 2;
+    unsigned dist_from_bottom = height - 1 - i;
+
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned row = i < support - k ? std::min(support - k - i - 1, height - 1) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned row = dist_from_bottom < k - support ? height - std::min(k - support - dist_from_bottom, i) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+}
+
+template <SvType TY>
+void sv_plane_h(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename sv_traits<TY>::T T;
+    const uint32_t satmask = p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu;
+    int32_t weight_bias = sv_word_bias_sum<TY>(sv_coeffs<TY>(p), p.matrixsize);
+    for (unsigned i = 0; i < height; ++i) {
+        const T *srcp = reinterpret_cast<const T *>(static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(i) * src_stride);
+        T *dstp = reinterpret_cast<T *>(static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        sv_h_scanline<TY>(srcp, dstp, width, p, satmask, weight_bias);
+    }
+}
+
+template <SvType TY>
+void sv_plane_x(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename sv_traits<TY>::T T;
+    const uint32_t satmask = p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu;
+    int32_t weight_bias = sv_word_bias_sum<TY>(sv_coeffs<TY>(p), p.matrixsize);
+    std::vector<T> tmp(width);
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        sv_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        T *dstp = reinterpret_cast<T *>(static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        sv_v_scanline<TY>(srcp, tmp.data(), width, p, satmask, weight_bias);
+        sv_h_scanline<TY>(tmp.data(), dstp, width, p, satmask, weight_bias);
+    }
+}
+
+// ---- 3x3 (replicate edges, filter_plane_3x3 semantics) -------------------------
+
+template <SvType TY>
+void sv_plane_3x3(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                  const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename sv_traits<TY>::T T;
+    typedef typename sv_traits<TY>::Acc Acc;
+    const auto *coeffs = sv_coeffs<TY>(p);
+    const uint32_t satmask = p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu;
+    int32_t weight_bias = sv_word_bias_sum<TY>(coeffs, 9);
+    const unsigned lanes32 = static_cast<unsigned>(svcntw());
+
+    for (unsigned i = 0; i < height; ++i) {
+        unsigned above_idx = i == 0 ? 0 : i - 1;
+        unsigned below_idx = i == height - 1 ? height - 1 : i + 1;
+        const T *rows[3] = {
+            reinterpret_cast<const T *>(static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(above_idx) * src_stride),
+            reinterpret_cast<const T *>(static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(i) * src_stride),
+            reinterpret_cast<const T *>(static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(below_idx) * src_stride),
+        };
+        T *dstp = reinterpret_cast<T *>(static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+
+        auto scalar_px = [&](unsigned a, unsigned b, unsigned c) -> T {
+            Acc accum = 0;
+            for (unsigned r = 0; r < 3; ++r) {
+                accum += coeffs[r * 3 + 0] * static_cast<Acc>(rows[r][a]);
+                accum += coeffs[r * 3 + 1] * static_cast<Acc>(rows[r][b]);
+                accum += coeffs[r * 3 + 2] * static_cast<Acc>(rows[r][c]);
+            }
+            float tmp = static_cast<float>(accum) * p.div + p.bias;
+            tmp = p.saturate ? tmp : std::fabs(tmp);
+            if constexpr (TY == SvType::Float) {
+                return tmp;
+            } else {
+                float cl = std::min(std::max(tmp, 0.0f), static_cast<float>(sizeof(T) == 1 ? 255 : 65535));
+                long v = std::lrint(cl);
+                return static_cast<T>(std::min<long>(v, p.maxval));
+            }
+        };
+
+        dstp[0] = scalar_px(0, 0, width > 1 ? 1 : 0);
+
+        unsigned end = width > 1 ? width - 1 : 0;
+        for (unsigned j = 1; j < end; j += lanes32) {
+            unsigned valid = std::min(lanes32, end - j);
+            svbool_t pg = svwhilelt_b32_u32(0, valid);
+            if constexpr (TY == SvType::Float) {
+                svfloat32_t acc = svdup_f32(0.0f);
+                for (unsigned r = 0; r < 3; ++r)
+                    for (unsigned k = 0; k < 3; ++k)
+                        acc = svmla_n_f32_x(svptrue_b32(), acc, svld1_f32(pg, rows[r] + j - 1 + k), coeffs[r * 3 + k]);
+                sv_store_float(dstp + j, pg, acc, p.div, p.bias, satmask);
+            } else {
+                svint32_t acc = svdup_s32(0);
+                for (unsigned r = 0; r < 3; ++r)
+                    for (unsigned k = 0; k < 3; ++k)
+                        acc = svmla_n_s32_x(svptrue_b32(), acc, sv_load_px<TY>(pg, rows[r] + j - 1 + k), coeffs[r * 3 + k]);
+                sv_store_int<TY>(dstp + j, pg, acc, weight_bias, p.div, p.bias, satmask, p.maxval);
+            }
+        }
+
+        if (width > 1)
+            dstp[width - 1] = scalar_px(width - 2, width - 1, width - 1);
+    }
+}
+
+} // namespace
+
+// Runtime SVE vector length in bytes, for the dispatcher (which is not
+// compiled with +sve and so cannot use svcntb itself). Only called after the
+// CPU is known to report SVE.
+unsigned vs_sve_vector_length(void)
+{
+    return static_cast<unsigned>(svcntb());
+}
+
+#define VS_SVE_SQUARE_ENTRY(SZ, N, TY, TN) \
+    void vs_generic_##SZ##_conv_##TN##_sve(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sv_sq_plane<SvType::TY>(src, src_stride, dst, dst_stride, *params, width, height, N); }
+
+// Only the shapes that beat the round-2 NEON tier on Graviton3 survive: byte
+// plain squares through 7x7 (9x9/11x11 wide lost to the NEON lane-coefficient
+// squares), and word svdot 9x9/11x11 (7x7 became a wash). The plain word
+// squares and the float squares (9x9/11x11) all lost to NEON and are gone.
+VS_SVE_SQUARE_ENTRY(5x5,   5,  Byte,  byte)
+VS_SVE_SQUARE_ENTRY(7x7,   7,  Byte,  byte)
+#define VS_SVE_SQUARE_DOT_ENTRY(SZ, N) \
+    void vs_generic_##SZ##_conv_word_sve_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sv_sq_word_dot_plane(src, src_stride, dst, dst_stride, *params, width, height, N); }
+
+VS_SVE_SQUARE_DOT_ENTRY(9x9,   9)
+VS_SVE_SQUARE_DOT_ENTRY(11x11, 11)
+
+#define VS_SVE_ENTRY(KERNEL, FN, TY, TN) \
+    void vs_generic_##KERNEL##_##TN##_sve(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { FN<SvType::TY>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SVE_ENTRY(3x3_conv, sv_plane_3x3, Byte, byte)
+VS_SVE_ENTRY(3x3_conv, sv_plane_3x3, Word, word)
+
+VS_SVE_ENTRY(1d_conv_h, sv_plane_h, Byte, byte)
+// 2d_conv_sep byte pruned -> the round-2 usdot NEON separable wins on Graviton3.

--- a/src/core/kernel/arm/lut_neon.cpp
+++ b/src/core/kernel/arm/lut_neon.cpp
@@ -1,0 +1,59 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* NEON byte -> byte Lut scanline. The whole 256-entry table lives in sixteen
+* vector registers; each block of 16 pixels resolves with four vqtbl4q
+* lookups (each covers a 64-entry window, returning 0 out of range) OR-ed
+* together. Like the scalar fallback, the row is processed in chunks that may
+* extend a few bytes past `w`; frame rows are padded, so this is safe.
+*/
+
+#include <arm_neon.h>
+#include <cstdint>
+
+void vs_lut1_b_b_neon(const uint8_t *src, uint8_t *dst, int w, const uint8_t *lut)
+{
+    uint8x16x4_t t0 = vld1q_u8_x4(lut);
+    uint8x16x4_t t1 = vld1q_u8_x4(lut + 64);
+    uint8x16x4_t t2 = vld1q_u8_x4(lut + 128);
+    uint8x16x4_t t3 = vld1q_u8_x4(lut + 192);
+    uint8x16_t c64 = vdupq_n_u8(64);
+
+    auto lookup16 = [&](uint8x16_t idx) -> uint8x16_t {
+        uint8x16_t r = vqtbl4q_u8(t0, idx);
+        idx = vsubq_u8(idx, c64);
+        r = vorrq_u8(r, vqtbl4q_u8(t1, idx));
+        idx = vsubq_u8(idx, c64);
+        r = vorrq_u8(r, vqtbl4q_u8(t2, idx));
+        idx = vsubq_u8(idx, c64);
+        return vorrq_u8(r, vqtbl4q_u8(t3, idx));
+    };
+
+    int x = 0;
+    for (; x + 16 <= w; x += 16)
+        vst1q_u8(dst + x, lookup16(vld1q_u8(src + x)));
+    // Tail: 8-pixel chunk with the same <= 7 byte overrun as the scalar path.
+    for (; x < w; x += 8) {
+        uint8x8_t idx8 = vld1_u8(src + x);
+        uint8x16_t r = lookup16(vcombine_u8(idx8, idx8));
+        vst1_u8(dst + x, vget_low_u8(r));
+    }
+}

--- a/src/core/kernel/arm/lut_sve.cpp
+++ b/src/core/kernel/arm/lut_sve.cpp
@@ -1,0 +1,144 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* SVE gather Lut1 for 16-bit sources.
+*
+* A 16-bit source indexes a 65536-entry table, which is far too large for the
+* byte path's tbl/vpermb trick, so every ISA runs this scalar -- x86 included,
+* where the only Lut1 SIMD kernel is the AVX-512 VBMI byte->byte one. SVE can do
+* it with a real gather: widen the 16-bit pixels into 32-bit lanes and use them
+* as indices, so one gather retires svcntw() lookups.
+*
+* Bit-exact by construction: it is the same table read, just several at a time.
+*
+* Whether it beats the scalar loop depends on how many lookups a gather retires,
+* which is svcntw() and therefore vector-length dependent (measured, 65536-entry
+* table, random indices):
+*
+*             word->word   word->byte
+*   256-bit      +55%         +75%      (Graviton3, 8 lookups/gather)
+*   128-bit       -7%         +36%      (Graviton4, 4 lookups/gather)
+*
+* so word->word is gated on a vector length above 128 bits and word->byte is not.
+* The narrower destination wins at both because the store narrows 4:1 rather than
+* 2:1, which is where the scalar loop spends its time.
+*/
+
+#include <arm_sve.h>
+#include <cstdint>
+#include <type_traits>
+
+void vs_lut1_w_w_sve(const uint16_t *src, uint16_t *dst, int w, const uint16_t *lut)
+{
+    const unsigned n = static_cast<unsigned>(w);
+    const unsigned step = static_cast<unsigned>(svcntw());
+    for (unsigned i = 0; i < n; i += step) {
+        svbool_t pg = svwhilelt_b32_u32(i, n);
+        svuint32_t idx = svld1uh_u32(pg, src + i);
+        svuint32_t v = svld1uh_gather_u32index_u32(pg, lut, idx);
+        svst1h_u32(pg, dst + i, v);
+    }
+}
+
+void vs_lut1_w_b_sve(const uint16_t *src, uint8_t *dst, int w, const uint8_t *lut)
+{
+    const unsigned n = static_cast<unsigned>(w);
+    const unsigned step = static_cast<unsigned>(svcntw());
+    for (unsigned i = 0; i < n; i += step) {
+        svbool_t pg = svwhilelt_b32_u32(i, n);
+        svuint32_t idx = svld1uh_u32(pg, src + i);
+        // byte elements need no index scaling, so this is the offset form.
+        svuint32_t v = svld1ub_gather_u32offset_u32(pg, lut, idx);
+        svst1b_u32(pg, dst + i, v);
+    }
+}
+
+/*
+* SVE gather Lut2.
+*
+* Lut2 indexes a 2D table with a pixel from each source clip:
+*
+*   dst[x] = lut[(min(sy[x], my) << bitsx) + min(sx[x], mx)]
+*
+* which is the scalar path verbatim, one lane at a time. Unlike Lut1, whose byte
+* destination packs 8 lookups into a uint64 and stores once, the Lut2 scalar path
+* is a plain per-pixel loop for every destination width, so there is more headroom
+* here than there was for Lut1.
+*
+* The combos mirror the AVX-512 ones: both sources 16-bit (ww), or one of the two
+* 8-bit (wb, bw), each with a word or byte destination. Two 8-bit sources are left
+* scalar -- Lut2 caps the total indexing bits at 20, so a byte/byte table is at most
+* 65536 entries (128 KB) and stays resident in L2, where a gather has nothing to
+* recover. x86 declines that combo for the same reason.
+*
+* Bit-exact by construction, and predicated on svwhilelt rather than relying on row
+* padding, so the width tail needs no scalar cleanup and nothing is read out of bounds.
+*/
+
+namespace {
+
+template<typename T>
+inline svuint32_t load_widen(svbool_t pg, const T *p)
+{
+    if constexpr (sizeof(T) == 1)
+        return svld1ub_u32(pg, p);
+    else
+        return svld1uh_u32(pg, p);
+}
+
+template<typename V>
+inline void gather_store(svbool_t pg, V *d, const V *lut, svuint32_t idx)
+{
+    if constexpr (sizeof(V) == 2) {
+        // 16-bit table entries are scaled by the index form.
+        svst1h_u32(pg, d, svld1uh_gather_u32index_u32(pg, lut, idx));
+    } else {
+        // byte elements need no index scaling, so this is the offset form.
+        svst1b_u32(pg, d, svld1ub_gather_u32offset_u32(pg, lut, idx));
+    }
+}
+
+template<typename T, typename U, typename V>
+inline void lut2_gather(const T *sx, const U *sy, V *d, int w, const V *lut, int bitsx, unsigned mx, unsigned my)
+{
+    const unsigned n = static_cast<unsigned>(w);
+    const unsigned step = static_cast<unsigned>(svcntw());
+    const svuint32_t vmx = svdup_u32(mx);
+    const svuint32_t vmy = svdup_u32(my);
+    const svuint32_t vsh = svdup_u32(static_cast<unsigned>(bitsx));
+
+    for (unsigned i = 0; i < n; i += step) {
+        svbool_t pg = svwhilelt_b32_u32(i, n);
+        svuint32_t ix = svmin_u32_x(pg, load_widen<T>(pg, sx + i), vmx);
+        svuint32_t iy = svmin_u32_x(pg, load_widen<U>(pg, sy + i), vmy);
+        svuint32_t idx = svadd_u32_x(pg, svlsl_u32_x(pg, iy, vsh), ix);
+        gather_store<V>(pg, d + i, lut, idx);
+    }
+}
+
+} // namespace
+
+void vs_lut2_gather_ww_w_sve(const uint16_t *sx, const uint16_t *sy, uint16_t *d, int w, const uint16_t *lut, int bitsx, unsigned mx, unsigned my) { lut2_gather<uint16_t, uint16_t, uint16_t>(sx, sy, d, w, lut, bitsx, mx, my); }
+void vs_lut2_gather_ww_b_sve(const uint16_t *sx, const uint16_t *sy, uint8_t *d, int w, const uint8_t *lut, int bitsx, unsigned mx, unsigned my) { lut2_gather<uint16_t, uint16_t, uint8_t>(sx, sy, d, w, lut, bitsx, mx, my); }
+void vs_lut2_gather_wb_w_sve(const uint16_t *sx, const uint8_t *sy, uint16_t *d, int w, const uint16_t *lut, int bitsx, unsigned mx, unsigned my) { lut2_gather<uint16_t, uint8_t, uint16_t>(sx, sy, d, w, lut, bitsx, mx, my); }
+void vs_lut2_gather_wb_b_sve(const uint16_t *sx, const uint8_t *sy, uint8_t *d, int w, const uint8_t *lut, int bitsx, unsigned mx, unsigned my) { lut2_gather<uint16_t, uint8_t, uint8_t>(sx, sy, d, w, lut, bitsx, mx, my); }
+void vs_lut2_gather_bw_w_sve(const uint8_t *sx, const uint16_t *sy, uint16_t *d, int w, const uint16_t *lut, int bitsx, unsigned mx, unsigned my) { lut2_gather<uint8_t, uint16_t, uint16_t>(sx, sy, d, w, lut, bitsx, mx, my); }
+void vs_lut2_gather_bw_b_sve(const uint8_t *sx, const uint16_t *sy, uint8_t *d, int w, const uint8_t *lut, int bitsx, unsigned mx, unsigned my) { lut2_gather<uint8_t, uint16_t, uint8_t>(sx, sy, d, w, lut, bitsx, mx, my); }

--- a/src/core/kernel/arm/neon_common.h
+++ b/src/core/kernel/arm/neon_common.h
@@ -1,0 +1,142 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* Shared helpers for the AArch64 NEON convolution kernels.
+*
+* Store pipeline semantics match the C reference (and the x86 AVX2+ tiers):
+* int32/int64 accumulator -> float, fused multiply-add of (div, bias), optional
+* fabs via sign-bit mask, round to nearest-even, saturating narrow, min with
+* maxval for word. Integer accumulation orders are associative, so the integer
+* kernels are bit-exact with kernel/generic.cpp; float kernels use FMA and a
+* different summation order, matching the documented x86 AVX2/AVX-512 float
+* behaviour (not bit-exact with C by design).
+*
+* The scalar edge helpers replicate the C reference expressions exactly; on
+* AArch64 the reference C and these helpers compile to the same contracted
+* fmadd sequence, so edge columns match the C kernels on integer formats.
+*/
+
+#ifndef NEON_COMMON_H
+#define NEON_COMMON_H
+
+#include <arm_neon.h>
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <type_traits>
+#include "conv_scalar.h"
+
+namespace {
+
+// tmp = accum * div + bias (fused); !saturate clears the sign bit (fabs).
+inline float32x4_t nc_scale_bias_sat(float32x4_t x, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    float32x4_t t = vfmaq_f32(bi, x, sc);
+    return vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(t), sm));
+}
+
+inline uint32x4_t nc_satmask(uint8_t saturate)
+{
+    return vdupq_n_u32(saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu);
+}
+
+// 8 byte pixels from two int32x4 accumulators. Signed saturate to i16 then
+// unsigned saturate to u8: same clamp as the scalar [0, 255] + lrint sequence.
+inline void nc_store_u8x8(uint8_t *dst, int32x4_t lo, int32x4_t hi, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    int32x4_t rlo = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(lo), sc, bi, sm));
+    int32x4_t rhi = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(hi), sc, bi, sm));
+    int16x8_t p = vcombine_s16(vqmovn_s32(rlo), vqmovn_s32(rhi));
+    vst1_u8(dst, vqmovun_s16(p));
+}
+
+// 8 word pixels from two int32x4 accumulators. Unsigned saturate to u16, then
+// clamp to maxval for sub-16-bit depths.
+inline void nc_store_u16x8(uint16_t *dst, int32x4_t lo, int32x4_t hi, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int32x4_t rlo = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(lo), sc, bi, sm));
+    int32x4_t rhi = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(hi), sc, bi, sm));
+    uint16x8_t p = vcombine_u16(vqmovun_s32(rlo), vqmovun_s32(rhi));
+    vst1q_u16(dst, vminq_u16(p, mv));
+}
+
+// int64 -> float32 for the word 9x9/11x11 accumulators: exact via double
+// (|x| < 2^34), single rounding to float32 -- identical to the C reference's
+// direct int64 -> float conversion.
+inline float32x4_t nc_i64x4_to_f32(int64x2_t a, int64x2_t b)
+{
+    float32x2_t lo = vcvt_f32_f64(vcvtq_f64_s64(a));
+    return vcvt_high_f32_f64(lo, vcvtq_f64_s64(b));
+}
+
+inline void nc_store_u16x8_i64(uint16_t *dst, int64x2_t a, int64x2_t b, int64x2_t c, int64x2_t d,
+                               float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int32x4_t rlo = vcvtnq_s32_f32(nc_scale_bias_sat(nc_i64x4_to_f32(a, b), sc, bi, sm));
+    int32x4_t rhi = vcvtnq_s32_f32(nc_scale_bias_sat(nc_i64x4_to_f32(c, d), sc, bi, sm));
+    uint16x8_t p = vcombine_u16(vqmovun_s32(rlo), vqmovun_s32(rhi));
+    vst1q_u16(dst, vminq_u16(p, mv));
+}
+
+// float store: scale/bias/sat only, no clamp (matches C float semantics).
+inline void nc_store_f32x4(float *dst, float32x4_t acc, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    vst1q_f32(dst, nc_scale_bias_sat(acc, sc, bi, sm));
+}
+
+// half store: f32 -> f16 round-to-nearest-even, matching floatToHalf.
+inline void nc_store_h16x8(uint16_t *dst, float32x4_t a0, float32x4_t a1, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    float16x4_t lo = vcvt_f16_f32(nc_scale_bias_sat(a0, sc, bi, sm));
+    float16x8_t p = vcvt_high_f16_f32(lo, nc_scale_bias_sat(a1, sc, bi, sm));
+    vst1q_u16(dst, vreinterpretq_u16_f16(p));
+}
+
+// 16 byte pixels widened to two s16x8 (always non-negative).
+struct nc_byte16 {
+    int16x8_t lo, hi;
+};
+inline nc_byte16 nc_load_byte16(const uint8_t *p)
+{
+    uint8x16_t v = vld1q_u8(p);
+    return { vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(v))),
+             vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(v))) };
+}
+
+// 8 word pixels biased into signed range: u16 + INT16_MIN (xor 0x8000).
+inline int16x8_t nc_load_word_biased(const uint16_t *p)
+{
+    return vreinterpretq_s16_u16(veorq_u16(vld1q_u16(p), vdupq_n_u16(0x8000u)));
+}
+
+// 8 half pixels widened to two f32x4.
+struct nc_half8 {
+    float32x4_t lo, hi;
+};
+inline nc_half8 nc_load_half8(const uint16_t *p)
+{
+    float16x8_t v = vreinterpretq_f16_u16(vld1q_u16(p));
+    return { vcvt_f32_f16(vget_low_f16(v)), vcvt_high_f32_f16(v) };
+}
+
+} // namespace
+
+#endif // NEON_COMMON_H

--- a/src/core/kernel/arm/square_dot_neon.cpp
+++ b/src/core/kernel/arm/square_dot_neon.cpp
@@ -1,0 +1,383 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* FEAT_I8MM byte square NxN convolution, N in {5,7,9,11} -- a faster interior for
+* the byte path, dispatched only when every coefficient fits int8 (conv_int8) and
+* the CPU reports i8mm.
+*
+* This is the ARM analog of square_vnni_impl.h: usdot is the vpdpbusd equivalent,
+* reducing 4 uint8*int8 products into an int32 lane in one op with no byte->word
+* widening, and vqtbl1q_u8 plays the role of vpermb -- it builds the sliding
+* window so that 32-bit lane l holds the 4 pixels output j+l needs. The
+* accumulator therefore stays linear (lane l = output j+l) and the store needs no
+* un-scramble.
+*
+* Bit-exact with sq_interior_byte: the products and the int32 sum are the same
+* integers (integer addition is associative, so the regrouping into 4-tap chunks
+* cannot change the result), and the scale/bias/round/clamp reuses the same
+* nc_store_u8x8. |coeff| <= 127 under conv_int8, so 121 * 127 * 255 cannot
+* overflow int32.
+*
+* Coefficients are zero-padded to a multiple of 4 taps per row, so the window can
+* read up to 4G-N taps past the kernel; those pixels are multiplied by zero, but
+* they are still *read*, so the SIMD interior is bounded to keep every load inside
+* the row and the driver's scalar edge covers whatever is left.
+*
+* Compiled in its own TU with -march=...+i8mm (see meson.build). NEON baseline
+* code must not be built with +i8mm, hence the separate TU rather than a target
+* attribute.
+*/
+
+#include <cstdint>
+#include <cstring>
+#include "../generic.h"
+#include "conv_scalar.h"
+#include "neon_common.h"
+
+namespace {
+
+// Window indices: 32-bit lane l gets pixels {l, l+1, l+2, l+3} of the 8-byte load.
+alignas(16) const uint8_t NC_DOT_WIN[16] = {
+    0, 1, 2, 3,
+    1, 2, 3, 4,
+    2, 3, 4, 5,
+    3, 4, 5, 6,
+};
+
+template <unsigned N>
+unsigned sq_interior_byte_dot(const uint8_t *const *rows, uint8_t *dst, unsigned S, unsigned W,
+                              const int32_t *cg, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned G = (N + 3) / 4;                 // 4-tap groups per row
+    const uint8x16_t widx = vld1q_u8(NC_DOT_WIN);
+
+    auto block = [&](unsigned jj) {
+        int32x4_t a0 = vdupq_n_s32(0), a1 = vdupq_n_s32(0), a2 = vdupq_n_s32(0), a3 = vdupq_n_s32(0);
+        for (unsigned r = 0; r < N; ++r) {
+            const uint8_t *row = rows[r] + (jj - S);
+            for (unsigned g = 0; g < G; ++g) {
+                // The group's 4 coefficients, replicated into every 32-bit lane.
+                const int8x16_t w = vreinterpretq_s8_s32(vdupq_n_s32(cg[r * G + g]));
+                const uint8_t *q = row + 4 * g;
+                const uint8x16_t z = vdupq_n_u8(0);
+                uint8x16_t t0 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 0), vget_low_u8(z)), widx);
+                uint8x16_t t1 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 4), vget_low_u8(z)), widx);
+                uint8x16_t t2 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 8), vget_low_u8(z)), widx);
+                uint8x16_t t3 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 12), vget_low_u8(z)), widx);
+                a0 = vusdotq_s32(a0, t0, w);
+                a1 = vusdotq_s32(a1, t1, w);
+                a2 = vusdotq_s32(a2, t2, w);
+                a3 = vusdotq_s32(a3, t3, w);
+            }
+        }
+        nc_store_u8x8(dst + jj, a0, a1, sc, bi, sm);
+        nc_store_u8x8(dst + jj + 8, a2, a3, sc, bi, sm);
+    };
+
+    const unsigned end = W > S ? W - S : 0;
+    if (end < S + 16)
+        return S;
+
+    // Highest block start whose furthest load, row[(jj - S) + 4(G-1) + 12 + 7],
+    // still lands inside the row.
+    const long maxjj = static_cast<long>(W) + static_cast<long>(S) - 4L * static_cast<long>(G) - 16L;
+    if (maxjj < static_cast<long>(S))
+        return S;
+
+    unsigned j = S;
+    for (; j + 16 <= end && static_cast<long>(j) <= maxjj; j += 16)
+        block(j);
+
+    // Overlapping final block for the sub-vector remainder; re-storing already
+    // written columns is safe because this path is bit-exact with the scalar one.
+    if (j < end) {
+        long c = static_cast<long>(end) - 16;
+        if (c > maxjj)
+            c = maxjj;
+        if (c >= static_cast<long>(S) && static_cast<unsigned>(c) + 16 > j) {
+            block(static_cast<unsigned>(c));
+            j = static_cast<unsigned>(c) + 16;
+        }
+    }
+    return j;
+}
+
+template <unsigned N>
+void sq_plane_byte_dot(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                       const vs_generic_params &p, unsigned W, unsigned H)
+{
+    constexpr unsigned S = N / 2;
+    constexpr unsigned G = (N + 3) / 4;
+
+    // Pack each row's taps into 4-tap groups of int8, zero-filling the tail.
+    int32_t cg[N * G];
+    for (unsigned r = 0; r < N; ++r) {
+        for (unsigned g = 0; g < G; ++g) {
+            int8_t b[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                const unsigned k = 4 * g + t;
+                b[t] = k < N ? static_cast<int8_t>(p.matrix[r * N + k]) : 0;
+            }
+            std::memcpy(&cg[r * G + g], b, 4);
+        }
+    }
+
+    const float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    const uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint8_t *rows[N];
+        for (unsigned r = 0; r < N; ++r)
+            rows[r] = static_cast<const uint8_t *>(src) +
+                static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(i) + static_cast<int>(r) - static_cast<int>(S), static_cast<int>(H))) * ss;
+        uint8_t *d = static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * ds;
+
+        const unsigned aend = sq_interior_byte_dot<N>(rows, d, S, W, cg, sc, bi, sm);
+
+        for (unsigned j = 0; j < S && j < W; ++j)
+            d[j] = nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+        for (unsigned j = (aend > S ? aend : S); j < W; ++j)
+            d[j] = nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+// ---- 3x3 byte (replicate edges, conv_plane_3x3 semantics) ----------------------
+//
+// The 3x3 shape was originally skipped because the square driver above uses
+// MIRROR edges while 3x3 convolution replicates -- but the interior
+// (sq_interior_byte_dot<3>, G=1) is edge-agnostic, so all it needs is its own
+// replicate-edge driver. Same conv_int8 + i8mm gate, same bit-exactness
+// argument, and 3x3 byte is the most common convolution there is.
+
+inline uint8_t sq3_edge_px_byte(const uint8_t *const rows[3], const vs_generic_params &p,
+                                unsigned a, unsigned b, unsigned c)
+{
+    int32_t accum = 0;
+    for (unsigned r = 0; r < 3; ++r) {
+        accum += p.matrix[r * 3 + 0] * static_cast<int32_t>(rows[r][a]);
+        accum += p.matrix[r * 3 + 1] * static_cast<int32_t>(rows[r][b]);
+        accum += p.matrix[r * 3 + 2] * static_cast<int32_t>(rows[r][c]);
+    }
+    float tmp = static_cast<float>(accum) * p.div + p.bias;
+    tmp = p.saturate ? tmp : std::fabs(tmp);
+    float cl = std::min(std::max(tmp, 0.0f), 255.0f);
+    long v = std::lrint(cl);
+    return static_cast<uint8_t>(std::min<long>(v, p.maxval));
+}
+
+void sq_plane_byte_dot_3x3(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                           const vs_generic_params &p, unsigned W, unsigned H)
+{
+    // One 4-tap group per row: {c0, c1, c2, 0}.
+    int32_t cg[3];
+    for (unsigned r = 0; r < 3; ++r) {
+        int8_t b[4] = { static_cast<int8_t>(p.matrix[r * 3 + 0]),
+                        static_cast<int8_t>(p.matrix[r * 3 + 1]),
+                        static_cast<int8_t>(p.matrix[r * 3 + 2]), 0 };
+        std::memcpy(&cg[r], b, 4);
+    }
+
+    const float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    const uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < H; ++i) {
+        unsigned above = i == 0 ? 0 : i - 1;
+        unsigned below = i == H - 1 ? H - 1 : i + 1;
+        const uint8_t *rows[3] = {
+            static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(above) * ss,
+            static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(i) * ss,
+            static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(below) * ss,
+        };
+        uint8_t *d = static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * ds;
+
+        const unsigned aend = sq_interior_byte_dot<3>(rows, d, 1, W, cg, sc, bi, sm);
+
+        d[0] = sq3_edge_px_byte(rows, p, 0, 0, W > 1 ? 1 : 0);
+        for (unsigned j = std::max(aend, 1u); j < W; ++j)
+            d[j] = sq3_edge_px_byte(rows, p, j - 1, j, j == W - 1 ? W - 1 : j + 1);
+    }
+}
+
+// ---- 1D horizontal byte -------------------------------------------------------
+//
+// One row of the square machinery: the taps run along the scanline and
+// zero-pad to 4-tap groups exactly like a square row, so the window/usdot
+// form carries over with the row loop removed. One 1D-specific improvement:
+// consecutive groups overlap 3 of their 4 window loads (group g reads at
+// offsets 4g..4g+12, group g+1 at 4g+4..), so the group loop rolls the loads
+// forward instead of reloading -- the squares cannot do this because each
+// row has its own pointer. Bit-exact with vs_generic_1d_conv_h_byte_neon for
+// the same reason the squares are: integer regrouping is associative and the
+// store pipeline is shared. Vertical 1D does NOT transfer: its taps run
+// across rows, so there is no scanline window to build.
+
+// conv_h_edge_px<Byte> replica (convolution_neon.cpp); keep in sync. The 1D
+// kernels clamp edge taps instead of the squares' mirror.
+inline uint8_t h_edge_px_byte(const uint8_t *srcp, unsigned j, unsigned width, const vs_generic_params &p)
+{
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    unsigned dist_from_right = width - 1 - j;
+
+    int32_t accum = 0;
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned idx = j < support - k ? std::min(support - k - j - 1, width - 1) : j - support + k;
+        accum += p.matrix[k] * static_cast<int32_t>(srcp[idx]);
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned idx = dist_from_right < k - support ? width - std::min(k - support - dist_from_right, width) : j - support + k;
+        accum += p.matrix[k] * static_cast<int32_t>(srcp[idx]);
+    }
+    float tmp = static_cast<float>(accum) * p.div + p.bias;
+    tmp = p.saturate ? tmp : std::fabs(tmp);
+    float c = std::min(std::max(tmp, 0.0f), 255.0f);
+    long v = std::lrint(c);
+    return static_cast<uint8_t>(std::min<long>(v, p.maxval));
+}
+
+// Everything that depends only on the filter, not on the row. Split out so the
+// plane driver can hoist it out of its row loop while the exported per-scanline
+// entry (used by the separable driver, which owns its own row loop) can build
+// it per call -- it is ~40 ops against a row of thousands of pixels.
+struct h_dot_ctx {
+    int32_t cg[7];                        // ceil(25/4) 4-tap int8 groups
+    unsigned S, G, end;
+    long maxjj;
+    float32x4_t sc, bi;
+    uint32x4_t sm;
+    uint8x16_t widx;
+};
+
+inline h_dot_ctx h_dot_make(const vs_generic_params &p, unsigned W)
+{
+    h_dot_ctx c;
+    const unsigned N = p.matrixsize;      // runtime, 3..25 odd
+    c.S = N / 2;
+    c.G = (N + 3) / 4;
+
+    // Taps packed into 4-tap int8 groups, zero-filled tail.
+    for (unsigned g = 0; g < c.G; ++g) {
+        int8_t b[4];
+        for (unsigned t = 0; t < 4; ++t) {
+            const unsigned k = 4 * g + t;
+            b[t] = k < N ? static_cast<int8_t>(p.matrix[k]) : 0;
+        }
+        std::memcpy(&c.cg[g], b, 4);
+    }
+
+    c.sc = vdupq_n_f32(p.div);
+    c.bi = vdupq_n_f32(p.bias);
+    c.sm = nc_satmask(p.saturate);
+    c.widx = vld1q_u8(NC_DOT_WIN);
+
+    // Same interior bounds as the squares: the furthest load of a block at jj
+    // is byte (jj - S) + 4(G-1) + 12 + 7; keep it inside the row.
+    c.end = W > c.S ? W - c.S : 0;
+    c.maxjj = static_cast<long>(W) + static_cast<long>(c.S) - 4L * static_cast<long>(c.G) - 16L;
+    return c;
+}
+
+inline void h_dot_scanline(const h_dot_ctx &c, const uint8_t *srcp, uint8_t *d, unsigned W, const vs_generic_params &p)
+{
+    const uint8x8_t zlo = vdup_n_u8(0);
+    const unsigned S = c.S, G = c.G, end = c.end;
+    const long maxjj = c.maxjj;
+
+    auto block = [&](unsigned jj) {
+        const uint8_t *q = srcp + (jj - S);
+        int32x4_t a0 = vdupq_n_s32(0), a1 = vdupq_n_s32(0), a2 = vdupq_n_s32(0), a3 = vdupq_n_s32(0);
+        uint8x8_t v0 = vld1_u8(q), v1 = vld1_u8(q + 4), v2 = vld1_u8(q + 8);
+        for (unsigned g = 0; g < G; ++g) {
+            uint8x8_t v3 = vld1_u8(q + 4 * g + 12);
+            const int8x16_t w = vreinterpretq_s8_s32(vdupq_n_s32(c.cg[g]));
+            a0 = vusdotq_s32(a0, vqtbl1q_u8(vcombine_u8(v0, zlo), c.widx), w);
+            a1 = vusdotq_s32(a1, vqtbl1q_u8(vcombine_u8(v1, zlo), c.widx), w);
+            a2 = vusdotq_s32(a2, vqtbl1q_u8(vcombine_u8(v2, zlo), c.widx), w);
+            a3 = vusdotq_s32(a3, vqtbl1q_u8(vcombine_u8(v3, zlo), c.widx), w);
+            v0 = v1; v1 = v2; v2 = v3;
+        }
+        nc_store_u8x8(d + jj, a0, a1, c.sc, c.bi, c.sm);
+        nc_store_u8x8(d + jj + 8, a2, a3, c.sc, c.bi, c.sm);
+    };
+
+    unsigned j = S;
+    if (end >= S + 16 && maxjj >= static_cast<long>(S)) {
+        for (; j + 16 <= end && static_cast<long>(j) <= maxjj; j += 16)
+            block(j);
+        // Overlapping final block; safe because this path is bit-exact.
+        if (j < end) {
+            long cc = static_cast<long>(end) - 16;
+            if (cc > maxjj)
+                cc = maxjj;
+            if (cc >= static_cast<long>(S) && static_cast<unsigned>(cc) + 16 > j) {
+                block(static_cast<unsigned>(cc));
+                j = static_cast<unsigned>(cc) + 16;
+            }
+        }
+    }
+
+    for (unsigned jj = 0; jj < S && jj < W; ++jj)
+        d[jj] = h_edge_px_byte(srcp, jj, W, p);
+    for (unsigned jj = std::max(j, S); jj < W; ++jj)
+        d[jj] = h_edge_px_byte(srcp, jj, W, p);
+}
+
+void h_plane_byte_dot(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                      const vs_generic_params &p, unsigned W, unsigned H)
+{
+    const h_dot_ctx c = h_dot_make(p, W);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint8_t *srcp = static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(i) * ss;
+        uint8_t *d = static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * ds;
+        h_dot_scanline(c, srcp, d, W, p);
+    }
+}
+
+} // namespace
+
+void vs_generic_1d_conv_h_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{
+    h_plane_byte_dot(src, src_stride, dst, dst_stride, *params, width, height);
+}
+
+// One scanline, for the separable driver's horizontal half: that driver owns
+// the row loop (it interleaves a vertical pass through a tmp scanline), and it
+// lives in a TU built without i8mm, so it cannot inline this.
+void vs_generic_1d_conv_h_byte_scanline_neon_dot(const void *srcp, void *dstp, const struct vs_generic_params *params, unsigned width)
+{
+    const h_dot_ctx c = h_dot_make(*params, width);
+    h_dot_scanline(c, static_cast<const uint8_t *>(srcp), static_cast<uint8_t *>(dstp), width, *params);
+}
+
+void vs_generic_3x3_conv_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{
+    sq_plane_byte_dot_3x3(src, src_stride, dst, dst_stride, *params, width, height);
+}
+
+#define VS_SQUARE_DOT_ENTRY(SZ, N) \
+    void vs_generic_##SZ##_conv_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sq_plane_byte_dot<N>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SQUARE_DOT_ENTRY(5x5, 5)
+VS_SQUARE_DOT_ENTRY(7x7, 7)
+VS_SQUARE_DOT_ENTRY(9x9, 9)
+VS_SQUARE_DOT_ENTRY(11x11, 11)

--- a/src/core/kernel/arm/square_dot_sve.cpp
+++ b/src/core/kernel/arm/square_dot_sve.cpp
@@ -1,0 +1,166 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* SVE + FEAT_I8MM byte square NxN convolution, N in {5,7,9,11}.
+*
+* The VLA analog of square_dot_neon.cpp: svusdot folds 4 uint8*int8 products per
+* 32-bit lane, and svtbl builds the sliding window so lane l holds the 4 pixels
+* output j+l needs. Where NEON does 4 outputs per (load, tbl, usdot), SVE does
+* svcntw() of them -- 8 at a 256-bit VL -- so this only makes sense above 128-bit
+* vectors, and the dispatcher gates it on VL the same way the other SVE kernels
+* are gated.
+*
+* Bit-exact with the C/NEON byte path: identical integer products and sum, and
+* the store reproduces nc_store_u8x8 exactly. That store's int32 -> saturated
+* int16 -> saturated uint8 chain is just a clamp to [0, 255], which SVE does with
+* svmax/svmin plus the truncating svst1b (the value already fits a byte).
+*
+* Own TU compiled with +sve+i8mm: a CPU can have SVE without I8MM (A64FX), so the
+* other SVE kernels must not be built with i8mm enabled.
+*/
+
+#include <arm_sve.h>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include "../generic.h"
+#include "conv_scalar.h"
+
+namespace {
+
+// acc -> scale/bias/saturate/round/clamp -> byte, matching nc_store_u8x8.
+inline void sv_store_u8(uint8_t *dst, svbool_t pg, svint32_t acc,
+                        svfloat32_t sc, svfloat32_t bi, svuint32_t smask)
+{
+    svfloat32_t t = svmad_f32_x(pg, svcvt_f32_s32_x(pg, acc), sc, bi);
+    t = svreinterpret_f32_u32(svand_u32_x(pg, svreinterpret_u32_f32(t), smask));
+    svint32_t r = svcvt_s32_f32_x(pg, svrintn_f32_x(pg, t));
+    r = svmax_s32_x(pg, r, svdup_n_s32(0));
+    r = svmin_s32_x(pg, r, svdup_n_s32(255));
+    svst1b_s32(pg, reinterpret_cast<int8_t *>(dst), r);
+}
+
+template <unsigned N>
+unsigned sq_interior_byte_dot_sve(const uint8_t *const *rows, uint8_t *dst, unsigned S, unsigned W,
+                                  const int32_t *coeff_groups, svfloat32_t sc, svfloat32_t bi, svuint32_t smask)
+{
+    constexpr unsigned G = (N + 3) / 4;
+    const unsigned nl = static_cast<unsigned>(svcntw());   // outputs per vector
+
+    // Window indices: byte i of the table result belongs to 32-bit lane i/4 and
+    // tap i%4, so it must come from pixel (i/4 + i%4) of the load.
+    std::vector<uint8_t> idxbuf(static_cast<size_t>(svcntb()));
+    for (size_t i = 0; i < idxbuf.size(); ++i)
+        idxbuf[i] = static_cast<uint8_t>(i / 4 + i % 4);
+    const svuint8_t vidx = svld1_u8(svptrue_b8(), idxbuf.data());
+
+    const svbool_t pg32 = svptrue_b32();
+    // Only nl+3 bytes of each row window are ever indexed; predicating the load
+    // to exactly that keeps the kernel from touching memory past the row.
+    const svbool_t pgld = svwhilelt_b8_u32(0u, nl + 3u);
+
+    const unsigned end = W > S ? W - S : 0;
+    if (end < S + nl)
+        return S;
+
+    const long maxjj = static_cast<long>(W) + static_cast<long>(S) - 4L * static_cast<long>(G) - static_cast<long>(nl);
+    if (maxjj < static_cast<long>(S))
+        return S;
+
+    auto block = [&](unsigned jj) {
+        svint32_t acc = svdup_n_s32(0);
+        for (unsigned r = 0; r < N; ++r) {
+            const uint8_t *row = rows[r] + (jj - S);
+            for (unsigned g = 0; g < G; ++g) {
+                const svuint8_t v = svld1_u8(pgld, row + 4 * g);
+                const svuint8_t t = svtbl_u8(v, vidx);
+                const svint8_t w = svreinterpret_s8_s32(svdup_n_s32(coeff_groups[r * G + g]));
+                acc = svusdot_s32(acc, t, w);
+            }
+        }
+        sv_store_u8(dst + jj, pg32, acc, sc, bi, smask);
+    };
+
+    unsigned j = S;
+    for (; j + nl <= end && static_cast<long>(j) <= maxjj; j += nl)
+        block(j);
+
+    if (j < end) {
+        long c = static_cast<long>(end) - static_cast<long>(nl);
+        if (c > maxjj)
+            c = maxjj;
+        if (c >= static_cast<long>(S) && static_cast<unsigned>(c) + nl > j) {
+            block(static_cast<unsigned>(c));
+            j = static_cast<unsigned>(c) + nl;
+        }
+    }
+    return j;
+}
+
+template <unsigned N>
+void sq_plane_byte_dot_sve(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                           const vs_generic_params &p, unsigned W, unsigned H)
+{
+    constexpr unsigned S = N / 2;
+    constexpr unsigned G = (N + 3) / 4;
+
+    int32_t coeff_groups[N * G];
+    for (unsigned r = 0; r < N; ++r) {
+        for (unsigned g = 0; g < G; ++g) {
+            int8_t b[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                const unsigned k = 4 * g + t;
+                b[t] = k < N ? static_cast<int8_t>(p.matrix[r * N + k]) : 0;
+            }
+            std::memcpy(&coeff_groups[r * G + g], b, 4);
+        }
+    }
+
+    const svfloat32_t sc = svdup_n_f32(p.div), bi = svdup_n_f32(p.bias);
+    const svuint32_t smask = svdup_n_u32(p.saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint8_t *rows[N];
+        for (unsigned r = 0; r < N; ++r)
+            rows[r] = static_cast<const uint8_t *>(src) +
+                static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(i) + static_cast<int>(r) - static_cast<int>(S), static_cast<int>(H))) * src_stride;
+        uint8_t *d = static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride;
+
+        const unsigned aend = sq_interior_byte_dot_sve<N>(rows, d, S, W, coeff_groups, sc, bi, smask);
+
+        for (unsigned j = 0; j < S && j < W; ++j)
+            d[j] = nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+        for (unsigned j = (aend > S ? aend : S); j < W; ++j)
+            d[j] = nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+} // namespace
+
+#define VS_SQUARE_DOT_SVE_ENTRY(SZ, N) \
+    void vs_generic_##SZ##_conv_byte_sve_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sq_plane_byte_dot_sve<N>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+// 5x5 and 11x11 were thread-gated (won only on tiny pools) and are pruned;
+// int8 5x5/11x11 fall back to the NEON usdot squares. 7x7/9x9 win at every
+// pool size and stay.
+VS_SQUARE_DOT_SVE_ENTRY(7x7, 7)
+VS_SQUARE_DOT_SVE_ENTRY(9x9, 9)

--- a/src/core/kernel/arm/square_neon.cpp
+++ b/src/core/kernel/arm/square_neon.cpp
@@ -1,0 +1,441 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* NEON square (non-separable) NxN convolution, N in {3,5,7,9,11}.
+*
+* Same structure as the x86 square_impl.h kernels: scalar mirror-edge columns,
+* SIMD interior, and an overlapping final vector to cover the sub-vector
+* interior remainder (re-storing already-written columns is safe because the
+* SIMD interior is bit-exact with the scalar reference on integer formats).
+*
+* byte:  u8 widens to s16 (non-negative), per-tap vmlal_s16 into int32.
+*        Worst case 121 * 1023 * 255 < INT32_MAX -- never overflows.
+* word:  u16 biased by INT16_MIN into s16, per-tap vmlal_s16 into int32.
+*        N <= 7: 49 * 1023 * 32768 < INT32_MAX; the coefficient*bias sum is
+*        subtracted afterwards (exact), so results match the C reference.
+*        N >= 9: per-row int32 sums (11 * 1023 * 32768 fits) spill into int64
+*        accumulators; int64 -> float via double is exact, bit-identical to
+*        the int64 C reference.
+* float: per-tap FMA; like the x86 AVX2+ tiers this is not bit-exact with the
+*        non-FMA scalar reference (allowed for float).
+* half:  samples widen to float32, float math, narrow on store.
+*
+* The 3x3 square entry (vs_generic_3x3_conv_*) uses replicate edges and a
+* separate driver (see convolution_neon.cpp); this file is 5x5 and up.
+*/
+
+#include <cstdint>
+#include "../generic.h"
+#include "neon_common.h"
+
+namespace {
+
+// ---- per-row lane-form coefficients (integer squares) ----
+//
+// The obvious way to feed a coefficient to vmlal_s16 is vdup_n_s16(m[...]),
+// but the compiler cannot hoist that broadcast out of the block: p.matrix is
+// caller memory and the block stores through dst, which may alias it, so every
+// tap of every 16-px block re-emits an address `sub` plus an `ld1r.8h`
+// (verified in the emitted asm). That is 2 of the ~10 ops per tap, one of them
+// a load.
+//
+// vmlal_laneq_s16 instead reads the coefficient from a lane of a register, so
+// the matrix can be loaded once per scanline. Coefficients are staged per ROW,
+// not per matrix: RQ = ceil(N/8) vectors hold one row's taps (tap k -> vector
+// k/8, lane k%8), and the row loop stays rolled, so only one row's coefficients
+// and loads are in flight at a time.
+//
+// Staging the WHOLE matrix and unrolling all N*N taps was measurably worse:
+// it lets the scheduler hoist every tap's loads to the top of the block, which
+// needs more registers than gcc 13.3 has. gcc emits the lane forms correctly
+// and then spills around them (-35..-47% on Neoverse V1/V2/V3); clang gained
+// less than the per-row form does. Per-row wins on both compilers, so unlike
+// the whole-matrix float hoist this replaced, it needs no __clang__ gate.
+//
+// Bit-exact: vmlal_laneq_s16 with lane L computes the same widening MLA as
+// vmlal_s16 against a dup of the same coefficient, and the tap order is
+// unchanged, so results are identical to the plain path.
+
+template <unsigned N>
+constexpr unsigned sq_row_q() { return (N + 7) / 8; }
+
+template <unsigned N>
+inline void sq_load_row_coeffs(int16x8_t *cq, const int16_t *m)
+{
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16_t cpad[N * RQ * 8] = {};
+    for (unsigned r = 0; r < N; ++r)
+        for (unsigned k = 0; k < N; ++k)
+            cpad[(r * RQ + k / 8) * 8 + k % 8] = m[r * N + k];
+    for (unsigned i = 0; i < N * RQ; ++i)
+        cq[i] = vld1q_s16(cpad + 8 * i);
+}
+
+// One row's N taps over 16 byte pixels.
+template <unsigned N, unsigned K>
+inline void sq_tap_byte_row(int32x4_t (&a)[4], const uint8_t *p, const int16x8_t *crow)
+{
+    nc_byte16 x = nc_load_byte16(p + K);
+    a[0] = vmlal_laneq_s16(a[0], vget_low_s16(x.lo), crow[K / 8], K % 8);
+    a[1] = vmlal_laneq_s16(a[1], vget_high_s16(x.lo), crow[K / 8], K % 8);
+    a[2] = vmlal_laneq_s16(a[2], vget_low_s16(x.hi), crow[K / 8], K % 8);
+    a[3] = vmlal_laneq_s16(a[3], vget_high_s16(x.hi), crow[K / 8], K % 8);
+    if constexpr (K + 1 < N)
+        sq_tap_byte_row<N, K + 1>(a, p, crow);
+}
+
+// One row's N taps over 16 word pixels.
+template <unsigned N, unsigned K>
+inline void sq_tap_word_row(int32x4_t (&a)[4], const uint16_t *p, const int16x8_t *crow)
+{
+    int16x8_t x0 = nc_load_word_biased(p + K);
+    int16x8_t x1 = nc_load_word_biased(p + K + 8);
+    a[0] = vmlal_laneq_s16(a[0], vget_low_s16(x0), crow[K / 8], K % 8);
+    a[1] = vmlal_laneq_s16(a[1], vget_high_s16(x0), crow[K / 8], K % 8);
+    a[2] = vmlal_laneq_s16(a[2], vget_low_s16(x1), crow[K / 8], K % 8);
+    a[3] = vmlal_laneq_s16(a[3], vget_high_s16(x1), crow[K / 8], K % 8);
+    if constexpr (K + 1 < N)
+        sq_tap_word_row<N, K + 1>(a, p, crow);
+}
+
+// One row's N taps over 8 word pixels, into the int32 per-row sums that the
+// int64 path widens from.
+template <unsigned N, unsigned K>
+inline void sq_tap_word8_row(int32x4_t &r0, int32x4_t &r1, const uint16_t *p, const int16x8_t *crow)
+{
+    int16x8_t x = nc_load_word_biased(p + K);
+    r0 = vmlal_laneq_s16(r0, vget_low_s16(x), crow[K / 8], K % 8);
+    r1 = vmlal_laneq_s16(r1, vget_high_s16(x), crow[K / 8], K % 8);
+    if constexpr (K + 1 < N)
+        sq_tap_word8_row<N, K + 1>(r0, r1, p, crow);
+}
+
+// ---- byte ----
+
+template <unsigned N>
+unsigned sq_interior_byte(const uint8_t *const *rows, uint8_t *dst, unsigned S, unsigned W,
+                          const int16_t *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16x8_t cq[N * RQ];
+    sq_load_row_coeffs<N>(cq, m);
+    const uint8_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        int32x4_t a[4] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0) };
+        for (unsigned r = 0; r < N; ++r)
+            sq_tap_byte_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+        nc_store_u8x8(dst + jj, a[0], a[1], sc, bi, sm);
+        nc_store_u8x8(dst + jj + 8, a[2], a[3], sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- word, int32 accumulation (N <= 7) ----
+
+template <unsigned N>
+unsigned sq_interior_word_i32(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                              const int16_t *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int32_t wb = 0;
+    for (unsigned i = 0; i < N * N; ++i) wb += static_cast<int32_t>(INT16_MIN) * m[i];
+    int32x4_t wbv = vdupq_n_s32(wb);
+
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16x8_t cq[N * RQ];
+    sq_load_row_coeffs<N>(cq, m);
+    const uint16_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        int32x4_t a[4] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0) };
+        for (unsigned r = 0; r < N; ++r)
+            sq_tap_word_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+        nc_store_u16x8(dst + jj, vsubq_s32(a[0], wbv), vsubq_s32(a[1], wbv), sc, bi, sm, mv);
+        nc_store_u16x8(dst + jj + 8, vsubq_s32(a[2], wbv), vsubq_s32(a[3], wbv), sc, bi, sm, mv);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- word, int64 accumulation (N >= 9) ----
+
+template <unsigned N>
+unsigned sq_interior_word_i64(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                              const int16_t *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int64_t wb = 0;
+    for (unsigned i = 0; i < N * N; ++i) wb += static_cast<int64_t>(INT16_MIN) * m[i];
+    int64x2_t wbv = vdupq_n_s64(wb);
+
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16x8_t cq[N * RQ];
+    sq_load_row_coeffs<N>(cq, m);
+    const uint16_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        int64x2_t a0 = vdupq_n_s64(0), a1 = vdupq_n_s64(0), a2 = vdupq_n_s64(0), a3 = vdupq_n_s64(0);
+        for (unsigned r = 0; r < N; ++r) {
+            int32x4_t r0 = vdupq_n_s32(0), r1 = vdupq_n_s32(0);
+            sq_tap_word8_row<N, 0>(r0, r1, lrows[r] + (jj - S), cq + r * RQ);
+            a0 = vaddw_s32(a0, vget_low_s32(r0));
+            a1 = vaddw_s32(a1, vget_high_s32(r0));
+            a2 = vaddw_s32(a2, vget_low_s32(r1));
+            a3 = vaddw_s32(a3, vget_high_s32(r1));
+        }
+        nc_store_u16x8_i64(dst + jj, vsubq_s64(a0, wbv), vsubq_s64(a1, wbv),
+                           vsubq_s64(a2, wbv), vsubq_s64(a3, wbv), sc, bi, sm, mv);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 8 <= end; j += 8) block(j);
+    if (j < end && end >= S + 8) { block(end - 8); j = end; }
+    return j;
+}
+
+// ---- float ----
+
+// Float coefficients staged per row, exactly like the integer squares above:
+// RQ = ceil(N/4) vectors per row, tap k -> vector k/4, lane k%4, row loop left
+// rolled. Float taps are 1 load : 1 FMA, so the per-tap coefficient reload the
+// compiler cannot hoist (see the integer note) lands right on the FMA critical
+// path.
+//
+// This replaces an earlier 5x5-only variant that staged the whole 25-tap matrix
+// and unrolled every tap. That one had to be gated on __clang__: it was +7-10%
+// on M4 / +18% on Graviton5-with-clang, but -22% under gcc 13.3, which could
+// not keep the coefficients live across the fully unrolled block. The per-row
+// form keeps one row's coefficients in flight instead of the whole matrix, wins
+// on both toolchains, and so needs no compiler gate and no N == 5 restriction.
+//
+// Tap order matches the plain r/k loops exactly, and vfmaq_laneq_f32 computes
+// the same FMA as vfmaq_f32 with a dup'd scalar, so this is bit-identical to
+// the plain path.
+//
+// 7x7 float is EXCLUDED and keeps the plain loops: it is the one shape that
+// measured slower with per-row coefficients under gcc 13.3 (-3.9% G3, -7.9%
+// G4b, -6.9% G5, three interleaved runs each, while clang 17 gained +1.4%).
+// Every other float size wins on gcc (5x5 +5..15%, 9x9 +41..49%, 11x11
+// +78..81%). The cause was not isolated -- gcc emits no spills for it, and
+// outlining the block cannot be it either, since 9x9/11x11 are outlined too
+// and win big. 7x7 was also the shape the earlier whole-matrix hoist could not
+// help (it spilled even under clang), so this size seems to sit right at a
+// scheduling cliff. Re-measure before extending per-row to it.
+template <unsigned N>
+constexpr bool sq_float_lane() { return N != 7; }
+
+template <unsigned N>
+constexpr unsigned sq_row_qf() { return (N + 3) / 4; }
+
+template <unsigned N>
+inline void sq_load_row_coeffs_f(float32x4_t *cq, const float *m)
+{
+    constexpr unsigned RQ = sq_row_qf<N>();
+    float cpad[N * RQ * 4] = {};
+    for (unsigned r = 0; r < N; ++r)
+        for (unsigned k = 0; k < N; ++k)
+            cpad[(r * RQ + k / 4) * 4 + k % 4] = m[r * N + k];
+    for (unsigned i = 0; i < N * RQ; ++i)
+        cq[i] = vld1q_f32(cpad + 4 * i);
+}
+
+template <unsigned N, unsigned K>
+inline void sq_tap_float_row(float32x4_t (&a)[4], const float *p, const float32x4_t *crow)
+{
+    a[0] = vfmaq_laneq_f32(a[0], vld1q_f32(p + K), crow[K / 4], K % 4);
+    a[1] = vfmaq_laneq_f32(a[1], vld1q_f32(p + K + 4), crow[K / 4], K % 4);
+    a[2] = vfmaq_laneq_f32(a[2], vld1q_f32(p + K + 8), crow[K / 4], K % 4);
+    a[3] = vfmaq_laneq_f32(a[3], vld1q_f32(p + K + 12), crow[K / 4], K % 4);
+    if constexpr (K + 1 < N)
+        sq_tap_float_row<N, K + 1>(a, p, crow);
+}
+
+template <unsigned N>
+unsigned sq_interior_float(const float *const *rows, float *dst, unsigned S, unsigned W,
+                           const float *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned RQ = sq_row_qf<N>();
+    [[maybe_unused]] float32x4_t cq[N * RQ];
+    [[maybe_unused]] const float *lrows[N];
+    if constexpr (sq_float_lane<N>()) {
+        sq_load_row_coeffs_f<N>(cq, m);
+        for (unsigned r = 0; r < N; ++r)
+            lrows[r] = rows[r];
+    }
+
+    auto block = [&](unsigned jj) {
+        if constexpr (sq_float_lane<N>()) {
+            float32x4_t a[4] = { vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0) };
+            for (unsigned r = 0; r < N; ++r)
+                sq_tap_float_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+            nc_store_f32x4(dst + jj, a[0], sc, bi, sm);
+            nc_store_f32x4(dst + jj + 4, a[1], sc, bi, sm);
+            nc_store_f32x4(dst + jj + 8, a[2], sc, bi, sm);
+            nc_store_f32x4(dst + jj + 12, a[3], sc, bi, sm);
+            return;
+        }
+        float32x4_t a0 = vdupq_n_f32(0), a1 = vdupq_n_f32(0), a2 = vdupq_n_f32(0), a3 = vdupq_n_f32(0);
+        for (unsigned r = 0; r < N; ++r) {
+            const float *row = rows[r] + (jj - S);
+            for (unsigned k = 0; k < N; ++k) {
+                float32x4_t w = vdupq_n_f32(m[r * N + k]);
+                a0 = vfmaq_f32(a0, vld1q_f32(row + k), w);
+                a1 = vfmaq_f32(a1, vld1q_f32(row + k + 4), w);
+                a2 = vfmaq_f32(a2, vld1q_f32(row + k + 8), w);
+                a3 = vfmaq_f32(a3, vld1q_f32(row + k + 12), w);
+            }
+        }
+        nc_store_f32x4(dst + jj, a0, sc, bi, sm);
+        nc_store_f32x4(dst + jj + 4, a1, sc, bi, sm);
+        nc_store_f32x4(dst + jj + 8, a2, sc, bi, sm);
+        nc_store_f32x4(dst + jj + 12, a3, sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- half ----
+
+// Per-row lane coefficients, as for float above. This path only runs for
+// coefficients that do not narrow exactly to f16 (conv_f16) or on CPUs without
+// FEAT_FHM; everything else dispatches to the fmlal kernels.
+template <unsigned N, unsigned K>
+inline void sq_tap_half_row(float32x4_t (&a)[4], const uint16_t *p, const float32x4_t *crow)
+{
+    nc_half8 x0 = nc_load_half8(p + K);
+    nc_half8 x1 = nc_load_half8(p + K + 8);
+    a[0] = vfmaq_laneq_f32(a[0], x0.lo, crow[K / 4], K % 4);
+    a[1] = vfmaq_laneq_f32(a[1], x0.hi, crow[K / 4], K % 4);
+    a[2] = vfmaq_laneq_f32(a[2], x1.lo, crow[K / 4], K % 4);
+    a[3] = vfmaq_laneq_f32(a[3], x1.hi, crow[K / 4], K % 4);
+    if constexpr (K + 1 < N)
+        sq_tap_half_row<N, K + 1>(a, p, crow);
+}
+
+template <unsigned N>
+unsigned sq_interior_half(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                          const float *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned RQ = sq_row_qf<N>();
+    float32x4_t cq[N * RQ];
+    sq_load_row_coeffs_f<N>(cq, m);
+    const uint16_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        float32x4_t a[4] = { vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0) };
+        for (unsigned r = 0; r < N; ++r)
+            sq_tap_half_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+        nc_store_h16x8(dst + jj, a[0], a[1], sc, bi, sm);
+        nc_store_h16x8(dst + jj + 8, a[2], a[3], sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- plane driver: scalar mirror edges + SIMD interior ----
+
+enum class SqType { Byte, Word, Float, Half };
+
+template <SqType TY, unsigned N>
+void sq_plane(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const vs_generic_params &p, unsigned W, unsigned H)
+{
+    typedef typename std::conditional<TY == SqType::Float, float, typename std::conditional<TY == SqType::Byte, uint8_t, uint16_t>::type>::type T;
+    constexpr unsigned S = N / 2;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const T *rows[N];
+        for (unsigned r = 0; r < N; ++r)
+            rows[r] = reinterpret_cast<const T *>(static_cast<const unsigned char *>(src) +
+                static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(i) + static_cast<int>(r) - static_cast<int>(S), static_cast<int>(H))) * ss);
+        T *d = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * ds);
+
+        unsigned aend;
+        if constexpr (TY == SqType::Byte)
+            aend = sq_interior_byte<N>(rows, d, S, W, p.matrix, sc, bi, sm);
+        else if constexpr (TY == SqType::Word) {
+            if constexpr (N > 7)
+                aend = sq_interior_word_i64<N>(rows, d, S, W, p.matrix, sc, bi, sm, mv);
+            else
+                aend = sq_interior_word_i32<N>(rows, d, S, W, p.matrix, sc, bi, sm, mv);
+        } else if constexpr (TY == SqType::Float)
+            aend = sq_interior_float<N>(rows, d, S, W, p.matrixf, sc, bi, sm);
+        else
+            aend = sq_interior_half<N>(rows, d, S, W, p.matrixf, sc, bi, sm);
+
+        auto scalar_px = [&](unsigned j) -> T {
+            if constexpr (TY == SqType::Byte)
+                return nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+            else if constexpr (TY == SqType::Word) {
+                typedef typename std::conditional<(N > 5), int64_t, int32_t>::type Acc;
+                return nc_sq_scalar_px<uint16_t, Acc, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+            } else if constexpr (TY == SqType::Float)
+                return nc_sq_scalar_px<float, float, float, N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate, p.maxval);
+            else
+                return nc_sq_scalar_px_half<N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate);
+        };
+
+        for (unsigned j = 0; j < S && j < W; ++j)
+            d[j] = scalar_px(j);
+        for (unsigned j = (aend > S ? aend : S); j < W; ++j)
+            d[j] = scalar_px(j);
+    }
+}
+
+} // namespace
+
+#define VS_SQUARE_NEON_ENTRY(SZ, N, TY, TN) \
+    void vs_generic_##SZ##_conv_##TN##_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sq_plane<SqType::TY, N>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Byte,  byte)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Byte,  byte)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Byte,  byte)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Byte,  byte)
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Word,  word)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Word,  word)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Word,  word)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Word,  word)
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Float, float)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Float, float)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Float, float)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Float, float)
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Half,  half)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Half,  half)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Half,  half)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Half,  half)

--- a/src/core/kernel/cpulevel.cpp
+++ b/src/core/kernel/cpulevel.cpp
@@ -40,6 +40,13 @@ int vs_cpulevel_from_str(const char *name) {
         return VS_CPU_LEVEL_AVX2;
     else if (!strcmp(name, "avx512"))
         return VS_CPU_LEVEL_AVX512;
+#elif defined(VS_TARGET_CPU_ARM64)
+    else if (!strcmp(name, "neon"))
+        return VS_CPU_LEVEL_NEON;
+    else if (!strcmp(name, "sve"))
+        return VS_CPU_LEVEL_SVE;
+    else if (!strcmp(name, "sme"))
+        return VS_CPU_LEVEL_SME;
 #endif
     else
         return VS_CPU_LEVEL_MAX;
@@ -55,6 +62,13 @@ const char *vs_cpulevel_to_str(int level) {
         return "avx2";
     else if (level <= VS_CPU_LEVEL_AVX512)
         return "avx512";
+#elif defined(VS_TARGET_CPU_ARM64)
+    else if (level <= VS_CPU_LEVEL_NEON)
+        return "neon";
+    else if (level <= VS_CPU_LEVEL_SVE)
+        return "sve";
+    else if (level <= VS_CPU_LEVEL_SME)
+        return "sme";
 #endif
     else
         return "";

--- a/src/core/kernel/cpulevel.h
+++ b/src/core/kernel/cpulevel.h
@@ -33,6 +33,13 @@ enum {
     VS_CPU_LEVEL_SSE2 = 1,
     VS_CPU_LEVEL_AVX2 = 2,
     VS_CPU_LEVEL_AVX512 = 3,
+#elif defined(VS_TARGET_CPU_ARM64)
+    /* NEON is the AArch64 baseline. SVE (non-streaming, servers) and SME
+       (streaming, Apple M4+ and newer server cores) rank above it so
+       SetMaxCPU can clamp each tier independently of runtime detection. */
+    VS_CPU_LEVEL_NEON = 1,
+    VS_CPU_LEVEL_SVE = 2,
+    VS_CPU_LEVEL_SME = 3,
 #endif
     VS_CPU_LEVEL_MAX = INT_MAX
 };

--- a/src/core/kernel/generic.h
+++ b/src/core/kernel/generic.h
@@ -316,6 +316,136 @@ DECL(11x11_conv, byte, avx512vnni)
 
 #endif /* VS_TARGET_CPU_X86 */
 
+#ifdef VS_TARGET_CPU_ARM64
+/* NEON baseline kernels: the whole convolution family (square 3x3..11x11,
+   1D horizontal/vertical, separable) for byte/word/float/half. Integer paths
+   are bit-exact with the C reference; float/half use FMA. */
+DECL_3x3(conv, byte, neon)
+DECL_3x3(conv, word, neon)
+/* 3x3 float: no NEON kernel -- loses to its autovectorised C tier at a full
+   thread pool on M4, so it is dispatched to C. */
+DECL_3x3(conv, half, neon)
+
+DECL(5x5_conv, byte, neon)
+DECL(7x7_conv, byte, neon)
+DECL(9x9_conv, byte, neon)
+DECL(11x11_conv, byte, neon)
+DECL(5x5_conv, word, neon)
+DECL(7x7_conv, word, neon)
+DECL(9x9_conv, word, neon)
+DECL(11x11_conv, word, neon)
+DECL(5x5_conv, float, neon)
+DECL(7x7_conv, float, neon)
+DECL(9x9_conv, float, neon)
+DECL(11x11_conv, float, neon)
+DECL(5x5_conv, half, neon)
+DECL(7x7_conv, half, neon)
+DECL(9x9_conv, half, neon)
+DECL(11x11_conv, half, neon)
+
+DECL(1d_conv_h, byte, neon)
+DECL(1d_conv_h, word, neon)
+DECL(1d_conv_h, float, neon)
+DECL(1d_conv_h, half, neon)
+
+DECL(1d_conv_v, byte, neon)
+DECL(1d_conv_v, word, neon)
+DECL(1d_conv_v, float, neon)
+DECL(1d_conv_v, half, neon)
+
+DECL(2d_conv_sep, byte, neon)
+DECL(2d_conv_sep, word, neon)
+DECL(2d_conv_sep, float, neon)
+DECL(2d_conv_sep, half, neon)
+
+#ifdef VS_TARGET_ARM_I8MM
+/* usdot byte square conv; valid only when every coefficient fits int8. */
+DECL_3x3(conv, byte, neon_dot)
+DECL(5x5_conv, byte, neon_dot)
+DECL(7x7_conv, byte, neon_dot)
+DECL(9x9_conv, byte, neon_dot)
+DECL(11x11_conv, byte, neon_dot)
+DECL(1d_conv_h, byte, neon_dot)
+/* Separable byte: vmlal vertical pass, usdot horizontal pass. Same int8
+   coefficient requirement as the rest of this block. */
+DECL(2d_conv_sep, byte, neon_dot)
+/* One horizontal scanline of the above, exported from the i8mm TU so the
+   separable driver (built without i8mm) can call it per row. */
+void vs_generic_1d_conv_h_byte_scanline_neon_dot(const void *srcp, void *dstp, const struct vs_generic_params *params, unsigned width);
+#endif /* VS_TARGET_ARM_I8MM */
+
+#ifdef VS_TARGET_ARM_FHM
+/* fmlal widening f16 MAC; valid only when coefficients are f16-exact (conv_f16). */
+DECL_3x3(conv, half, neon_fhm)
+DECL(5x5_conv, half, neon_fhm)
+DECL(7x7_conv, half, neon_fhm)
+DECL(9x9_conv, half, neon_fhm)
+DECL(11x11_conv, half, neon_fhm)
+DECL(1d_conv_h, half, neon_fhm)
+DECL(1d_conv_v, half, neon_fhm)
+/* Separable: both halves are half-format, so this drives its own row loop and
+   runs the vertical and horizontal passes on fmlal. */
+DECL(2d_conv_sep, half, neon_fhm)
+#endif /* VS_TARGET_ARM_FHM */
+
+#ifdef VS_TARGET_ARM_SVE
+/* Non-streaming SVE (VLA) kernels; never built or dispatched on Apple Silicon. */
+unsigned vs_sve_vector_length(void);
+
+DECL_3x3(conv, byte, sve)
+DECL_3x3(conv, word, sve)
+
+/* Plain-SVE byte squares: only 5x5/7x7 (wide coefficients) still beat NEON on
+   Graviton3; 9x9/11x11 lost to the round-2 NEON lane-coefficient squares and are
+   pruned. The plain word squares, the float squares, and the byte separable all
+   lost to NEON too and are gone. */
+DECL(5x5_conv, byte, sve)
+DECL(7x7_conv, byte, sve)
+
+DECL(1d_conv_h, byte, sve)
+
+/* svdot_s64 word squares: the only integer SVE form that beats NEON at a
+   128-bit VL. 9x9/11x11 win at every pool size; 7x7 became a wash after the
+   round-2 NEON word squares and is pruned. */
+DECL(9x9_conv, word, sve_dot)
+DECL(11x11_conv, word, sve_dot)
+
+#ifdef VS_TARGET_ARM_SVE_I8MM
+/* SVE usdot byte square conv; needs SVE + I8MM and pays only above 128-bit VL.
+   Only 7x7/9x9 win at every pool size; 5x5/11x11 were thread-gated and pruned
+   (int8 5x5/11x11 fall back to the NEON usdot squares). */
+DECL(7x7_conv, byte, sve_dot)
+DECL(9x9_conv, byte, sve_dot)
+#endif /* VS_TARGET_ARM_SVE_I8MM */
+
+#endif /* VS_TARGET_ARM_SVE */
+
+#ifdef VS_TARGET_ARM_SME
+/* SME2 streaming-mode kernels: only the shapes that beat NEON even fully
+   contended survive -- the >= 7x7 square outer products and vertical 1D. Byte
+   via 2-way int16 SMOPA into ZA32 (WIDE coefficients only; int8 goes to NEON
+   usdot), float via FMOPA. The smaller/thread-contested squares, all word
+   squares, and word vertical were pruned and fall back to NEON. */
+DECL(7x7_conv, byte, sme)
+DECL(9x9_conv, byte, sme)
+DECL(11x11_conv, byte, sme)
+DECL(7x7_conv, float, sme)
+DECL(9x9_conv, float, sme)
+DECL(11x11_conv, float, sme)
+
+DECL(1d_conv_v, byte, sme)
+DECL(1d_conv_v, float, sme)
+
+/* half: samples widen to f32 and reuse the ZA32 FMOPA path. */
+DECL(7x7_conv, half, sme)
+DECL(9x9_conv, half, sme)
+DECL(11x11_conv, half, sme)
+DECL(1d_conv_v, half, sme)
+
+#endif /* VS_TARGET_ARM_SME */
+
+#endif /* VS_TARGET_CPU_ARM64 */
+
 #undef DECL_3x3
 #undef DECL
 

--- a/src/core/lutfilters.cpp
+++ b/src/core/lutfilters.cpp
@@ -42,6 +42,16 @@ using namespace vsh;
 #ifdef VS_TARGET_CPU_X86
 void vs_lut1_b_b_avx512vbmi(const uint8_t *src, uint8_t *dst, int w, const uint8_t *lut);
 #endif
+#ifdef VS_TARGET_CPU_ARM64
+void vs_lut1_b_b_neon(const uint8_t *src, uint8_t *dst, int w, const uint8_t *lut);
+#ifdef VS_TARGET_ARM_SVE
+/* 16-bit source: the table is 65536 entries, too large to permute, so every other
+   ISA runs this scalar. SVE gathers svcntw() lookups at a time. */
+unsigned vs_sve_vector_length(void);
+void vs_lut1_w_w_sve(const uint16_t *src, uint16_t *dst, int w, const uint16_t *lut);
+void vs_lut1_w_b_sve(const uint16_t *src, uint8_t *dst, int w, const uint8_t *lut);
+#endif
+#endif
 
 namespace {
 
@@ -51,6 +61,8 @@ typedef struct LutDataExtra {
     void *lut;
     bool process[3];
     bool use_vbmi;
+    bool use_neon;
+    bool use_sve_gather;
     ~LutDataExtra() { free(lut); };
 } LutDataExtra;
 
@@ -94,6 +106,40 @@ static const VSFrame *VS_CC lutGetframe(int n, int activationReason, void *insta
                         continue; // plane done; skip the scalar fallback
                     }
                 }
+#endif
+#ifdef VS_TARGET_CPU_ARM64
+                if constexpr (std::is_same_v<T, uint8_t> && std::is_same_v<U, uint8_t>) {
+                    if (d->use_neon) {
+                        for (int hl = 0; hl < h; hl++) {
+                            vs_lut1_b_b_neon(srcp, dstp, w, lut);
+                            dstp += dst_stride / sizeof(U);
+                            srcp += src_stride / sizeof(T);
+                        }
+                        continue; // plane done; skip the scalar fallback
+                    }
+                }
+#ifdef VS_TARGET_ARM_SVE
+                if constexpr (std::is_same_v<T, uint16_t> && std::is_same_v<U, uint16_t>) {
+                    if (d->use_sve_gather) {
+                        for (int hl = 0; hl < h; hl++) {
+                            vs_lut1_w_w_sve(srcp, dstp, w, lut);
+                            dstp += dst_stride / sizeof(U);
+                            srcp += src_stride / sizeof(T);
+                        }
+                        continue;
+                    }
+                }
+                if constexpr (std::is_same_v<T, uint16_t> && std::is_same_v<U, uint8_t>) {
+                    if (d->use_sve_gather) {
+                        for (int hl = 0; hl < h; hl++) {
+                            vs_lut1_w_b_sve(srcp, dstp, w, lut);
+                            dstp += dst_stride / sizeof(U);
+                            srcp += src_stride / sizeof(T);
+                        }
+                        continue;
+                    }
+                }
+#endif
 #endif
                 for (int hl = 0; hl < h; hl++) {
                     if constexpr (std::is_same_v<U, uint8_t>) {
@@ -303,9 +349,30 @@ static void VS_CC lutCreate(const VSMap *in, VSMap *out, void *userData, VSCore 
         vsapi->queryVideoFormat(&d->vi_out.format, d->vi->format.colorFamily, floatout ? stFloat : stInteger, bitsout, d->vi->format.subSamplingW, d->vi->format.subSamplingH, core);
 
         d->use_vbmi = false;
+        d->use_neon = false;
+        d->use_sve_gather = false;
 #ifdef VS_TARGET_CPU_X86
         if (getCPUFeatures()->avx512_vbmi && vs_get_cpulevel(core) >= VS_CPU_LEVEL_AVX512)
             d->use_vbmi = true;
+#elif defined(VS_TARGET_CPU_ARM64)
+        if (vs_get_cpulevel(core) >= VS_CPU_LEVEL_NEON)
+            d->use_neon = true;
+#ifdef VS_TARGET_ARM_SVE
+        // A gather retires svcntw() lookups, so the win scales with vector length,
+        // and it has to beat a scalar path that is already good: for byte output
+        // that path packs 8 lookups into a uint64 and stores once. Measured in the
+        // filter (not a microbenchmark, which flatters the gather by comparing it
+        // against a naive scalar loop):
+        //
+        //   256-bit  word->word +26%, word->byte +14%   (Graviton3)
+        //   128-bit  word->word  -7%, word->byte  -8%   (Graviton4)
+        //
+        // so a gather only pays above 128 bits, for either destination width.
+        if (getCPUFeatures()->sve && vs_get_cpulevel(core) >= VS_CPU_LEVEL_SVE) {
+            if (d->vi->format.bytesPerSample == 2 && vs_sve_vector_length() > 16)
+                d->use_sve_gather = true;
+        }
+#endif
 #endif
 
         if (d->vi->format.bytesPerSample == 1 && bitsout == 8)
@@ -349,8 +416,16 @@ void vs_lut2_gather_wb_b_avx512(const uint16_t *, const uint8_t *, uint8_t *, in
 void vs_lut2_gather_bw_w_avx512(const uint8_t *, const uint16_t *, uint16_t *, int, const uint16_t *, int, unsigned, unsigned);
 void vs_lut2_gather_bw_b_avx512(const uint8_t *, const uint16_t *, uint8_t *, int, const uint8_t *, int, unsigned, unsigned);
 #endif
+#if defined(VS_TARGET_CPU_ARM64) && defined(VS_TARGET_ARM_SVE)
+void vs_lut2_gather_ww_w_sve(const uint16_t *, const uint16_t *, uint16_t *, int, const uint16_t *, int, unsigned, unsigned);
+void vs_lut2_gather_ww_b_sve(const uint16_t *, const uint16_t *, uint8_t *, int, const uint8_t *, int, unsigned, unsigned);
+void vs_lut2_gather_wb_w_sve(const uint16_t *, const uint8_t *, uint16_t *, int, const uint16_t *, int, unsigned, unsigned);
+void vs_lut2_gather_wb_b_sve(const uint16_t *, const uint8_t *, uint8_t *, int, const uint8_t *, int, unsigned, unsigned);
+void vs_lut2_gather_bw_w_sve(const uint8_t *, const uint16_t *, uint16_t *, int, const uint16_t *, int, unsigned, unsigned);
+void vs_lut2_gather_bw_b_sve(const uint8_t *, const uint16_t *, uint8_t *, int, const uint8_t *, int, unsigned, unsigned);
+#endif
 
-/* Dispatch one row to the AVX-512 gather kernel for the current type combo.
+/* Dispatch one row to the gather kernel for the current type combo.
    Returns false (compile-time) for combos without a kernel so the caller falls
    back to the scalar path; only ever called when d->use_gather is set. */
 template<typename T, typename U, typename V>
@@ -368,6 +443,22 @@ static inline bool lut2GatherRow(const T *sx, const U *sy, V *d, int w, const V 
         } else if constexpr (std::is_same_v<T, uint8_t> && std::is_same_v<U, uint16_t>) {
             if constexpr (sizeof(V) == 2) vs_lut2_gather_bw_w_avx512(sx, sy, d, w, lut, bitsx, mx, my);
             else vs_lut2_gather_bw_b_avx512(sx, sy, d, w, lut, bitsx, mx, my);
+            return true;
+        }
+    }
+#elif defined(VS_TARGET_CPU_ARM64) && defined(VS_TARGET_ARM_SVE)
+    if constexpr (std::is_integral_v<V>) {
+        if constexpr (std::is_same_v<T, uint16_t> && std::is_same_v<U, uint16_t>) {
+            if constexpr (sizeof(V) == 2) vs_lut2_gather_ww_w_sve(sx, sy, d, w, lut, bitsx, mx, my);
+            else vs_lut2_gather_ww_b_sve(sx, sy, d, w, lut, bitsx, mx, my);
+            return true;
+        } else if constexpr (std::is_same_v<T, uint16_t> && std::is_same_v<U, uint8_t>) {
+            if constexpr (sizeof(V) == 2) vs_lut2_gather_wb_w_sve(sx, sy, d, w, lut, bitsx, mx, my);
+            else vs_lut2_gather_wb_b_sve(sx, sy, d, w, lut, bitsx, mx, my);
+            return true;
+        } else if constexpr (std::is_same_v<T, uint8_t> && std::is_same_v<U, uint16_t>) {
+            if constexpr (sizeof(V) == 2) vs_lut2_gather_bw_w_sve(sx, sy, d, w, lut, bitsx, mx, my);
+            else vs_lut2_gather_bw_b_sve(sx, sy, d, w, lut, bitsx, mx, my);
             return true;
         }
     }
@@ -529,6 +620,37 @@ static void lut2CreateHelper(const VSMap *in, VSMap *out, VSFunction *func, std:
     if constexpr (std::is_integral_v<V>) {
         if (getCPUFeatures()->avx512 && d->cpulevel >= VS_CPU_LEVEL_AVX512 && (size_t)inrange * sizeof(V) >= (512u << 10))
             d->use_gather = true;
+    }
+#elif defined(VS_TARGET_CPU_ARM64) && defined(VS_TARGET_ARM_SVE)
+    /* Measured with bench/bench_lut2_stream.py against a streaming source.
+       Round 1 gated this from a bench that convolved one *cached* frame, which
+       flatters the gather by leaving the source hot: it read 1.63x for a 1 MB
+       word table on Neoverse-V2 where streaming measures 0.91x.
+
+       Above 128 bits the gather retires 8+ lookups per instruction and wins on
+       throughput -- 1.61x-2.39x on Neoverse-V1, both resolutions and thread
+       counts -- except at the largest table Lut2 can build. 2 MB requires a word
+       destination and so streams the heaviest sources; on an already
+       bandwidth-bound part it drops to 0.69x on a full pool. Tested against the
+       20-bit index cap rather than a byte count, so that raising the cap cannot
+       silently admit a byte destination, whose table tops out at half the size.
+
+       At 128 bits the gather only ever paid once the table outgrew L2, which
+       makes that threshold L2-relative -- and L2 is not assumable here: 2 MB on
+       Graviton4/5, 1 MB on Grace despite the same Neoverse-V2 core, 512 KB-3 MB
+       across Cortex-X925 and C1 mobile parts, and mixed between core tiers
+       within one SoC. A 3 MB part would hold the 2 MB table resident and lose,
+       so 128-bit stays scalar until it can be measured across that spread. */
+    if constexpr (std::is_integral_v<V>) {
+        /* vs_sve_vector_length() executes an SVE instruction, so it must stay
+           inside the feature check -- reading it earlier faults on a core
+           without SVE. */
+        if (getCPUFeatures()->sve && d->cpulevel >= VS_CPU_LEVEL_SVE) {
+            const bool wide_vl = vs_sve_vector_length() > 16;
+            const bool full_word_table = sizeof(V) == 2
+                && (d->vi[0]->format.bitsPerSample + d->vi[1]->format.bitsPerSample) == 20;
+            d->use_gather = wide_vl && !full_word_table;
+        }
     }
 #endif
 


### PR DESCRIPTION
Introduces arm64/AArch64 vector kernels for the generic convolution family and the byte LUT filters, dispatched by runtime CPU feature detection:

- NEON kernels: Baseline arm64 kernels for convolution (separable, squares, 1D scanlines) and byte LUT. Selected on all arm64 CPUs, and used wherever the wide-vector tiers don't win despite CPU support.
- SVE / SVE2 kernels: usdot/svdot byte and word square convolutions and gather Lut1/Lut2, used only where they beat NEON at the target vector length (in practice 256-bit SVE, i.e. Graviton3).
- SME2 kernels: FMOPA-based square and vertical-1D convolution (including native 2-way f16 FMOPA), gated on exactly-representable coefficients.
- Build wiring (meson options, cpufeatures, cpulevel) and filter dispatch in genericfilters.cpp / lutfilters.cpp alongside the existing x86_64 kernels.

Every shipped kernel beats the C tier on the hardware it dispatches on; kernels that only won on small thread pools, or that the improved NEON tier overtook, were pruned rather than carried behind a thread-count or CPU-brand gate. Specifically dropped: the SME byte/half/float squares below 7x7 and all SME word squares/vertical (they only won on thread pools of <=4, which is below the default pool size on every SME machine); the SVE shapes NEON overtook (float squares, word 5x5/7x7, byte-plain-wide 9x9/11x11, byte separable); and the 3x3 float NEON square, which loses to its autovectorised C tier at a full thread pool on Apple Silicon.

## Benchmarking

FPS with a streaming source (distinct frames sized past last-level cache, so source loads are real) at 1920x1080 and 3840x2160, single-thread and all-cores (16). Each SIMD tier's throughput is shown as a multiple of the C path.

A blank cell means no kernel dispatches for that shape/format/tier on this machine (either none exists, or a lower tier but faster or saturation-friendly kernel gets selected instead). Byte-square SME/SVE cells are blank because for the int8 coefficients benched, the NEON usdot kernels win; those SME/SVE byte squares serve *wide* coefficients, shown in the separate wide-coefficient tables.

### Apple M4 Max (SME2, SVL 512)
#### 1080p, single thread
| case | fmt | C fps | neon fps | sme fps | neon vs C | sme vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 907.3 | 2529.8 |  | 2.79x |  |
| s3x3 | word | 872.0 | 1540.8 |  | 1.77x |  |
| s3x3 | half | 1363.9 | 2177.6 |  | 1.60x |  |
| s3x3 | float | 1343.1 |  |  |  |  |
| s5x5 | byte | 304.0 | 1299.6 |  | 4.27x |  |
| s5x5 | word | 263.8 | 568.2 |  | 2.15x |  |
| s5x5 | half | 322.5 | 589.7 |  | 1.83x |  |
| s5x5 | float | 429.9 | 602.7 |  | 1.40x |  |
| s7x7 | byte | 132.8 | 969.1 |  | 7.30x |  |
| s7x7 | word | 44.3 | 290.7 |  | 6.56x |  |
| s7x7 | half | 142.5 | 258.5 | 742.4 | 1.81x | 5.21x |
| s7x7 | float | 165.0 | 274.9 | 879.0 | 1.67x | 5.33x |
| s9x9 | byte | 138.5 | 481.0 |  | 3.47x |  |
| s9x9 | word | 45.1 | 189.5 |  | 4.21x |  |
| s9x9 | half | 108.7 | 148.5 | 532.4 | 1.37x | 4.90x |
| s9x9 | float | 104.8 | 156.9 | 636.8 | 1.50x | 6.07x |
| s11x11 | byte | 90.6 | 392.9 |  | 4.34x |  |
| s11x11 | word | 30.8 | 115.0 |  | 3.74x |  |
| s11x11 | half | 67.6 | 95.2 | 372.7 | 1.41x | 5.51x |
| s11x11 | float | 71.2 | 104.1 | 438.6 | 1.46x | 6.16x |
| h25 | byte | 154.7 | 786.8 |  | 5.08x |  |
| h25 | word | 165.6 | 499.2 |  | 3.02x |  |
| h25 | half | 120.0 | 629.7 |  | 5.25x |  |
| h25 | float | 142.6 | 656.6 |  | 4.60x |  |
| v25 | byte | 75.8 | 620.8 | 2420.7 | 8.19x | 31.93x |
| v25 | word | 68.2 | 541.9 |  | 7.95x |  |
| v25 | half | 66.2 | 634.1 | 1777.0 | 9.57x | 26.82x |
| v25 | float | 66.2 | 447.9 | 2187.8 | 6.76x | 33.03x |
| hv9 | byte | 115.8 | 818.2 |  | 7.07x |  |
| hv9 | word | 110.1 | 734.2 |  | 6.67x |  |
| hv9 | half | 112.0 | 996.7 |  | 8.90x |  |
| hv9 | float | 109.9 | 868.5 |  | 7.90x |  |
| lut | byte | 2796.0 | 6621.8 |  | 2.37x |  |

#### 1080p, all cores (16 threads)
| case | fmt | C fps | neon fps | sme fps | neon vs C | sme vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 10494.3 | 26005.0 |  | 2.48x |  |
| s3x3 | word | 10048.5 | 17591.6 |  | 1.75x |  |
| s3x3 | half | 13427.6 | 23482.1 |  | 1.75x |  |
| s3x3 | float | 15275.3 |  |  |  |  |
| s5x5 | byte | 3654.6 | 15145.3 |  | 4.14x |  |
| s5x5 | word | 3204.0 | 6919.9 |  | 2.16x |  |
| s5x5 | half | 3826.6 | 7147.7 |  | 1.87x |  |
| s5x5 | float | 5104.5 | 7188.9 |  | 1.41x |  |
| s7x7 | byte | 1580.0 | 11503.2 |  | 7.28x |  |
| s7x7 | word | 564.8 | 3546.2 |  | 6.28x |  |
| s7x7 | half | 1682.6 | 3137.2 | 3178.4 | 1.86x | 1.89x |
| s7x7 | float | 1917.5 | 3373.2 | 3474.1 | 1.76x | 1.81x |
| s9x9 | byte | 1710.8 | 5909.5 |  | 3.45x |  |
| s9x9 | word | 534.2 | 2327.8 |  | 4.36x |  |
| s9x9 | half | 1371.6 | 1810.8 | 2451.1 | 1.32x | 1.79x |
| s9x9 | float | 1244.4 | 1899.9 | 2698.4 | 1.53x | 2.17x |
| s11x11 | byte | 1134.0 | 4712.8 |  | 4.16x |  |
| s11x11 | word | 347.0 | 1395.5 |  | 4.02x |  |
| s11x11 | half | 834.7 | 1150.6 | 1896.9 | 1.38x | 2.27x |
| s11x11 | float | 852.0 | 1247.3 | 2079.3 | 1.46x | 2.44x |
| h25 | byte | 1551.1 | 9263.3 |  | 5.97x |  |
| h25 | word | 1697.1 | 5684.8 |  | 3.35x |  |
| h25 | half | 1304.8 | 7357.9 |  | 5.64x |  |
| h25 | float | 1546.2 | 7753.9 |  | 5.01x |  |
| v25 | byte | 846.7 | 7270.7 | 7337.5 | 8.59x | 8.67x |
| v25 | word | 774.0 | 6188.4 |  | 8.00x |  |
| v25 | half | 783.8 | 7106.1 | 8064.2 | 9.07x | 10.29x |
| v25 | float | 775.6 | 4763.3 | 7644.0 | 6.14x | 9.86x |
| hv9 | byte | 1219.3 | 9588.8 |  | 7.86x |  |
| hv9 | word | 1169.6 | 8655.7 |  | 7.40x |  |
| hv9 | half | 1213.6 | 11240.3 |  | 9.26x |  |
| hv9 | float | 1273.2 | 9454.5 |  | 7.43x |  |
| lut | byte | 27752.7 | 41714.5 |  | 1.50x |  |

#### UHD (3840x2160), single thread
| case | fmt | C fps | neon fps | sme fps | neon vs C | sme vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 217.0 | 635.4 |  | 2.93x |  |
| s3x3 | word | 209.3 | 377.6 |  | 1.80x |  |
| s3x3 | half | 332.4 | 531.4 |  | 1.60x |  |
| s3x3 | float | 377.0 |  |  |  |  |
| s5x5 | byte | 73.6 | 332.9 |  | 4.52x |  |
| s5x5 | word | 64.0 | 140.3 |  | 2.19x |  |
| s5x5 | half | 77.9 | 145.6 |  | 1.87x |  |
| s5x5 | float | 106.4 | 153.0 |  | 1.44x |  |
| s7x7 | byte | 32.2 | 239.1 |  | 7.42x |  |
| s7x7 | word | 10.9 | 71.8 |  | 6.57x |  |
| s7x7 | half | 34.7 | 64.1 | 183.1 | 1.85x | 5.27x |
| s7x7 | float | 40.9 | 68.7 | 223.8 | 1.68x | 5.48x |
| s9x9 | byte | 34.3 | 125.9 |  | 3.67x |  |
| s9x9 | word | 11.3 | 48.0 |  | 4.26x |  |
| s9x9 | half | 27.6 | 37.3 | 137.9 | 1.35x | 4.99x |
| s9x9 | float | 26.6 | 39.4 | 163.4 | 1.48x | 6.15x |
| s11x11 | byte | 22.2 | 102.7 |  | 4.63x |  |
| s11x11 | word | 7.7 | 33.3 |  | 4.31x |  |
| s11x11 | half | 17.2 | 24.2 | 102.3 | 1.41x | 5.97x |
| s11x11 | float | 18.3 | 26.5 | 118.7 | 1.45x | 6.49x |
| h25 | byte | 39.8 | 224.4 |  | 5.64x |  |
| h25 | word | 42.4 | 132.0 |  | 3.12x |  |
| h25 | half | 29.8 | 169.9 |  | 5.70x |  |
| h25 | float | 36.5 | 176.7 |  | 4.84x |  |
| v25 | byte | 16.9 | 155.6 | 635.4 | 9.22x | 37.67x |
| v25 | word | 17.2 | 133.9 |  | 7.77x |  |
| v25 | half | 16.6 | 155.6 | 443.2 | 9.37x | 26.68x |
| v25 | float | 16.6 | 109.3 | 471.5 | 6.59x | 28.42x |
| hv9 | byte | 28.2 | 212.8 |  | 7.54x |  |
| hv9 | word | 27.5 | 191.9 |  | 6.98x |  |
| hv9 | half | 28.1 | 260.6 |  | 9.28x |  |
| hv9 | float | 28.1 | 180.4 |  | 6.43x |  |
| lut | byte | 713.3 | 1700.2 |  | 2.38x |  |

#### UHD, all cores (16 threads)
| case | fmt | C fps | neon fps | sme fps | neon vs C | sme vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 2613.9 | 7267.2 |  | 2.78x |  |
| s3x3 | word | 2445.4 | 4319.4 |  | 1.77x |  |
| s3x3 | half | 3786.3 | 5819.2 |  | 1.54x |  |
| s3x3 | float | 3177.7 |  |  |  |  |
| s5x5 | byte | 853.6 | 3910.2 |  | 4.58x |  |
| s5x5 | word | 747.3 | 1685.5 |  | 2.26x |  |
| s5x5 | half | 867.7 | 1733.6 |  | 2.00x |  |
| s5x5 | float | 1215.5 | 1815.1 |  | 1.49x |  |
| s7x7 | byte | 365.1 | 2816.8 |  | 7.72x |  |
| s7x7 | word | 124.3 | 808.7 |  | 6.51x |  |
| s7x7 | half | 378.2 | 716.0 | 730.9 | 1.89x | 1.93x |
| s7x7 | float | 459.0 | 777.9 | 866.0 | 1.69x | 1.89x |
| s9x9 | byte | 391.4 | 1494.6 |  | 3.82x |  |
| s9x9 | word | 116.9 | 526.8 |  | 4.51x |  |
| s9x9 | half | 309.4 | 402.5 | 575.0 | 1.30x | 1.86x |
| s9x9 | float | 274.2 | 420.5 | 668.6 | 1.53x | 2.44x |
| s11x11 | byte | 244.3 | 1141.8 |  | 4.67x |  |
| s11x11 | word | 76.9 | 347.6 |  | 4.52x |  |
| s11x11 | half | 187.9 | 254.8 | 444.1 | 1.36x | 2.36x |
| s11x11 | float | 192.5 | 281.4 | 487.7 | 1.46x | 2.53x |
| h25 | byte | 419.1 | 2515.6 |  | 6.00x |  |
| h25 | word | 404.4 | 1507.2 |  | 3.73x |  |
| h25 | half | 300.5 | 1925.9 |  | 6.41x |  |
| h25 | float | 351.7 | 1980.5 |  | 5.63x |  |
| v25 | byte | 171.8 | 1743.5 | 1888.6 | 10.15x | 10.99x |
| v25 | word | 173.7 | 1468.9 |  | 8.45x |  |
| v25 | half | 177.0 | 1668.1 | 2010.3 | 9.42x | 11.35x |
| v25 | float | 171.8 | 986.2 | 1778.0 | 5.74x | 10.35x |
| hv9 | byte | 278.2 | 2475.4 |  | 8.90x |  |
| hv9 | word | 269.3 | 2155.7 |  | 8.00x |  |
| hv9 | half | 283.7 | 2870.6 |  | 10.12x |  |
| hv9 | float | 284.8 | 2005.1 |  | 7.04x |  |
| lut | byte | 7724.2 | 17107.2 |  | 2.21x |  |

Wide-coefficient byte squares (the sme byte-square dispatch condition; int8 byte squares use the NEON usdot kernels shown above):

_1080p, 1 thread:_
| case | fmt | C fps | neon fps | sme fps | neon vs C | sme vs C |
|---|---|--:|--:|--:|--:|--:|
| s7x7 | byte | 133.4 | 301.8 | 877.0 | 2.26x | 6.58x |
| s9x9 | byte | 138.5 | 171.6 | 640.2 | 1.24x | 4.62x |
| s11x11 | byte | 90.8 | 118.0 | 457.5 | 1.30x | 5.04x |

_1080p, 16 threads:_
| case | fmt | C fps | neon fps | sme fps | neon vs C | sme vs C |
|---|---|--:|--:|--:|--:|--:|
| s7x7 | byte | 1587.7 | 3502.2 | 3357.4 | 2.21x | 2.11x |
| s9x9 | byte | 1724.3 | 2035.7 | 2760.3 | 1.18x | 1.60x |
| s11x11 | byte | 1131.6 | 1394.7 | 2121.9 | 1.23x | 1.88x |


### Apple M2 Pro (Mac mini, 10 cores, no SME) - tested by @myrsloik

Speedup ranges of the NEON tier vs the C tier from @myrsloik's runs (full per-shape output in the PR comments). Each cell is the min-max across formats and coefficient widths for that shape; "wide" coefficient byte squares are included and set the low end of the byte-square ranges, since the usdot kernels require int8 coefficients.

| case | 1080p t1 | 1080p t10 | UHD t1 | UHD t10 |
|---|--:|--:|--:|--:|
| s3x3 | 1.56x - 2.67x | 1.46x - 2.55x | 1.52x - 2.70x | 1.44x - 2.71x |
| s5x5 | 1.41x - 5.06x | 1.45x - 4.78x | 1.48x - 5.21x | 1.54x - 5.20x |
| s7x7 | 1.97x - 7.95x | 1.96x - 7.78x | 1.90x - 7.92x | 1.87x - 7.70x |
| s9x9 | 1.53x - 7.57x | 1.58x - 6.58x | 1.55x - 7.63x | 1.56x - 6.39x |
| s11x11 | 1.34x - 6.69x | 1.36x - 6.09x | 1.36x - 7.74x | 1.43x - 6.48x |
| h25 | 3.48x - 6.56x | 3.54x - 6.54x | 3.78x - 6.28x | 3.79x - 6.78x |
| v25 | 6.26x - 11.06x | 5.51x - 9.97x | 5.94x - 9.73x | 5.78x - 9.17x |
| hv9 | 7.09x - 9.76x | 6.57x - 9.55x | 6.43x - 10.04x | 6.10x - 9.49x |
| lut | 2.20x | 1.56x | 2.29x | 2.10x |

The s3x3 float rows are excluded from the ranges: no NEON kernel dispatches there (the 3x3 float square was pruned), and the measured 1.00x-1.06x confirms the clean C fallback. Per @myrsloik, the C-vs-NEON ratios track the M4 results closely enough that pre-SME Apple cores don't need separate re-testing when M3/M4 numbers are available.

### AWS Graviton3 (Neoverse-V1, SVE 256-bit)
#### 1080p, single thread
| case | fmt | C fps | neon fps | sve fps | neon vs C | sve vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 67.4 | 798.6 |  | 11.85x |  |
| s3x3 | word | 66.0 | 436.5 | 455.3 | 6.61x | 6.90x |
| s3x3 | half | 139.7 | 743.3 |  | 5.32x |  |
| s3x3 | float | 698.1 |  |  |  |  |
| s5x5 | byte | 26.7 | 438.0 |  | 16.38x |  |
| s5x5 | word | 27.1 | 214.4 |  | 7.92x |  |
| s5x5 | half | 47.0 | 262.4 |  | 5.58x |  |
| s5x5 | float | 192.8 | 313.5 |  | 1.63x |  |
| s7x7 | byte | 18.9 | 266.6 | 390.3 | 14.08x | 20.61x |
| s7x7 | word | 17.9 | 124.5 |  | 6.95x |  |
| s7x7 | half | 20.3 | 148.2 |  | 7.29x |  |
| s7x7 | float | 25.2 | 169.3 |  | 6.73x |  |
| s9x9 | byte | 9.2 | 163.0 | 202.3 | 17.77x | 22.05x |
| s9x9 | word | 9.2 | 54.3 | 69.5 | 5.88x | 7.52x |
| s9x9 | half | 16.6 | 95.0 |  | 5.73x |  |
| s9x9 | float | 36.7 | 103.9 |  | 2.83x |  |
| s11x11 | byte | 8.3 | 133.8 |  | 16.03x |  |
| s11x11 | word | 8.5 | 41.6 | 56.3 | 4.92x | 6.66x |
| s11x11 | half | 12.0 | 53.5 |  | 4.46x |  |
| s11x11 | float | 26.7 | 70.9 |  | 2.65x |  |
| h25 | byte | 25.7 | 360.8 |  | 14.05x |  |
| h25 | word | 17.1 | 188.9 |  | 11.05x |  |
| h25 | half | 35.6 | 280.9 |  | 7.88x |  |
| h25 | float | 42.7 | 271.7 |  | 6.37x |  |
| v25 | byte | 21.4 | 207.7 |  | 9.69x |  |
| v25 | word | 21.3 | 228.3 |  | 10.71x |  |
| v25 | half | 32.9 | 302.0 |  | 9.17x |  |
| v25 | float | 35.9 | 215.8 |  | 6.01x |  |
| hv9 | byte | 25.6 | 280.5 |  | 10.97x |  |
| hv9 | word | 19.8 | 233.7 |  | 11.78x |  |
| hv9 | half | 48.2 | 358.6 |  | 7.43x |  |
| hv9 | float | 53.4 | 348.6 |  | 6.53x |  |
| lut | byte | 1538.9 | 2329.3 |  | 1.51x |  |

#### 1080p, all cores (16 threads)
| case | fmt | C fps | neon fps | sve fps | neon vs C | sve vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 1021.0 | 10730.3 |  | 10.51x |  |
| s3x3 | word | 1007.7 | 6261.6 | 6101.2 | 6.21x | 6.05x |
| s3x3 | half | 2068.0 | 8413.2 |  | 4.07x |  |
| s3x3 | float | 8274.4 |  |  |  |  |
| s5x5 | byte | 401.3 | 6353.9 |  | 15.83x |  |
| s5x5 | word | 405.6 | 3158.2 |  | 7.79x |  |
| s5x5 | half | 699.7 | 3495.4 |  | 5.00x |  |
| s5x5 | float | 2839.8 | 3858.0 |  | 1.36x |  |
| s7x7 | byte | 283.5 | 3919.3 | 4511.1 | 13.83x | 15.91x |
| s7x7 | word | 267.3 | 1842.2 |  | 6.89x |  |
| s7x7 | half | 304.2 | 1946.2 |  | 6.40x |  |
| s7x7 | float | 376.1 | 2194.5 |  | 5.83x |  |
| s9x9 | byte | 137.6 | 2426.8 | 2445.0 | 17.63x | 17.76x |
| s9x9 | word | 138.4 | 808.8 | 910.0 | 5.84x | 6.57x |
| s9x9 | half | 248.0 | 1213.6 |  | 4.89x |  |
| s9x9 | float | 546.7 | 1334.7 |  | 2.44x |  |
| s11x11 | byte | 125.1 | 1987.2 |  | 15.89x |  |
| s11x11 | word | 126.7 | 620.5 | 747.4 | 4.90x | 5.90x |
| s11x11 | half | 179.6 | 796.3 |  | 4.43x |  |
| s11x11 | float | 396.4 | 937.2 |  | 2.36x |  |
| h25 | byte | 384.4 | 5191.5 |  | 13.50x |  |
| h25 | word | 256.1 | 2799.3 |  | 10.93x |  |
| h25 | half | 531.5 | 3849.2 |  | 7.24x |  |
| h25 | float | 635.9 | 3636.3 |  | 5.72x |  |
| v25 | byte | 320.5 | 3074.0 |  | 9.59x |  |
| v25 | word | 318.7 | 3042.7 |  | 9.55x |  |
| v25 | half | 492.1 | 3548.7 |  | 7.21x |  |
| v25 | float | 535.4 | 2747.6 |  | 5.13x |  |
| hv9 | byte | 382.7 | 4114.9 |  | 10.75x |  |
| hv9 | word | 296.8 | 3365.0 |  | 11.34x |  |
| hv9 | half | 718.4 | 4471.5 |  | 6.22x |  |
| hv9 | float | 794.6 | 4210.7 |  | 5.30x |  |
| lut | byte | 16088.6 | 17161.1 |  | 1.07x |  |

#### UHD (3840x2160), single thread
| case | fmt | C fps | neon fps | sve fps | neon vs C | sve vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 16.8 | 208.7 |  | 12.42x |  |
| s3x3 | word | 17.0 | 112.3 | 117.0 | 6.62x | 6.90x |
| s3x3 | half | 35.4 | 192.2 |  | 5.44x |  |
| s3x3 | float | 179.0 |  |  |  |  |
| s5x5 | byte | 6.7 | 117.0 |  | 17.44x |  |
| s5x5 | word | 6.8 | 55.1 |  | 8.14x |  |
| s5x5 | half | 11.8 | 67.3 |  | 5.71x |  |
| s5x5 | float | 49.2 | 81.2 |  | 1.65x |  |
| s7x7 | byte | 4.7 | 69.8 | 106.2 | 14.72x | 22.40x |
| s7x7 | word | 4.5 | 31.9 |  | 7.16x |  |
| s7x7 | half | 5.1 | 38.0 |  | 7.46x |  |
| s7x7 | float | 6.3 | 43.4 |  | 6.87x |  |
| s9x9 | byte | 2.3 | 43.5 | 56.6 | 18.93x | 24.60x |
| s9x9 | word | 2.3 | 13.8 | 18.1 | 5.91x | 7.78x |
| s9x9 | half | 4.2 | 24.4 |  | 5.86x |  |
| s9x9 | float | 9.3 | 26.8 |  | 2.90x |  |
| s11x11 | byte | 2.1 | 36.0 |  | 17.23x |  |
| s11x11 | word | 2.1 | 10.6 | 14.7 | 5.01x | 6.93x |
| s11x11 | half | 3.0 | 13.7 |  | 4.56x |  |
| s11x11 | float | 6.7 | 18.4 |  | 2.73x |  |
| h25 | byte | 6.4 | 110.0 |  | 17.08x |  |
| h25 | word | 4.3 | 52.9 |  | 12.31x |  |
| h25 | half | 9.0 | 77.6 |  | 8.66x |  |
| h25 | float | 10.8 | 78.4 |  | 7.22x |  |
| v25 | byte | 5.4 | 51.3 |  | 9.56x |  |
| v25 | word | 5.3 | 58.2 |  | 10.88x |  |
| v25 | half | 8.3 | 76.5 |  | 9.26x |  |
| v25 | float | 9.0 | 60.6 |  | 6.69x |  |
| hv9 | byte | 6.4 | 73.7 |  | 11.50x |  |
| hv9 | word | 5.0 | 60.8 |  | 12.27x |  |
| hv9 | half | 12.1 | 92.0 |  | 7.60x |  |
| hv9 | float | 12.9 | 87.7 |  | 6.82x |  |
| lut | byte | 401.8 | 626.3 |  | 1.56x |  |

#### UHD, all cores (16 threads)
| case | fmt | C fps | neon fps | sve fps | neon vs C | sve vs C |
|---|---|--:|--:|--:|--:|--:|
| s3x3 | byte | 216.6 | 2599.0 |  | 12.00x |  |
| s3x3 | word | 214.6 | 1397.1 | 1364.2 | 6.51x | 6.36x |
| s3x3 | half | 440.8 | 2093.3 |  | 4.75x |  |
| s3x3 | float | 1734.6 |  |  |  |  |
| s5x5 | byte | 84.1 | 1454.1 |  | 17.30x |  |
| s5x5 | word | 85.1 | 686.4 |  | 8.07x |  |
| s5x5 | half | 147.2 | 767.4 |  | 5.21x |  |
| s5x5 | float | 613.3 | 870.2 |  | 1.42x |  |
| s7x7 | byte | 59.3 | 871.7 | 1124.5 | 14.71x | 18.98x |
| s7x7 | word | 56.0 | 397.7 |  | 7.10x |  |
| s7x7 | half | 63.7 | 427.8 |  | 6.72x |  |
| s7x7 | float | 78.8 | 468.2 |  | 5.94x |  |
| s9x9 | byte | 28.7 | 542.4 | 595.9 | 18.89x | 20.75x |
| s9x9 | word | 29.1 | 171.8 | 204.1 | 5.90x | 7.01x |
| s9x9 | half | 52.1 | 267.8 |  | 5.14x |  |
| s9x9 | float | 115.6 | 296.5 |  | 2.56x |  |
| s11x11 | byte | 26.1 | 448.5 |  | 17.17x |  |
| s11x11 | word | 26.5 | 132.4 | 165.4 | 5.00x | 6.24x |
| s11x11 | half | 37.6 | 171.3 |  | 4.55x |  |
| s11x11 | float | 84.3 | 207.3 |  | 2.46x |  |
| h25 | byte | 80.7 | 1366.2 |  | 16.94x |  |
| h25 | word | 53.6 | 657.6 |  | 12.26x |  |
| h25 | half | 111.9 | 902.9 |  | 8.07x |  |
| h25 | float | 135.4 | 886.0 |  | 6.54x |  |
| v25 | byte | 67.0 | 638.5 |  | 9.53x |  |
| v25 | word | 66.9 | 663.9 |  | 9.93x |  |
| v25 | half | 103.3 | 791.4 |  | 7.66x |  |
| v25 | float | 113.0 | 658.1 |  | 5.82x |  |
| hv9 | byte | 80.1 | 917.9 |  | 11.46x |  |
| hv9 | word | 62.0 | 755.5 |  | 12.19x |  |
| hv9 | half | 151.1 | 1011.0 |  | 6.69x |  |
| hv9 | float | 166.8 | 922.7 |  | 5.53x |  |
| lut | byte | 4853.1 | 7486.2 |  | 1.54x |  |

Wide-coefficient byte squares (the sve byte-square dispatch condition; int8 byte squares use the NEON usdot kernels shown above):

_1080p, 1 thread:_
| case | fmt | C fps | neon fps | sve fps | neon vs C | sve vs C |
|---|---|--:|--:|--:|--:|--:|
| s7x7 | byte | 17.8 | 114.8 | 133.4 | 6.44x | 7.49x |
| s9x9 | byte | 8.9 | 74.7 |  | 8.38x |  |
| s11x11 | byte | 8.6 | 52.0 |  | 6.06x |  |

_1080p, 16 threads:_
| case | fmt | C fps | neon fps | sve fps | neon vs C | sve vs C |
|---|---|--:|--:|--:|--:|--:|
| s7x7 | byte | 266.8 | 1708.8 | 1984.6 | 6.40x | 7.44x |
| s9x9 | byte | 133.5 | 1113.4 |  | 8.34x |  |
| s11x11 | byte | 128.6 | 776.5 |  | 6.04x |  |


#### Lut2 (SVE gather), 1080p and UHD

`Lut2` has no NEON or SME kernel on any ISA, so the `neon` column is omitted here: the gather is SVE-only, and where it does not dispatch the filter runs the scalar C path. A blank ratio means the gather declined and the row is the C tier.

The table size is fixed by the source depths, since `Lut2` allows 20 indexing bits in total. The largest table it can build is 2 MB, which requires a word destination and so streams the heaviest sources; that case goes bandwidth-bound on a full pool and is left to C. Everything smaller wins at both resolutions and both thread counts.

| case | sources -> dst | table | 1080p t1 | 1080p t16 | UHD t1 | UHD t16 |
|---|---|--:|--:|--:|--:|--:|
| lut2ww_w | 10b x 10b -> word | 2 MB |  |  |  |  |
| lut2ww_b | 10b x 10b -> byte | 1 MB | 2.19x | 2.04x | 2.24x | 1.64x |
| lut2wb_w | 12b x 8b -> word | 2 MB |  |  |  |  |
| lut2wb_b | 10b x 8b -> byte | 256 KB | 1.88x | 1.69x | 1.93x | 1.85x |
| lut2bw_w | 8b x 12b -> word | 2 MB |  |  |  |  |
| lut2bw_b | 8b x 10b -> byte | 256 KB | 1.90x | 1.72x | 1.92x | 1.85x |

Sweeping table size with the kernel held fixed (256 KB through 2 MB) gives the same picture across all 15 dispatching shapes: 1.62x to 2.38x, with no shape below the C tier at either resolution or thread count.

Measured Graviton4 (Neoverse-V2) and Graviton5 (Neoverse-V3) results are omitted because their 128-bit SVE2 dispatches to NEON throughout: no convolution shape and no `Lut2` table size beats NEON or C at that vector length, so those parts run the NEON and C tiers only. (Correctness and accuracy were still verified on both.)

## Numerical Accuracy Audit
Max |err| of each SIMD tier vs the C reference, relative to accumulation magnitude for float (see round-1 notes). Integer paths are bit-exact (70/70, all machines). A `0` can mean the tier has no kernel for that shape and fell to C. x86 columns are from an AMD EPYC 9R45 (unchanged by this work).

| fmt | shape | coeff | x86:sse2 | x86:avx2 | x86:avx512 | M4:neon | M4:sme | G3:neon | G3:sve | G4:neon | G4:sve |
|---|---|---|---|---|---|---|---|---|---|---|---|
| half | s3x3 | f16 | 0 | 2.73e-4 | 2.73e-4 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| half | s3x3 | arb | 0 | 1.37e-4 | 1.37e-4 | 0.00e+00 | 0.00e+00 | 1.37e-04 | 1.37e-04 | 1.37e-04 | 1.37e-04 |
| half | s5x5 | f16 | 0 | 0 | 0 | 5.66e-05 | 5.66e-05 | 5.66e-05 | 5.66e-05 | 5.66e-05 | 5.66e-05 |
| half | s5x5 | arb | 0 | 0 | 0 | 1.13e-04 | 1.13e-04 | 1.13e-04 | 1.13e-04 | 1.13e-04 | 1.13e-04 |
| half | s7x7 | f16 | 0 | 0 | 0 | 7.29e-05 | 7.29e-05 | 7.29e-05 | 7.29e-05 | 7.29e-05 | 7.29e-05 |
| half | s7x7 | arb | 0 | 0 | 0 | 7.29e-05 | 7.29e-05 | 7.29e-05 | 7.29e-05 | 7.29e-05 | 7.29e-05 |
| half | s9x9 | f16 | 0 | 0 | 0 | 1.09e-04 | 1.09e-04 | 1.09e-04 | 1.09e-04 | 1.09e-04 | 1.09e-04 |
| half | s9x9 | arb | 0 | 0 | 0 | 5.44e-05 | 5.44e-05 | 5.44e-05 | 5.44e-05 | 5.44e-05 | 5.44e-05 |
| half | s11x11 | f16 | 0 | 0 | 0 | 6.68e-05 | 6.68e-05 | 6.68e-05 | 6.68e-05 | 6.68e-05 | 6.68e-05 |
| half | s11x11 | arb | 0 | 0 | 0 | 6.68e-05 | 6.68e-05 | 6.68e-05 | 6.68e-05 | 6.68e-05 | 6.68e-05 |
| half | h25 | f16 | 0 | 0 | 0 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| half | h25 | arb | 0 | 0 | 0 | 5.66e-05 | 5.66e-05 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| half | v25 | f16 | 0 | 0 | 0 | 0.00e+00 | 1.13e-04 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| half | v25 | arb | 0 | 0 | 0 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| half | hv9 | f16 | 0 | 0 | 0 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| half | hv9 | arb | 0 | 0 | 0 | 1.37e-04 | 1.37e-04 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | s3x3 | f16 | 1.00e-7 | 1.00e-7 | 1.00e-7 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | s3x3 | arb | 1.00e-7 | 1.00e-7 | 1.00e-7 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | s5x5 | f16 | 0 | 6.91e-8 | 6.91e-8 | 6.91e-08 | 6.91e-08 | 6.91e-08 | 6.91e-08 | 6.91e-08 | 6.91e-08 |
| float | s5x5 | arb | 0 | 5.53e-8 | 5.53e-8 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 5.53e-08 |
| float | s7x7 | f16 | 0 | 8.90e-8 | 8.90e-8 | 8.90e-08 | 8.90e-08 | 8.90e-08 | 8.90e-08 | 8.90e-08 | 8.90e-08 |
| float | s7x7 | arb | 0 | 8.90e-8 | 8.90e-8 | 7.12e-08 | 7.12e-08 | 7.12e-08 | 7.12e-08 | 7.12e-08 | 7.12e-08 |
| float | s9x9 | f16 | 0 | 8.64e-8 | 8.64e-8 | 8.64e-08 | 8.64e-08 | 8.64e-08 | 8.64e-08 | 8.64e-08 | 8.64e-08 |
| float | s9x9 | arb | 0 | 7.97e-8 | 7.97e-8 | 7.97e-08 | 7.97e-08 | 7.97e-08 | 7.97e-08 | 7.97e-08 | 7.97e-08 |
| float | s11x11 | f16 | 0 | 8.15e-8 | 8.15e-8 | 8.15e-08 | 8.15e-08 | 8.15e-08 | 8.15e-08 | 8.15e-08 | 8.15e-08 |
| float | s11x11 | arb | 0 | 7.33e-8 | 7.33e-8 | 7.33e-08 | 7.33e-08 | 7.33e-08 | 7.33e-08 | 7.33e-08 | 7.33e-08 |
| float | h25 | f16 | 5.53e-8 | 5.53e-8 | 5.53e-8 | 5.53e-08 | 5.53e-08 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | h25 | arb | 6.22e-8 | 6.22e-8 | 6.22e-8 | 5.53e-08 | 5.53e-08 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | v25 | f16 | 5.53e-8 | 5.53e-8 | 5.53e-8 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | v25 | arb | 6.91e-8 | 6.91e-8 | 6.91e-8 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | hv9 | f16 | 1.33e-7 | 1.33e-7 | 1.33e-7 | 8.34e-08 | 8.34e-08 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| float | hv9 | arb | 1.00e-7 | 1.00e-7 | 1.00e-7 | 1.00e-07 | 1.00e-07 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |

[convolution_accuracy.py](https://github.com/user-attachments/files/30145308/convolution_accuracy.py)
[convolution_benchmark.py](https://github.com/user-attachments/files/30145309/convolution_benchmark.py)

To reproduce tables like above on an M4 or M5:
```sh
python convolution_benchmark.py --sweep --profile m4 --levels none neon sme --preset 1080p --threads 1  --frames 150
python convolution_benchmark.py --sweep --profile m4 --levels none neon sme --preset 1080p --threads 16 --frames 150 --reps 5
python convolution_benchmark.py --sweep --profile m4 --levels none neon sme --preset uhd   --threads 1  --frames 50
python convolution_benchmark.py --sweep --profile m4 --levels none neon sme --preset uhd   --threads 16 --frames 50  --reps 5
```
For Graviton3, use `--profile g3 --levels none neon sve`.

