### PR TITLE
Add AArch64 NEON kernels for convolution and byte LUT

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         exclude_file: .codespellignore
         skip: ./src/avfs/include,./src/avisynth/avisynth.h,./src/avisynth/interface.cpp,./src/core/ter-116n.h,./src/core/expr/jitasm.h
-        ignore_words_list: indx
+        ignore_words_list: indx,sme

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,8 @@ x64/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 [Aa][Rr][Mm]64[Ee][Cc]/
+# The VS build-output patterns above must not hide the AArch64 kernel sources.
+!src/core/kernel/arm/
 bld/
 [Oo]bj/
 [Oo]ut/

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project('VapourSynth', 'c', 'cpp', 'cython',
 
 enable_guard_pattern = get_option('enable_guard_pattern')
 enable_x86_asm = get_option('enable_x86_asm')
+enable_arm_asm = get_option('enable_arm_asm')
 
 cxx = meson.get_compiler('cpp')
 
@@ -62,6 +63,10 @@ endif
 
 if not host_cpu_family.startswith('x86')
     enable_x86_asm = false
+endif
+
+if host_cpu_family != 'aarch64'
+    enable_arm_asm = false
 endif
 
 incdir = include_directories('include')
@@ -161,6 +166,42 @@ soversion = is_win ? '' : run_command(
 
 if enable_x86_asm
     add_project_arguments('-DVS_TARGET_CPU_X86', language: ['c', 'cpp'])
+endif
+
+# --- AArch64 SIMD kernels ----------------------------------------------------
+# NEON is the AArch64 baseline and its kernels ride along with the plain filter
+# sources. fp16fml/i8mm kernels get their own TUs with a raised -march; they are
+# runtime-dispatched.
+arm_have_i8mm = false
+arm_have_fhm = false
+if enable_arm_asm
+    add_project_arguments('-DVS_TARGET_CPU_ARM64', language: ['c', 'cpp'])
+
+    arm_i8mm_args = ['-march=armv8.2-a+i8mm']
+    arm_fhm_args = ['-march=armv8.2-a+fp16+fp16fml']
+
+    arm_have_i8mm = cxx.compiles('''
+#include <arm_neon.h>
+int32x4_t f(int32x4_t a, uint8x16_t b, int8x16_t c) { return vusdotq_s32(a, b, c); }
+''',
+        args: arm_i8mm_args,
+        name: 'AArch64 i8mm usdot intrinsics',
+    )
+
+    arm_have_fhm = cxx.compiles('''
+#include <arm_neon.h>
+float32x4_t f(float32x4_t r, float16x8_t a, float16x8_t b) { return vfmlalq_low_f16(r, a, b); }
+''',
+        args: arm_fhm_args,
+        name: 'AArch64 fp16fml (FEAT_FHM) intrinsics',
+    )
+
+    if arm_have_i8mm
+        add_project_arguments('-DVS_TARGET_ARM_I8MM', language: ['c', 'cpp'])
+    endif
+    if arm_have_fhm
+        add_project_arguments('-DVS_TARGET_ARM_FHM', language: ['c', 'cpp'])
+    endif
 endif
 
 libvapoursynth = library('libvapoursynth',
@@ -392,10 +433,54 @@ if enable_x86_asm
         )
     endforeach
 else
+    arm_filter_sources = []
+    arm_vlibs = []
+    if enable_arm_asm
+        # NEON is the AArch64 baseline; its kernels ride with the plugin proper.
+        arm_filter_sources += files(
+            'src/core/kernel/arm/convolution_neon.cpp',
+            'src/core/kernel/arm/lut_neon.cpp',
+            'src/core/kernel/arm/square_neon.cpp',
+        )
+        if arm_have_i8mm
+            # usdot byte square conv. Its own TU so the NEON baseline sources are
+            # never built with +i8mm.
+            arm_vlibs += static_library('vsfilters_i8mm',
+                files('src/core/kernel/arm/square_dot_neon.cpp'),
+                cpp_args: arm_i8mm_args,
+                gnu_symbol_visibility: 'hidden',
+                include_directories: incdir,
+            )
+        endif
+        if arm_have_fhm
+            # fmlal widening f16 MAC kernels. Separated so NEON baseline
+            # sources aren't built with +fp16fml.
+            # Kept out of LTO deliberately. Under gcc 13 + -flto, growing this
+            # unit changes how the link re-optimises the UNTOUCHED half
+            # scanlines in convolution_neon.cpp: adding the 1D kernels below
+            # cost half nof16 h25 -10..-13% and hv9 -14..-17% on V1/V2/V3, on
+            # a function whose source never changed (verified in the
+            # disassembly: same source, different codegen). Compiling to real
+            # object code keeps it out of the LTO partition and the regression
+            # disappears (nof16 back to +-0%). It costs the fhm kernels
+            # themselves almost nothing; the squares measure identical to the
+            # LTO build. Only f16 h25 gives up ~3% because they're
+            # self-contained with header inlines as helpers.
+            arm_vlibs += static_library('vsfilters_fhm',
+                files('src/core/kernel/arm/convolution_fhm_neon.cpp'),
+                cpp_args: arm_fhm_args,
+                gnu_symbol_visibility: 'hidden',
+                include_directories: incdir,
+                override_options: ['b_lto=false'],
+            )
+        endif
+    endif
+
     shared_module('libvapoursynthfilters',
-        filters_sources,
+        filters_sources + arm_filter_sources,
         gnu_symbol_visibility: 'hidden',
         include_directories: incdir,
+        link_with: arm_vlibs,
         name_prefix: '',
         install: true,
         install_dir: install_dir,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,9 @@ option('enable_x86_asm',
     value: true,
     description: 'Enable assembler code for x86 CPUs',
 )
+
+option('enable_arm_asm',
+    type: 'boolean',
+    value: true,
+    description: 'Enable SIMD kernels (NEON) for AArch64 CPUs',
+)

--- a/src/core/cpufeatures.cpp
+++ b/src/core/cpufeatures.cpp
@@ -141,6 +141,97 @@ int doGetX86ABILevel(void) {
     return 4;
 }
 
+#elif defined(VS_TARGET_CPU_ARM64)
+
+#if defined(__APPLE__)
+#include <sys/sysctl.h>
+
+static char vs_sysctl_flag(const char *name) {
+    int val = 0;
+    size_t len = sizeof(val);
+    if (sysctlbyname(name, &val, &len, nullptr, 0) != 0)
+        return 0;
+    return !!val;
+}
+
+static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
+    *cpuFeatures = {};
+    cpuFeatures->can_run_vs = 1;
+    cpuFeatures->dotprod = vs_sysctl_flag("hw.optional.arm.FEAT_DotProd");
+    cpuFeatures->fp16 = vs_sysctl_flag("hw.optional.arm.FEAT_FP16");
+    cpuFeatures->fhm = vs_sysctl_flag("hw.optional.arm.FEAT_FHM");
+    cpuFeatures->i8mm = vs_sysctl_flag("hw.optional.arm.FEAT_I8MM");
+    // Apple Silicon has no non-streaming SVE; SVE instructions exist only inside
+    // SME streaming mode. Leave sve/sve2 unset so no non-streaming kernel is picked.
+    cpuFeatures->sme = vs_sysctl_flag("hw.optional.arm.FEAT_SME");
+    cpuFeatures->sme2 = vs_sysctl_flag("hw.optional.arm.FEAT_SME2");
+    cpuFeatures->sme_i16i64 = vs_sysctl_flag("hw.optional.arm.FEAT_SME_I16I64");
+    cpuFeatures->sme_f64f64 = vs_sysctl_flag("hw.optional.arm.FEAT_SME_F64F64");
+}
+
+#elif defined(__linux__)
+#include <sys/auxv.h>
+
+/* Bits from linux arch/arm64/include/uapi/asm/hwcap.h; defined here so old
+   toolchain headers don't limit runtime detection. */
+#ifndef HWCAP_FPHP
+#define HWCAP_FPHP (1UL << 9)
+#endif
+#ifndef HWCAP_ASIMDHP
+#define HWCAP_ASIMDHP (1UL << 10)
+#endif
+#ifndef HWCAP_ASIMDDP
+#define HWCAP_ASIMDDP (1UL << 20)
+#endif
+#ifndef HWCAP_ASIMDFHM
+#define HWCAP_ASIMDFHM (1UL << 23)
+#endif
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1UL << 22)
+#endif
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1UL << 1)
+#endif
+#ifndef HWCAP2_I8MM
+#define HWCAP2_I8MM (1UL << 13)
+#endif
+#ifndef HWCAP2_SME
+#define HWCAP2_SME (1UL << 23)
+#endif
+#ifndef HWCAP2_SME_I16I64
+#define HWCAP2_SME_I16I64 (1UL << 24)
+#endif
+#ifndef HWCAP2_SME_F64F64
+#define HWCAP2_SME_F64F64 (1UL << 25)
+#endif
+#ifndef HWCAP2_SME2
+#define HWCAP2_SME2 (1UL << 37)
+#endif
+
+static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
+    *cpuFeatures = {};
+    cpuFeatures->can_run_vs = 1;
+    unsigned long hwcap = getauxval(AT_HWCAP);
+    unsigned long hwcap2 = getauxval(AT_HWCAP2);
+    cpuFeatures->dotprod = !!(hwcap & HWCAP_ASIMDDP);
+    cpuFeatures->fp16 = !!(hwcap & HWCAP_FPHP) && !!(hwcap & HWCAP_ASIMDHP);
+    cpuFeatures->fhm = !!(hwcap & HWCAP_ASIMDFHM);
+    cpuFeatures->i8mm = !!(hwcap2 & HWCAP2_I8MM);
+    cpuFeatures->sve = !!(hwcap & HWCAP_SVE);
+    cpuFeatures->sve2 = !!(hwcap2 & HWCAP2_SVE2);
+    cpuFeatures->sme = !!(hwcap2 & HWCAP2_SME);
+    cpuFeatures->sme2 = !!(hwcap2 & HWCAP2_SME2);
+    cpuFeatures->sme_i16i64 = !!(hwcap2 & HWCAP2_SME_I16I64);
+    cpuFeatures->sme_f64f64 = !!(hwcap2 & HWCAP2_SME_F64F64);
+}
+
+#else
+static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
+    *cpuFeatures = {};
+    cpuFeatures->can_run_vs = 1;
+}
+#endif
+
 #elif defined(VS_TARGET_CPU_RISCV)
 static void doGetCPUFeatures(CPUFeatures *cpuFeatures) {
     *cpuFeatures = {};

--- a/src/core/cpufeatures.h
+++ b/src/core/cpufeatures.h
@@ -62,6 +62,18 @@ typedef struct CPUFeatures {
     char vaes;
     char rdseed;
     char avx512;
+#elif defined(VS_TARGET_CPU_ARM64)
+    // On AArch64, NEON (ASIMD) is part of the baseline and always present.
+    char dotprod;     /* FEAT_DotProd: sdot/udot */
+    char fp16;        /* FEAT_FP16: fullfp16 arithmetic */
+    char fhm;         /* FEAT_FHM: fmlal/fmlal2 widening f16 MAC */
+    char i8mm;        /* FEAT_I8MM: usdot/ummla */
+    char sve;         /* FEAT_SVE, non-streaming (not set on Apple Silicon) */
+    char sve2;        /* FEAT_SVE2 */
+    char sme;         /* FEAT_SME */
+    char sme2;        /* FEAT_SME2 */
+    char sme_i16i64;  /* FEAT_SME_I16I64: 16-bit int outer products into ZA64 */
+    char sme_f64f64;  /* FEAT_SME_F64F64 */
 #endif
 } CPUFeatures;
 

--- a/src/core/genericfilters.cpp
+++ b/src/core/genericfilters.cpp
@@ -151,6 +151,7 @@ struct GenericDataExtra {
     float bias;
     bool saturate;
     bool conv_int8;   // all coefficients fit int8 -> byte square conv may take the VNNI path
+    bool conv_f16;    // all coefficients survive a round trip through half -> fmlal (FHM) is lossless
 
     int cpulevel;
 
@@ -534,6 +535,152 @@ static decltype(&vs_generic_3x3_conv_byte_c) genericSelectSSE2(const VSVideoForm
 }
 #endif
 
+#ifdef VS_TARGET_CPU_ARM64
+// The byte square usdot kernels are bit-exact fast paths, valid only when every
+// coefficient fits int8 and the CPU reports i8mm (the ARM analog of convByteVNNI);
+// they are ~2-3.5x the vmlal kernels. Wide-coefficient convolutions keep the
+// plain (still correct) NEON kernels.
+#ifdef VS_TARGET_ARM_I8MM
+static bool convByteDot(const GenericData *d) {
+    return d->conv_int8 && getCPUFeatures()->i8mm;
+}
+#else
+static bool convByteDot(const GenericData *) { return false; }
+#endif
+
+// Only the convolution family has hand-written ARM kernels; every other op
+// falls through to the (auto-vectorised) C tier.
+template <GenericOperations op>
+static decltype(&vs_generic_3x3_conv_byte_c) genericSelectNEON(const VSVideoFormat *fi, GenericData *d) {
+    if (op != GenericConvolution)
+        return nullptr;
+
+    if (fi->sampleType == stInteger && fi->bytesPerSample == 1) {
+#ifdef VS_TARGET_ARM_I8MM
+        // usdot folds 4 taps per op with no byte->word widening; bit-exact with
+        // the vmlal kernels, but only valid when every coefficient fits int8.
+        if (convByteDot(d)) {
+            if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+                return vs_generic_3x3_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+                return vs_generic_5x5_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+                return vs_generic_7x7_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+                return vs_generic_9x9_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+                return vs_generic_11x11_conv_byte_neon_dot;
+            else if (d->convolution_type == ConvolutionHorizontal)
+                return vs_generic_1d_conv_h_byte_neon_dot;
+            // Separable runs its vertical half on vmlal and its horizontal half
+            // on usdot; the vertical taps run across rows, so there is no
+            // scanline window for dot to fold there.
+            else if (d->convolution_type == ConvolutionSeparable)
+                return vs_generic_2d_conv_sep_byte_neon_dot;
+        }
+#endif
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_byte_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_byte_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_byte_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_byte_neon;
+    } else if (fi->sampleType == stInteger && fi->bytesPerSample == 2) {
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_word_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_word_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_word_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_word_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_word_neon;
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 4) {
+        // 3x3 float has no NEON kernel: its C tier autovectorises to a tighter
+        // loop (fewer vector ops/px) that NEON cannot beat at a full thread pool
+        // on M4 (0.89x), and the single-thread win it did hold on Neoverse was
+        // not worth carrying a shape that loses on the primary target. It falls
+        // through to the C tier.
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_float_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_float_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_float_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_float_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_float_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_float_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_float_neon;
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 2) {
+#ifdef VS_TARGET_ARM_FHM
+        // fmlal folds the f16->f32 convert into the MAC; the baseline half
+        // kernels are conversion-bound (3x3 only TIES C). Both fmlal operands
+        // are f16, so the coefficients must narrow exactly (conv_f16). Covers
+        // every half convolution shape: squares, and the 1D
+        // horizontal/vertical/separable scanlines.
+        if (d->conv_f16 && getCPUFeatures()->fhm) {
+            if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+                return vs_generic_3x3_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+                return vs_generic_5x5_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+                return vs_generic_7x7_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+                return vs_generic_9x9_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+                return vs_generic_11x11_conv_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionHorizontal)
+                return vs_generic_1d_conv_h_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionVertical)
+                return vs_generic_1d_conv_v_half_neon_fhm;
+            else if (d->convolution_type == ConvolutionSeparable)
+                return vs_generic_2d_conv_sep_half_neon_fhm;
+        }
+#endif
+        if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 9)
+            return vs_generic_3x3_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 25)
+            return vs_generic_5x5_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 49)
+            return vs_generic_7x7_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 81)
+            return vs_generic_9x9_conv_half_neon;
+        else if (d->convolution_type == ConvolutionSquare && d->matrix_elements == 121)
+            return vs_generic_11x11_conv_half_neon;
+        else if (d->convolution_type == ConvolutionHorizontal)
+            return vs_generic_1d_conv_h_half_neon;
+        else if (d->convolution_type == ConvolutionVertical)
+            return vs_generic_1d_conv_v_half_neon;
+        else if (d->convolution_type == ConvolutionSeparable)
+            return vs_generic_2d_conv_sep_half_neon;
+    }
+    return nullptr;
+}
+
+
+#endif // VS_TARGET_CPU_ARM64
+
 template <GenericOperations op>
 static decltype(&vs_generic_3x3_conv_byte_c) genericSelectC(const VSVideoFormat *fi, GenericData *d) {
     if (fi->sampleType == stInteger && fi->bytesPerSample == 1) {
@@ -828,6 +975,7 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
             float matrix_sumf = 0;
             const double *matrix = vsapi->mapGetFloatArray(in, "matrix", nullptr);
             d->conv_int8 = true;
+            d->conv_f16 = true;
             for (int i = 0; i < d->matrix_elements; i++) {
                 double c = matrix[i];
                 if (!std::isfinite(c))
@@ -844,6 +992,13 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
                 } else {
                     d->matrixf[i] = static_cast<float>(c);
                 }
+
+                // Kernels that must take their coefficients in a narrower type may
+                // only do so when the value survives the trip exactly -- same rule
+                // conv_int8 applies to the VNNI path. Rounding a coefficient to buy
+                // speed is not on the table.
+                if (halfToFloat(floatToHalf(d->matrixf[i])) != d->matrixf[i])
+                    d->conv_f16 = false;
 
                 matrix_sumf += d->matrixf[i];
             }
@@ -879,6 +1034,9 @@ static void VS_CC genericCreate(const VSMap *in, VSMap *out, void *userData, VSC
             d->func = genericSelectAVX2<op>(fi, d.get());
         if (!d->func && d->cpulevel >= VS_CPU_LEVEL_SSE2)
             d->func = genericSelectSSE2<op>(fi, d.get());
+#elif defined(VS_TARGET_CPU_ARM64)
+        if (!d->func && d->cpulevel >= VS_CPU_LEVEL_NEON)
+            d->func = genericSelectNEON<op>(fi, d.get());
 #endif
         if (!d->func)
             d->func = genericSelectC<op>(fi, d.get());

--- a/src/core/kernel/arm/conv_scalar.h
+++ b/src/core/kernel/arm/conv_scalar.h
@@ -1,0 +1,105 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* Scalar helpers shared by the AArch64 kernel TUs. No SIMD includes here.
+* These replicate kernel/generic.cpp expressions exactly, so the SIMD
+* kernels' scalar edge columns match the C tier.
+*/
+
+#ifndef ARM_CONV_SCALAR_H
+#define ARM_CONV_SCALAR_H
+
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <type_traits>
+
+namespace {
+
+inline unsigned nc_mirror(int pos, int len)
+{
+    if (pos < 0) pos = -pos - 1;
+    else if (pos >= len) pos = 2 * len - 1 - pos;
+    if (pos < 0) pos = 0;
+    else if (pos >= len) pos = len - 1;
+    return static_cast<unsigned>(pos);
+}
+
+inline float nc_half_to_float(uint16_t bits)
+{
+    __fp16 h;
+    __builtin_memcpy(&h, &bits, sizeof(h));
+    return static_cast<float>(h);
+}
+
+inline uint16_t nc_float_to_half(float x)
+{
+    __fp16 h = static_cast<__fp16>(x);
+    uint16_t bits;
+    __builtin_memcpy(&bits, &h, sizeof(bits));
+    return bits;
+}
+
+// Scalar reference for a single pixel of square NxN convolution; bit-exact
+// with kernel/generic.cpp conv_plane_square (same (tap-column outer, row
+// inner) order, same mirror, same rounding/clamp). Used for edge columns.
+template <class T, class Acc, class Weight, unsigned N>
+inline T nc_sq_scalar_px(const T *const *rows, unsigned j, unsigned S, unsigned W,
+                         const Weight *coeffs, float div, float bias, bool saturate, uint16_t maxval)
+{
+    Acc accum = 0;
+    for (unsigned k = 0; k < N; ++k) {
+        unsigned col = nc_mirror(static_cast<int>(j) + static_cast<int>(k) - static_cast<int>(S), static_cast<int>(W));
+        for (unsigned r = 0; r < N; ++r)
+            accum += coeffs[r * N + k] * static_cast<Acc>(rows[r][col]);
+    }
+    float tmp = static_cast<float>(accum) * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    if constexpr (std::is_integral<T>::value) {
+        float c = std::min(std::max(tmp, 0.0f), static_cast<float>(sizeof(T) == 1 ? 255 : 65535));
+        long v = std::lrint(c);
+        return static_cast<T>(std::min<long>(v, maxval));
+    } else {
+        return static_cast<T>(tmp);
+    }
+}
+
+// Scalar edge reference for half (binary16) planes: samples widen to float32
+// for the arithmetic and the result narrows back to half, mirroring the C
+// fallback's HalfOp/conv paths.
+template <unsigned N>
+inline uint16_t nc_sq_scalar_px_half(const uint16_t *const *rows, unsigned j, unsigned S, unsigned W,
+                                     const float *coeffs, float div, float bias, bool saturate)
+{
+    float accum = 0.0f;
+    for (unsigned k = 0; k < N; ++k) {
+        unsigned col = nc_mirror(static_cast<int>(j) + static_cast<int>(k) - static_cast<int>(S), static_cast<int>(W));
+        for (unsigned r = 0; r < N; ++r)
+            accum += coeffs[r * N + k] * nc_half_to_float(rows[r][col]);
+    }
+    float tmp = accum * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    return nc_float_to_half(tmp);
+}
+
+} // namespace
+
+#endif // ARM_CONV_SCALAR_H

--- a/src/core/kernel/arm/convolution_fhm_neon.cpp
+++ b/src/core/kernel/arm/convolution_fhm_neon.cpp
@@ -1,0 +1,514 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* FEAT_FHM half (binary16) convolution: 3x3, NxN squares, and the 1D
+* horizontal/vertical/separable shapes -- fmlal/fmlal2 do the f16->f32
+* widening MAC in one instruction, replacing the fcvtl+fmla pairs of the
+* baseline half path (half_tap16: 2 loads + 4 converts + 4 FMAs per 16 px per
+* tap becomes 2 loads + 4 fmlal). The baseline 3x3 half kernel only ties the
+* autovectorised C tier (1.02-1.07x), and it is conversion-bound, which is
+* exactly what fmlal removes.
+*
+* fmlal takes BOTH operands in f16, so the coefficient must survive f32->f16
+* narrowing exactly (the dispatcher's conv_f16 gate).
+* Under that gate results are identical to the baseline half kernel: the f16
+* product is exact in f32 (11x11-bit significands), and fmlal accumulates it
+* into f32 with a single rounding, the same as vfmaq_f32 on the converted
+* values.
+*
+* Compiled in its own TU with -march=...+fp16+fp16fml (see meson.build); the
+* NEON baseline sources must not be built with +fp16fml.
+*/
+
+#include <cstdint>
+#include <cstring>
+#include "VSHelper4.h"
+#include "../generic.h"
+#include "conv_scalar.h"
+#include "neon_common.h"
+
+namespace {
+
+// Scalar replicate-edge pixel; mirrors conv_plane_3x3_neon's scalar_px for
+// half exactly (same accumulation order, same store expression).
+inline uint16_t h3x3_scalar_px(const uint16_t *const rows[3], const float *coeffs,
+                               unsigned a, unsigned b, unsigned c,
+                               float div, float bias, bool saturate)
+{
+    float accum = 0.0f;
+    for (unsigned r = 0; r < 3; ++r) {
+        accum += coeffs[r * 3 + 0] * nc_half_to_float(rows[r][a]);
+        accum += coeffs[r * 3 + 1] * nc_half_to_float(rows[r][b]);
+        accum += coeffs[r * 3 + 2] * nc_half_to_float(rows[r][c]);
+    }
+    float tmp = accum * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    return nc_float_to_half(tmp);
+}
+
+void conv_plane_3x3_half_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                             const vs_generic_params &p, unsigned width, unsigned height)
+{
+    const float *coeffs = p.matrixf;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    // Both fmlal operands are f16; the dispatch gate (conv_f16) guarantees the
+    // narrowing is exact. Broadcast once per plane, as the float 3x3 does.
+    float16x8_t cf[9];
+    for (unsigned i = 0; i < 9; ++i)
+        cf[i] = vdupq_n_f16(static_cast<float16_t>(coeffs[i]));
+
+    for (unsigned i = 0; i < height; ++i) {
+        unsigned above_idx = i == 0 ? 0 : i - 1;
+        unsigned below_idx = i == height - 1 ? height - 1 : i + 1;
+        const uint16_t *rows[3] = {
+            reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(above_idx) * src_stride),
+            reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(i) * src_stride),
+            reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(below_idx) * src_stride),
+        };
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+
+        dstp[0] = h3x3_scalar_px(rows, coeffs, 0, 0, width > 1 ? 1 : 0, p.div, p.bias, p.saturate);
+
+        unsigned end = width > 1 ? width - 1 : 0;
+        unsigned j = 1;
+        auto block = [&](unsigned jj) {
+            float32x4_t a0 = vdupq_n_f32(0), a1 = vdupq_n_f32(0), a2 = vdupq_n_f32(0), a3 = vdupq_n_f32(0);
+            for (unsigned r = 0; r < 3; ++r) {
+                for (unsigned k = 0; k < 3; ++k) {
+                    const uint16_t *q = rows[r] + jj - 1 + k;
+                    float16x8_t w = cf[r * 3 + k];
+                    float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(q));
+                    float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(q + 8));
+                    a0 = vfmlalq_low_f16(a0, x0, w);
+                    a1 = vfmlalq_high_f16(a1, x0, w);
+                    a2 = vfmlalq_low_f16(a2, x1, w);
+                    a3 = vfmlalq_high_f16(a3, x1, w);
+                }
+            }
+            nc_store_h16x8(dstp + jj, a0, a1, sc, bi, sm);
+            nc_store_h16x8(dstp + jj + 8, a2, a3, sc, bi, sm);
+        };
+        if (end > 1) {
+            for (; j + 16 <= end; j += 16) block(j);
+            if (j < end && end >= 1 + 16) { block(end - 16); j = end; }
+            for (; j < end; ++j)
+                dstp[j] = h3x3_scalar_px(rows, coeffs, j - 1, j, j + 1, p.div, p.bias, p.saturate);
+        }
+
+        if (width > 1)
+            dstp[width - 1] = h3x3_scalar_px(rows, coeffs, width - 2, width - 1, width - 1, p.div, p.bias, p.saturate);
+    }
+}
+
+// ---- half NxN squares (mirror edges, sq_plane semantics), N in {5,7,9,11} ----
+// Same interior as sq_interior_half with the fcvtl+fmla pairs replaced by
+// fmlal; the per-tap coefficient stays a per-tap ld1r dup (hoisting 25+
+// broadcasts is the exact gcc 13.3 spill trap square_neon.cpp documents).
+
+template <unsigned N>
+unsigned sq_interior_half_fhm(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                              const float *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    auto block = [&](unsigned jj) {
+        float32x4_t a0 = vdupq_n_f32(0), a1 = vdupq_n_f32(0), a2 = vdupq_n_f32(0), a3 = vdupq_n_f32(0);
+        for (unsigned r = 0; r < N; ++r) {
+            const uint16_t *row = rows[r] + (jj - S);
+            for (unsigned k = 0; k < N; ++k) {
+                float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(row + k));
+                float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(row + k + 8));
+                float16x8_t w = vdupq_n_f16(static_cast<float16_t>(m[r * N + k]));
+                a0 = vfmlalq_low_f16(a0, x0, w);
+                a1 = vfmlalq_high_f16(a1, x0, w);
+                a2 = vfmlalq_low_f16(a2, x1, w);
+                a3 = vfmlalq_high_f16(a3, x1, w);
+            }
+        }
+        nc_store_h16x8(dst + jj, a0, a1, sc, bi, sm);
+        nc_store_h16x8(dst + jj + 8, a2, a3, sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+template <unsigned N>
+void sq_plane_half_fhm(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                       const vs_generic_params &p, unsigned W, unsigned H)
+{
+    constexpr unsigned S = N / 2;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint16_t *rows[N];
+        for (unsigned r = 0; r < N; ++r)
+            rows[r] = reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) +
+                static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(i) + static_cast<int>(r) - static_cast<int>(S), static_cast<int>(H))) * ss);
+        uint16_t *d = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * ds);
+
+        unsigned aend = sq_interior_half_fhm<N>(rows, d, S, W, p.matrixf, sc, bi, sm);
+
+        for (unsigned j = 0; j < S && j < W; ++j)
+            d[j] = nc_sq_scalar_px_half<N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate);
+        for (unsigned j = (aend > S ? aend : S); j < W; ++j)
+            d[j] = nc_sq_scalar_px_half<N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate);
+    }
+}
+
+// ---- half 1D horizontal / vertical / separable on fmlal ---------------------
+//
+// The fmlal counterpart of convolution_neon.cpp's half h/v/x scanlines, and it
+// mirrors their structure exactly: templated on a compile-time tap count FW
+// (odd 3..25, FW == 0 the runtime fallback), coefficients staged once per
+// scanline in lane form, and taps emitted in GROUPS OF 4 with the group loop
+// left ROLLED. The group size is the load-bearing part -- widening the group
+// past one coefficient vector is what cost the baseline scanlines -10..-20%
+// under gcc 13.3 (see convolution_neon.cpp's cv_lanes comment); fmlal changes
+// the MAC, not the scheduling budget it has to fit in.
+//
+// Edge columns/rows go through the same scalar float code as the baseline, so
+// only the interior changes -- and there the values are identical too, since
+// the conv_f16 gate makes the f16 coefficient equal to the f32 one.
+
+struct fhm_acc16 {
+    float32x4_t a0, a1, a2, a3;
+    void clear() { a0 = a1 = a2 = a3 = vdupq_n_f32(0); }
+};
+
+// fmlal has no widening-multiply form, so unlike the other formats' scanlines
+// there is no first-tap vmul init to skip the zero fill with.
+inline void fhm_tap16(fhm_acc16 &a, const uint16_t *p, float16x8_t w)
+{
+    float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(p));
+    float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(p + 8));
+    a.a0 = vfmlalq_low_f16(a.a0, x0, w);
+    a.a1 = vfmlalq_high_f16(a.a1, x0, w);
+    a.a2 = vfmlalq_low_f16(a.a2, x1, w);
+    a.a3 = vfmlalq_high_f16(a.a3, x1, w);
+}
+
+template <unsigned L>
+inline void fhm_tap16_lane(fhm_acc16 &a, const uint16_t *p, float16x4_t c)
+{
+    float16x8_t x0 = vreinterpretq_f16_u16(vld1q_u16(p));
+    float16x8_t x1 = vreinterpretq_f16_u16(vld1q_u16(p + 8));
+    a.a0 = vfmlalq_lane_low_f16(a.a0, x0, c, L);
+    a.a1 = vfmlalq_lane_high_f16(a.a1, x0, c, L);
+    a.a2 = vfmlalq_lane_low_f16(a.a2, x1, c, L);
+    a.a3 = vfmlalq_lane_high_f16(a.a3, x1, c, L);
+}
+
+// 4 f16 coefficients per lane vector; >= 1 vector so the FW == 0 path can still
+// declare the array.
+template <unsigned FW>
+constexpr unsigned fhm_nq() { return FW ? (FW + 3) / 4 : 1; }
+
+template <unsigned FW>
+inline void fhm_stage_coeffs(float16x4_t *cq, const float *m)
+{
+    constexpr unsigned NQ = fhm_nq<FW>();
+    float16_t pad[NQ * 4] = {};
+    for (unsigned i = 0; i < FW; ++i)
+        pad[i] = static_cast<float16_t>(m[i]);
+    for (unsigned i = 0; i < NQ; ++i)
+        cq[i] = vld1_f16(pad + 4 * i);
+}
+
+// CNT taps from one coefficient vector starting at lane L; tap i reads p + i.
+template <unsigned CNT, unsigned L>
+inline void fhm_tap_group_h(fhm_acc16 &a, const uint16_t *p, float16x4_t c)
+{
+    fhm_tap16_lane<L>(a, p + L, c);
+    if constexpr (L + 1 < CNT)
+        fhm_tap_group_h<CNT, L + 1>(a, p, c);
+}
+
+// Same, but tap i reads row pointer srcs[i].
+template <unsigned CNT, unsigned L>
+inline void fhm_tap_group_v(fhm_acc16 &a, const void *const *srcs, unsigned jj, float16x4_t c)
+{
+    fhm_tap16_lane<L>(a, static_cast<const uint16_t *>(srcs[L]) + jj, c);
+    if constexpr (L + 1 < CNT)
+        fhm_tap_group_v<CNT, L + 1>(a, srcs, jj, c);
+}
+
+template <unsigned FW>
+inline void fhm_taps_h(fhm_acc16 &a, const uint16_t *base, const float16x4_t *cq)
+{
+    constexpr unsigned NG = FW / 4;
+    constexpr unsigned TAIL = FW - NG * 4;
+    constexpr unsigned FIRST = FW < 4 ? FW : 4;
+
+    a.clear();
+    fhm_tap_group_h<FIRST, 0>(a, base, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        fhm_tap_group_h<4, 0>(a, base + g * 4, cq[g]);
+    if constexpr (TAIL > 0 && FW > 4)
+        fhm_tap_group_h<TAIL, 0>(a, base + NG * 4, cq[NG]);
+}
+
+template <unsigned FW>
+inline void fhm_taps_v(fhm_acc16 &a, const void *const *srcs, unsigned jj, const float16x4_t *cq)
+{
+    constexpr unsigned NG = FW / 4;
+    constexpr unsigned TAIL = FW - NG * 4;
+    constexpr unsigned FIRST = FW < 4 ? FW : 4;
+
+    a.clear();
+    fhm_tap_group_v<FIRST, 0>(a, srcs, jj, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        fhm_tap_group_v<4, 0>(a, srcs + g * 4, jj, cq[g]);
+    if constexpr (TAIL > 0 && FW > 4)
+        fhm_tap_group_v<TAIL, 0>(a, srcs + NG * 4, jj, cq[NG]);
+}
+
+// Scalar mirror-edge pixel; replicates conv_scanline_h's formulas verbatim, in
+// float with the float coefficients, exactly as the baseline half scanline's
+// conv_h_edge_px<Half> does.
+inline uint16_t fhm_h_edge_px(const uint16_t *srcp, unsigned j, unsigned width, const vs_generic_params &p)
+{
+    const float *coeffs = p.matrixf;
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    unsigned dist_from_right = width - 1 - j;
+
+    float accum = 0.0f;
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned idx = j < support - k ? std::min(support - k - j - 1, width - 1) : j - support + k;
+        accum += coeffs[k] * nc_half_to_float(srcp[idx]);
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned idx = dist_from_right < k - support ? width - std::min(k - support - dist_from_right, width) : j - support + k;
+        accum += coeffs[k] * nc_half_to_float(srcp[idx]);
+    }
+    float tmp = accum * p.div + p.bias;
+    tmp = p.saturate ? tmp : std::fabs(tmp);
+    return nc_float_to_half(tmp);
+}
+
+template <unsigned FW>
+void fhm_h_scanline(const uint16_t *srcp, uint16_t *dstp, unsigned width,
+                    const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    const float *coeffs = p.matrixf;
+    unsigned fwidth = FW ? FW : p.matrixsize;
+    unsigned support = fwidth / 2;
+
+    [[maybe_unused]] float16x4_t cq[fhm_nq<FW>()];
+    if constexpr (FW)
+        fhm_stage_coeffs<FW>(cq, coeffs);
+
+    for (unsigned j = 0; j < std::min(width, support); ++j)
+        dstp[j] = fhm_h_edge_px(srcp, j, width, p);
+
+    unsigned end = width - std::min(width, support);
+    unsigned j = support;
+    auto block = [&](unsigned jj) {
+        fhm_acc16 a;
+        if constexpr (FW) {
+            fhm_taps_h<FW>(a, srcp + jj - support, cq);
+        } else {
+            a.clear();
+            for (unsigned k = 0; k < fwidth; ++k)
+                fhm_tap16(a, srcp + jj - support + k, vdupq_n_f16(static_cast<float16_t>(coeffs[k])));
+        }
+        nc_store_h16x8(dstp + jj, a.a0, a.a1, sc, bi, sm);
+        nc_store_h16x8(dstp + jj + 8, a.a2, a.a3, sc, bi, sm);
+    };
+    if (end > support) {
+        for (; j + 16 <= end; j += 16) block(j);
+        if (j < end && end >= support + 16) { block(end - 16); j = end; }
+        for (; j < end; ++j)
+            dstp[j] = fhm_h_edge_px(srcp, j, width, p);
+    }
+
+    for (unsigned jj = std::max(support, end); jj < width; ++jj)
+        dstp[jj] = fhm_h_edge_px(srcp, jj, width, p);
+}
+
+template <unsigned FW>
+void fhm_v_scanline(const void *const *srcs, uint16_t *dstp, unsigned width,
+                    const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    const float *coeffs = p.matrixf;
+    unsigned fwidth = FW ? FW : p.matrixsize;
+
+    [[maybe_unused]] float16x4_t cq[fhm_nq<FW>()];
+    if constexpr (FW)
+        fhm_stage_coeffs<FW>(cq, coeffs);
+
+    unsigned j = 0;
+    auto block = [&](unsigned jj) {
+        fhm_acc16 a;
+        if constexpr (FW) {
+            fhm_taps_v<FW>(a, srcs, jj, cq);
+        } else {
+            a.clear();
+            for (unsigned k = 0; k < fwidth; ++k)
+                fhm_tap16(a, static_cast<const uint16_t *>(srcs[k]) + jj, vdupq_n_f16(static_cast<float16_t>(coeffs[k])));
+        }
+        nc_store_h16x8(dstp + jj, a.a0, a.a1, sc, bi, sm);
+        nc_store_h16x8(dstp + jj + 8, a.a2, a.a3, sc, bi, sm);
+    };
+    for (; j + 16 <= width; j += 16) block(j);
+    if (j < width && width >= 16) { block(width - 16); j = width; }
+    for (; j < width; ++j) {
+        float accum = 0.0f;
+        for (unsigned k = 0; k < fwidth; ++k)
+            accum += coeffs[k] * nc_half_to_float(static_cast<const uint16_t *>(srcs[k])[j]);
+        float tmp = accum * p.div + p.bias;
+        tmp = p.saturate ? tmp : std::fabs(tmp);
+        dstp[j] = nc_float_to_half(tmp);
+    }
+}
+
+// Mirror row-pointer selection of conv_plane_v / conv_plane_x, verbatim.
+inline void fhm_v_select_rows(const void *src, ptrdiff_t src_stride, const void *srcp[25],
+                              unsigned i, unsigned height, unsigned fwidth)
+{
+    unsigned support = fwidth / 2;
+    unsigned dist_from_bottom = height - 1 - i;
+
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned row = i < support - k ? std::min(support - k - i - 1, height - 1) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned row = dist_from_bottom < k - support ? height - std::min(k - support - dist_from_bottom, i) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+}
+
+template <unsigned FW>
+void fhm_plane_h_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                      const vs_generic_params &p, unsigned width, unsigned height)
+{
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const uint16_t *srcp = reinterpret_cast<const uint16_t *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(i) * src_stride);
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        fhm_h_scanline<FW>(srcp, dstp, width, p, sc, bi, sm);
+    }
+}
+
+template <unsigned FW>
+void fhm_plane_v_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                      const vs_generic_params &p, unsigned width, unsigned height)
+{
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        fhm_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        fhm_v_scanline<FW>(srcp, dstp, width, p, sc, bi, sm);
+    }
+}
+
+// Separable: both halves are half-format, so unlike the byte separable (whose
+// vertical half stays on vmlal and calls an exported usdot scanline for the
+// horizontal half) the whole driver lives here and inlines both fmlal
+// scanlines. Quantises through a plane-typed tmp scanline, like conv_plane_x.
+template <unsigned FW>
+void fhm_plane_x_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                      const vs_generic_params &p, unsigned width, unsigned height)
+{
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+
+    uint16_t *tmp = static_cast<uint16_t *>(vsh::vsh_aligned_malloc(width * sizeof(uint16_t), 64));
+    if (!tmp) {
+        // Deterministic zeros rather than whatever the frame allocator handed
+        // out; see conv_plane_x_impl.
+        for (unsigned i = 0; i < height; ++i)
+            std::memset(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride, 0, width * sizeof(uint16_t));
+        return;
+    }
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        fhm_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        uint16_t *dstp = reinterpret_cast<uint16_t *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        fhm_v_scanline<FW>(srcp, tmp, width, p, sc, bi, sm);
+        fhm_h_scanline<FW>(tmp, dstp, width, p, sc, bi, sm);
+    }
+
+    vsh::vsh_aligned_free(tmp);
+}
+
+// Same tap-count switch as convolution_neon.cpp's VS_CONV_PLANE_SELECT: runs
+// once per plane, FW = 0 kept reachable as the correctness fallback for any
+// shape not enumerated here.
+#define VS_FHM_PLANE_SELECT(dir)                                                                    \
+void fhm_plane_##dir(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,        \
+                     const vs_generic_params &p, unsigned width, unsigned height)                   \
+{                                                                                                   \
+    switch (p.matrixsize) {                                                                         \
+    case 3:  return fhm_plane_##dir##_impl<3>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 5:  return fhm_plane_##dir##_impl<5>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 7:  return fhm_plane_##dir##_impl<7>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 9:  return fhm_plane_##dir##_impl<9>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 11: return fhm_plane_##dir##_impl<11>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 13: return fhm_plane_##dir##_impl<13>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 15: return fhm_plane_##dir##_impl<15>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 17: return fhm_plane_##dir##_impl<17>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 19: return fhm_plane_##dir##_impl<19>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 21: return fhm_plane_##dir##_impl<21>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 23: return fhm_plane_##dir##_impl<23>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 25: return fhm_plane_##dir##_impl<25>(src, src_stride, dst, dst_stride, p, width, height); \
+    default: return fhm_plane_##dir##_impl<0>(src, src_stride, dst, dst_stride, p, width, height);  \
+    }                                                                                               \
+}
+
+VS_FHM_PLANE_SELECT(h)
+VS_FHM_PLANE_SELECT(v)
+VS_FHM_PLANE_SELECT(x)
+
+} // namespace
+
+void vs_generic_1d_conv_h_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ fhm_plane_h(src, src_stride, dst, dst_stride, *params, width, height); }
+
+void vs_generic_1d_conv_v_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ fhm_plane_v(src, src_stride, dst, dst_stride, *params, width, height); }
+
+void vs_generic_2d_conv_sep_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ fhm_plane_x(src, src_stride, dst, dst_stride, *params, width, height); }
+
+void vs_generic_3x3_conv_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{
+    conv_plane_3x3_half_fhm(src, src_stride, dst, dst_stride, *params, width, height);
+}
+
+#define VS_SQUARE_FHM_ENTRY(SZ, N) \
+    void vs_generic_##SZ##_conv_half_neon_fhm(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sq_plane_half_fhm<N>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SQUARE_FHM_ENTRY(5x5, 5)
+VS_SQUARE_FHM_ENTRY(7x7, 7)
+VS_SQUARE_FHM_ENTRY(9x9, 9)
+VS_SQUARE_FHM_ENTRY(11x11, 11)

--- a/src/core/kernel/arm/convolution_neon.cpp
+++ b/src/core/kernel/arm/convolution_neon.cpp
@@ -1,0 +1,901 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* NEON 1D (horizontal/vertical/separable) and 3x3 square convolution.
+*
+* Semantics track kernel/generic.cpp exactly:
+*  - 1D edges use the half-sample mirror formulas of conv_scanline_h /
+*    conv_plane_v (replicated verbatim in the scalar edge paths).
+*  - 3x3 uses replicate edges (filter_plane_3x3 row/column selection).
+*  - The separable path quantises the vertical pass into a plane-typed tmp
+*    scanline before the horizontal pass, like conv_plane_x.
+*
+* Integer accumulation:
+*  - byte: u8 widens to s16, per-tap vmlal_s16 into int32. 25 * 1023 * 255
+*    never overflows. Bit-exact with the int32 C reference.
+*  - word: u16 biased by INT16_MIN into s16; biased worst case
+*    25 * 1023 * 32768 fits int32, and the coefficient*bias sum is subtracted
+*    afterwards. int32 wraparound arithmetic makes this exact, so results are
+*    bit-exact with the (unbiased) int32 C reference.
+*  - float/half: FMA, not bit-exact with C (allowed for float formats).
+*/
+
+#include <cstdint>
+#include <cstring>
+#include "VSHelper4.h"
+#include "../generic.h"
+#include "neon_common.h"
+
+namespace {
+
+enum class CvType { Byte, Word, Float, Half };
+
+template <CvType TY>
+struct cv_traits;
+
+template <> struct cv_traits<CvType::Byte>  { typedef uint8_t T; typedef int32_t Acc; typedef int16_t Weight; };
+template <> struct cv_traits<CvType::Word>  { typedef uint16_t T; typedef int32_t Acc; typedef int16_t Weight; };
+template <> struct cv_traits<CvType::Float> { typedef float T; typedef float Acc; typedef float Weight; };
+template <> struct cv_traits<CvType::Half>  { typedef uint16_t T; typedef float Acc; typedef float Weight; };
+
+template <CvType TY>
+inline const typename cv_traits<TY>::Weight *cv_coeffs(const vs_generic_params &p)
+{
+    if constexpr (TY == CvType::Byte || TY == CvType::Word)
+        return p.matrix;
+    else
+        return p.matrixf;
+}
+
+template <CvType TY>
+inline typename cv_traits<TY>::Acc cv_sample(typename cv_traits<TY>::T x)
+{
+    if constexpr (TY == CvType::Half)
+        return nc_half_to_float(x);
+    else
+        return static_cast<typename cv_traits<TY>::Acc>(x);
+}
+
+// Final scalar store; matches limit(xrint<T>(tmp), maxval) in the C reference.
+template <CvType TY>
+inline typename cv_traits<TY>::T cv_scalar_store(float accum, float div, float bias, bool saturate, uint16_t maxval)
+{
+    float tmp = accum * div + bias;
+    tmp = saturate ? tmp : std::fabs(tmp);
+    if constexpr (TY == CvType::Byte) {
+        float c = std::min(std::max(tmp, 0.0f), 255.0f);
+        long v = std::lrint(c);
+        return static_cast<uint8_t>(std::min<long>(v, maxval));
+    } else if constexpr (TY == CvType::Word) {
+        float c = std::min(std::max(tmp, 0.0f), 65535.0f);
+        long v = std::lrint(c);
+        return static_cast<uint16_t>(std::min<long>(v, maxval));
+    } else if constexpr (TY == CvType::Float) {
+        return tmp;
+    } else {
+        return nc_float_to_half(tmp);
+    }
+}
+
+// ---- vectorised tap accumulation over one 16-pixel block --------------------
+// Each *_tap16 accumulates coefficient k of a row pointer into 4 chains.
+
+struct acc16_i32 {
+    int32x4_t a0, a1, a2, a3;
+    void clear() { a0 = a1 = a2 = a3 = vdupq_n_s32(0); }
+};
+
+struct acc16_f32 {
+    float32x4_t a0, a1, a2, a3;
+    void clear() { a0 = a1 = a2 = a3 = vdupq_n_f32(0); }
+};
+
+inline void byte_tap16(acc16_i32 &a, const uint8_t *p, int16_t w)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmlal_s16(a.a0, vget_low_s16(x.lo), wv);
+    a.a1 = vmlal_s16(a.a1, vget_high_s16(x.lo), wv);
+    a.a2 = vmlal_s16(a.a2, vget_low_s16(x.hi), wv);
+    a.a3 = vmlal_s16(a.a3, vget_high_s16(x.hi), wv);
+}
+
+inline void word_tap16(acc16_i32 &a, const uint16_t *p, int16_t w)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmlal_s16(a.a0, vget_low_s16(x0), wv);
+    a.a1 = vmlal_s16(a.a1, vget_high_s16(x0), wv);
+    a.a2 = vmlal_s16(a.a2, vget_low_s16(x1), wv);
+    a.a3 = vmlal_s16(a.a3, vget_high_s16(x1), wv);
+}
+
+inline void float_tap16(acc16_f32 &a, const float *p, float w)
+{
+    float32x4_t wv = vdupq_n_f32(w);
+    a.a0 = vfmaq_f32(a.a0, vld1q_f32(p), wv);
+    a.a1 = vfmaq_f32(a.a1, vld1q_f32(p + 4), wv);
+    a.a2 = vfmaq_f32(a.a2, vld1q_f32(p + 8), wv);
+    a.a3 = vfmaq_f32(a.a3, vld1q_f32(p + 12), wv);
+}
+
+inline void half_tap16(acc16_f32 &a, const uint16_t *p, float w)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    float32x4_t wv = vdupq_n_f32(w);
+    a.a0 = vfmaq_f32(a.a0, x0.lo, wv);
+    a.a1 = vfmaq_f32(a.a1, x0.hi, wv);
+    a.a2 = vfmaq_f32(a.a2, x1.lo, wv);
+    a.a3 = vfmaq_f32(a.a3, x1.hi, wv);
+}
+
+// First tap of a block: plain multiply instead of clear() + accumulate. The
+// autovectorised C tier starts its chain with fmul, so a zero-init mov per
+// accumulator is density we pay and it does not. Bit-exact for the integer
+// forms (0 + x*w == x*w) and value-identical for float/half.
+
+inline void byte_tap16_init(acc16_i32 &a, const uint8_t *p, int16_t w)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmull_s16(vget_low_s16(x.lo), wv);
+    a.a1 = vmull_s16(vget_high_s16(x.lo), wv);
+    a.a2 = vmull_s16(vget_low_s16(x.hi), wv);
+    a.a3 = vmull_s16(vget_high_s16(x.hi), wv);
+}
+
+inline void word_tap16_init(acc16_i32 &a, const uint16_t *p, int16_t w)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    int16x4_t wv = vdup_n_s16(w);
+    a.a0 = vmull_s16(vget_low_s16(x0), wv);
+    a.a1 = vmull_s16(vget_high_s16(x0), wv);
+    a.a2 = vmull_s16(vget_low_s16(x1), wv);
+    a.a3 = vmull_s16(vget_high_s16(x1), wv);
+}
+
+inline void float_tap16_init(acc16_f32 &a, const float *p, float32x4_t wv)
+{
+    a.a0 = vmulq_f32(vld1q_f32(p), wv);
+    a.a1 = vmulq_f32(vld1q_f32(p + 4), wv);
+    a.a2 = vmulq_f32(vld1q_f32(p + 8), wv);
+    a.a3 = vmulq_f32(vld1q_f32(p + 12), wv);
+}
+
+inline void half_tap16_init(acc16_f32 &a, const uint16_t *p, float w)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    float32x4_t wv = vdupq_n_f32(w);
+    a.a0 = vmulq_f32(x0.lo, wv);
+    a.a1 = vmulq_f32(x0.hi, wv);
+    a.a2 = vmulq_f32(x1.lo, wv);
+    a.a3 = vmulq_f32(x1.hi, wv);
+}
+
+template <CvType TY>
+inline void store16(typename cv_traits<TY>::T *dst,
+                    typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                    int32_t wb, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    if constexpr (TY == CvType::Byte) {
+        nc_store_u8x8(dst, a.a0, a.a1, sc, bi, sm);
+        nc_store_u8x8(dst + 8, a.a2, a.a3, sc, bi, sm);
+    } else if constexpr (TY == CvType::Word) {
+        int32x4_t wbv = vdupq_n_s32(wb);
+        nc_store_u16x8(dst, vsubq_s32(a.a0, wbv), vsubq_s32(a.a1, wbv), sc, bi, sm, mv);
+        nc_store_u16x8(dst + 8, vsubq_s32(a.a2, wbv), vsubq_s32(a.a3, wbv), sc, bi, sm, mv);
+    } else if constexpr (TY == CvType::Float) {
+        nc_store_f32x4(dst, a.a0, sc, bi, sm);
+        nc_store_f32x4(dst + 4, a.a1, sc, bi, sm);
+        nc_store_f32x4(dst + 8, a.a2, sc, bi, sm);
+        nc_store_f32x4(dst + 12, a.a3, sc, bi, sm);
+    } else {
+        nc_store_h16x8(dst, a.a0, a.a1, sc, bi, sm);
+        nc_store_h16x8(dst + 8, a.a2, a.a3, sc, bi, sm);
+    }
+}
+
+template <CvType TY>
+inline void tap16(typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                  const typename cv_traits<TY>::T *p, typename cv_traits<TY>::Weight w)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16(a, p, w);
+    else if constexpr (TY == CvType::Word)
+        word_tap16(a, p, w);
+    else if constexpr (TY == CvType::Float)
+        float_tap16(a, p, w);
+    else
+        half_tap16(a, p, w);
+}
+
+template <CvType TY>
+inline void tap16_init(typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                       const typename cv_traits<TY>::T *p, typename cv_traits<TY>::Weight w)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16_init(a, p, w);
+    else if constexpr (TY == CvType::Word)
+        word_tap16_init(a, p, w);
+    else if constexpr (TY == CvType::Float)
+        float_tap16_init(a, p, vdupq_n_f32(w));
+    else
+        half_tap16_init(a, p, w);
+}
+
+// ---- compile-time tap counts + lane-form coefficients -----------------------
+//
+// With a runtime fwidth the tap loop reloads and re-broadcasts coeffs[k] every
+// tap (an `ld1r` per tap; the compiler cannot hoist it, since p.matrix is
+// caller memory the dstp stores may alias) and pays loop overhead per tap on
+// top. Templating fwidth makes the count compile-time, which both unrolls the
+// loop and lets coefficients live in register lanes instead.
+//
+// Taps are emitted in GROUPS of one coefficient vector (8 int16 lanes / 4 f32
+// lanes) with the group loop left ROLLED. That cap is deliberate: the square
+// kernels measured -35..-47% under gcc 13.3 when all N*N taps were unrolled
+// against a fully staged matrix, because the scheduler hoists every tap's
+// loads to the top of the block and spills (see square_neon.cpp). x86 caps the
+// same way, at 13 taps per pass (VS_CONV_SELECT / conv_scanline_*_pass).
+// For fwidth <= 8 (int) or <= 4 (float) there is exactly one group, so small
+// filters still unroll completely.
+//
+// Bit-exact: the lane forms compute the same MLA/FMA as a dup'd scalar, tap
+// order is unchanged, and tap 0 keeps the vmull/vmul first-tap init.
+
+// 4 taps per group for every type. Integer coefficients could hold 8 lanes in
+// an int16x8_t, but an 8-tap group measured WORSE under gcc 13.3 on exactly
+// the horizontal integer shapes (word h25 -10..-20%, separable byte/word
+// hv9 -4..-18% on V1/V2/V3) while float/half -- which only ever had 4 lanes --
+// won everywhere. Same unroll-cap lesson as the squares, one level finer.
+template <CvType TY>
+constexpr unsigned cv_lanes() { return 4; }
+
+template <CvType TY>
+using cv_cvec = typename std::conditional<TY == CvType::Byte || TY == CvType::Word, int16x4_t, float32x4_t>::type;
+
+template <CvType TY>
+using cv_acc = typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type;
+
+template <unsigned L>
+inline void byte_tap16_lane(acc16_i32 &a, const uint8_t *p, int16x4_t c)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    a.a0 = vmlal_lane_s16(a.a0, vget_low_s16(x.lo), c, L);
+    a.a1 = vmlal_lane_s16(a.a1, vget_high_s16(x.lo), c, L);
+    a.a2 = vmlal_lane_s16(a.a2, vget_low_s16(x.hi), c, L);
+    a.a3 = vmlal_lane_s16(a.a3, vget_high_s16(x.hi), c, L);
+}
+
+template <unsigned L>
+inline void word_tap16_lane(acc16_i32 &a, const uint16_t *p, int16x4_t c)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    a.a0 = vmlal_lane_s16(a.a0, vget_low_s16(x0), c, L);
+    a.a1 = vmlal_lane_s16(a.a1, vget_high_s16(x0), c, L);
+    a.a2 = vmlal_lane_s16(a.a2, vget_low_s16(x1), c, L);
+    a.a3 = vmlal_lane_s16(a.a3, vget_high_s16(x1), c, L);
+}
+
+template <unsigned L>
+inline void float_tap16_lane(acc16_f32 &a, const float *p, float32x4_t c)
+{
+    a.a0 = vfmaq_laneq_f32(a.a0, vld1q_f32(p), c, L);
+    a.a1 = vfmaq_laneq_f32(a.a1, vld1q_f32(p + 4), c, L);
+    a.a2 = vfmaq_laneq_f32(a.a2, vld1q_f32(p + 8), c, L);
+    a.a3 = vfmaq_laneq_f32(a.a3, vld1q_f32(p + 12), c, L);
+}
+
+template <unsigned L>
+inline void half_tap16_lane(acc16_f32 &a, const uint16_t *p, float32x4_t c)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    a.a0 = vfmaq_laneq_f32(a.a0, x0.lo, c, L);
+    a.a1 = vfmaq_laneq_f32(a.a1, x0.hi, c, L);
+    a.a2 = vfmaq_laneq_f32(a.a2, x1.lo, c, L);
+    a.a3 = vfmaq_laneq_f32(a.a3, x1.hi, c, L);
+}
+
+template <unsigned L>
+inline void byte_tap16_init_lane(acc16_i32 &a, const uint8_t *p, int16x4_t c)
+{
+    nc_byte16 x = nc_load_byte16(p);
+    a.a0 = vmull_lane_s16(vget_low_s16(x.lo), c, L);
+    a.a1 = vmull_lane_s16(vget_high_s16(x.lo), c, L);
+    a.a2 = vmull_lane_s16(vget_low_s16(x.hi), c, L);
+    a.a3 = vmull_lane_s16(vget_high_s16(x.hi), c, L);
+}
+
+template <unsigned L>
+inline void word_tap16_init_lane(acc16_i32 &a, const uint16_t *p, int16x4_t c)
+{
+    int16x8_t x0 = nc_load_word_biased(p);
+    int16x8_t x1 = nc_load_word_biased(p + 8);
+    a.a0 = vmull_lane_s16(vget_low_s16(x0), c, L);
+    a.a1 = vmull_lane_s16(vget_high_s16(x0), c, L);
+    a.a2 = vmull_lane_s16(vget_low_s16(x1), c, L);
+    a.a3 = vmull_lane_s16(vget_high_s16(x1), c, L);
+}
+
+template <unsigned L>
+inline void float_tap16_init_lane(acc16_f32 &a, const float *p, float32x4_t c)
+{
+    a.a0 = vmulq_laneq_f32(vld1q_f32(p), c, L);
+    a.a1 = vmulq_laneq_f32(vld1q_f32(p + 4), c, L);
+    a.a2 = vmulq_laneq_f32(vld1q_f32(p + 8), c, L);
+    a.a3 = vmulq_laneq_f32(vld1q_f32(p + 12), c, L);
+}
+
+template <unsigned L>
+inline void half_tap16_init_lane(acc16_f32 &a, const uint16_t *p, float32x4_t c)
+{
+    nc_half8 x0 = nc_load_half8(p);
+    nc_half8 x1 = nc_load_half8(p + 8);
+    a.a0 = vmulq_laneq_f32(x0.lo, c, L);
+    a.a1 = vmulq_laneq_f32(x0.hi, c, L);
+    a.a2 = vmulq_laneq_f32(x1.lo, c, L);
+    a.a3 = vmulq_laneq_f32(x1.hi, c, L);
+}
+
+template <CvType TY, unsigned L>
+inline void tap16_lane(cv_acc<TY> &a, const typename cv_traits<TY>::T *p, cv_cvec<TY> c)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Word)
+        word_tap16_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Float)
+        float_tap16_lane<L>(a, p, c);
+    else
+        half_tap16_lane<L>(a, p, c);
+}
+
+template <CvType TY, unsigned L>
+inline void tap16_init_lane(cv_acc<TY> &a, const typename cv_traits<TY>::T *p, cv_cvec<TY> c)
+{
+    if constexpr (TY == CvType::Byte)
+        byte_tap16_init_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Word)
+        word_tap16_init_lane<L>(a, p, c);
+    else if constexpr (TY == CvType::Float)
+        float_tap16_init_lane<L>(a, p, c);
+    else
+        half_tap16_init_lane<L>(a, p, c);
+}
+
+// Number of coefficient vectors for FW taps (>= 1 so the FW == 0 runtime path
+// can still declare the array).
+template <CvType TY, unsigned FW>
+constexpr unsigned cv_nq() { return FW ? (FW + cv_lanes<TY>() - 1) / cv_lanes<TY>() : 1; }
+
+template <CvType TY, unsigned FW>
+inline void stage_coeffs(cv_cvec<TY> *cq, const typename cv_traits<TY>::Weight *m)
+{
+    constexpr unsigned G = cv_lanes<TY>();
+    constexpr unsigned NQ = cv_nq<TY, FW>();
+    typename cv_traits<TY>::Weight pad[NQ * G] = {};
+    for (unsigned i = 0; i < FW; ++i)
+        pad[i] = m[i];
+    for (unsigned i = 0; i < NQ; ++i) {
+        if constexpr (TY == CvType::Byte || TY == CvType::Word)
+            cq[i] = vld1_s16(pad + 4 * i);
+        else
+            cq[i] = vld1q_f32(pad + 4 * i);
+    }
+}
+
+// CNT taps from one coefficient vector, starting at lane L. Contiguous source
+// (horizontal / separable): tap i reads p + i.
+template <CvType TY, unsigned CNT, unsigned L>
+inline void tap_group_h(cv_acc<TY> &a, const typename cv_traits<TY>::T *p, cv_cvec<TY> c)
+{
+    tap16_lane<TY, L>(a, p + L, c);
+    if constexpr (L + 1 < CNT)
+        tap_group_h<TY, CNT, L + 1>(a, p, c);
+}
+
+// Same, but tap i reads row pointer srcs[i] (vertical).
+template <CvType TY, unsigned CNT, unsigned L>
+inline void tap_group_v(cv_acc<TY> &a, const void *const *srcs, unsigned jj, cv_cvec<TY> c)
+{
+    tap16_lane<TY, L>(a, static_cast<const typename cv_traits<TY>::T *>(srcs[L]) + jj, c);
+    if constexpr (L + 1 < CNT)
+        tap_group_v<TY, CNT, L + 1>(a, srcs, jj, c);
+}
+
+// All FW taps: group 0 (init + rest), rolled middle groups, compile-time tail.
+template <CvType TY, unsigned FW>
+inline void conv_taps_h(cv_acc<TY> &a, const typename cv_traits<TY>::T *base, const cv_cvec<TY> *cq)
+{
+    constexpr unsigned G = cv_lanes<TY>();
+    constexpr unsigned NG = FW / G;
+    constexpr unsigned TAIL = FW - NG * G;
+    constexpr unsigned FIRST = FW < G ? FW : G;
+
+    tap16_init_lane<TY, 0>(a, base, cq[0]);
+    if constexpr (FIRST > 1)
+        tap_group_h<TY, FIRST, 1>(a, base, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        tap_group_h<TY, G, 0>(a, base + g * G, cq[g]);
+    if constexpr (TAIL > 0 && FW > G)
+        tap_group_h<TY, TAIL, 0>(a, base + NG * G, cq[NG]);
+}
+
+template <CvType TY, unsigned FW>
+inline void conv_taps_v(cv_acc<TY> &a, const void *const *srcs, unsigned jj, const cv_cvec<TY> *cq)
+{
+    constexpr unsigned G = cv_lanes<TY>();
+    constexpr unsigned NG = FW / G;
+    constexpr unsigned TAIL = FW - NG * G;
+    constexpr unsigned FIRST = FW < G ? FW : G;
+
+    tap16_init_lane<TY, 0>(a, static_cast<const typename cv_traits<TY>::T *>(srcs[0]) + jj, cq[0]);
+    if constexpr (FIRST > 1)
+        tap_group_v<TY, FIRST, 1>(a, srcs, jj, cq[0]);
+    for (unsigned g = 1; g < NG; ++g)
+        tap_group_v<TY, G, 0>(a, srcs + g * G, jj, cq[g]);
+    if constexpr (TAIL > 0 && FW > G)
+        tap_group_v<TY, TAIL, 0>(a, srcs + NG * G, jj, cq[NG]);
+}
+
+// store16, minus the fabs mask when it is a guaranteed no-op. The C tier
+// unswitches saturate into masked/unmasked loop copies; matching it costs one
+// predictable branch per block instead of 4 no-op ands. Float only: the mask
+// is a smaller fraction of the integer/half store pipelines.
+//
+// GATED ON !__clang__: measured +2% (3x3) / +3.5% (h25) float on
+// Neoverse-V3 gcc 13.3, but -4.5% (3x3) / -11% (5x5, since reverted) on
+// Apple M4 clang 17 -- the branch defeats clang's store scheduling, while its
+// branchless masked store was already fine. Same one-compiler story as
+// VS_SQ_FLOAT_HOIST in square_neon.cpp, opposite direction.
+template <CvType TY>
+inline void store16_sat(typename cv_traits<TY>::T *dst,
+                        typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type &a,
+                        [[maybe_unused]] bool saturate, int32_t wb, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+#if !defined(__clang__)
+    if constexpr (TY == CvType::Float) {
+        if (saturate) {
+            vst1q_f32(dst, vfmaq_f32(bi, a.a0, sc));
+            vst1q_f32(dst + 4, vfmaq_f32(bi, a.a1, sc));
+            vst1q_f32(dst + 8, vfmaq_f32(bi, a.a2, sc));
+            vst1q_f32(dst + 12, vfmaq_f32(bi, a.a3, sc));
+            return;
+        }
+    }
+#endif
+    store16<TY>(dst, a, wb, sc, bi, sm, mv);
+}
+
+// Sum of coeff * INT16_MIN over the taps in use; subtracted from biased word
+// accumulators before the store. Zero for the other formats.
+template <CvType TY>
+inline int32_t word_bias_sum(const typename cv_traits<TY>::Weight *coeffs, unsigned n)
+{
+    if constexpr (TY == CvType::Word) {
+        int32_t wb = 0;
+        for (unsigned i = 0; i < n; ++i)
+            wb += static_cast<int32_t>(INT16_MIN) * coeffs[i];
+        return wb;
+    } else {
+        (void)coeffs; (void)n;
+        return 0;
+    }
+}
+
+// ---- 1D horizontal ----------------------------------------------------------
+
+// Scalar mirror-edge pixel; replicates the conv_scanline_h formulas verbatim.
+template <CvType TY>
+inline typename cv_traits<TY>::T conv_h_edge_px(const typename cv_traits<TY>::T *srcp, unsigned j, unsigned width,
+                                                const vs_generic_params &p)
+{
+    typedef typename cv_traits<TY>::Acc Acc;
+    const auto *coeffs = cv_coeffs<TY>(p);
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    unsigned dist_from_right = width - 1 - j;
+
+    Acc accum = 0;
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned idx = j < support - k ? std::min(support - k - j - 1, width - 1) : j - support + k;
+        accum += coeffs[k] * cv_sample<TY>(srcp[idx]);
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned idx = dist_from_right < k - support ? width - std::min(k - support - dist_from_right, width) : j - support + k;
+        accum += coeffs[k] * cv_sample<TY>(srcp[idx]);
+    }
+    return cv_scalar_store<TY>(static_cast<float>(accum), p.div, p.bias, p.saturate, p.maxval);
+}
+
+// FW == 0 keeps the runtime-fwidth loop (the fallback for tap counts the
+// dispatch below does not instantiate); FW > 0 is the templated form.
+template <CvType TY, unsigned FW = 0>
+void conv_h_scanline(const typename cv_traits<TY>::T *srcp, typename cv_traits<TY>::T *dstp, unsigned width,
+                     const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv, int32_t wb)
+{
+    const auto *coeffs = cv_coeffs<TY>(p);
+    unsigned fwidth = FW ? FW : p.matrixsize;
+    unsigned support = fwidth / 2;
+    // Local copy: p is caller memory, so reading p.saturate inside the block
+    // would reload (and branch on) it every 16 pixels -- the optimizer cannot
+    // hoist it past the dstp stores it might alias.
+    const bool satur = p.saturate != 0;
+
+    // Same reason: staged once here, not re-read per tap inside the block.
+    [[maybe_unused]] cv_cvec<TY> cq[cv_nq<TY, FW>()];
+    if constexpr (FW)
+        stage_coeffs<TY, FW>(cq, coeffs);
+
+    for (unsigned j = 0; j < std::min(width, support); ++j)
+        dstp[j] = conv_h_edge_px<TY>(srcp, j, width, p);
+
+    unsigned end = width - std::min(width, support);
+    unsigned j = support;
+    auto block = [&](unsigned jj) {
+        cv_acc<TY> a;
+        if constexpr (FW) {
+            conv_taps_h<TY, FW>(a, srcp + jj - support, cq);
+        } else {
+            tap16_init<TY>(a, srcp + jj - support, coeffs[0]);
+            for (unsigned k = 1; k < fwidth; ++k)
+                tap16<TY>(a, srcp + jj - support + k, coeffs[k]);
+        }
+        store16_sat<TY>(dstp + jj, a, satur, wb, sc, bi, sm, mv);
+    };
+    if (end > support) {
+        for (; j + 16 <= end; j += 16) block(j);
+        if (j < end && end >= support + 16) { block(end - 16); j = end; }
+        for (; j < end; ++j)
+            dstp[j] = conv_h_edge_px<TY>(srcp, j, width, p);
+    }
+
+    for (unsigned jj = std::max(support, end); jj < width; ++jj)
+        dstp[jj] = conv_h_edge_px<TY>(srcp, jj, width, p);
+}
+
+// ---- 1D vertical --------------------------------------------------------------
+
+template <CvType TY, unsigned FW = 0>
+void conv_v_scanline(const void *const *srcs, typename cv_traits<TY>::T *dstp, unsigned width,
+                     const vs_generic_params &p, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv, int32_t wb)
+{
+    typedef typename cv_traits<TY>::T T;
+    typedef typename cv_traits<TY>::Acc Acc;
+    const auto *coeffs = cv_coeffs<TY>(p);
+    unsigned fwidth = FW ? FW : p.matrixsize;
+    const bool satur = p.saturate != 0;   // local copy; see conv_h_scanline
+
+    [[maybe_unused]] cv_cvec<TY> cq[cv_nq<TY, FW>()];
+    if constexpr (FW)
+        stage_coeffs<TY, FW>(cq, coeffs);
+
+    unsigned j = 0;
+    auto block = [&](unsigned jj) {
+        cv_acc<TY> a;
+        if constexpr (FW) {
+            conv_taps_v<TY, FW>(a, srcs, jj, cq);
+        } else {
+            tap16_init<TY>(a, static_cast<const T *>(srcs[0]) + jj, coeffs[0]);
+            for (unsigned k = 1; k < fwidth; ++k)
+                tap16<TY>(a, static_cast<const T *>(srcs[k]) + jj, coeffs[k]);
+        }
+        store16_sat<TY>(dstp + jj, a, satur, wb, sc, bi, sm, mv);
+    };
+    for (; j + 16 <= width; j += 16) block(j);
+    if (j < width && width >= 16) { block(width - 16); j = width; }
+    for (; j < width; ++j) {
+        Acc accum = 0;
+        for (unsigned k = 0; k < fwidth; ++k)
+            accum += coeffs[k] * cv_sample<TY>(static_cast<const T *>(srcs[k])[j]);
+        dstp[j] = cv_scalar_store<TY>(static_cast<float>(accum), p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+// Mirror row-pointer selection of conv_plane_v / conv_plane_x, verbatim.
+inline void conv_v_select_rows(const void *src, ptrdiff_t src_stride, const void *srcp[25],
+                               unsigned i, unsigned height, unsigned fwidth)
+{
+    unsigned support = fwidth / 2;
+    unsigned dist_from_bottom = height - 1 - i;
+
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned row = i < support - k ? std::min(support - k - i - 1, height - 1) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned row = dist_from_bottom < k - support ? height - std::min(k - support - dist_from_bottom, i) : i - support + k;
+        srcp[k] = static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(row) * src_stride;
+    }
+}
+
+// ---- plane drivers ------------------------------------------------------------
+
+template <CvType TY, unsigned FW>
+void conv_plane_h_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                       const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename cv_traits<TY>::T T;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(cv_coeffs<TY>(p), p.matrixsize);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const T *srcp = reinterpret_cast<const T *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(i) * src_stride);
+        T *dstp = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        conv_h_scanline<TY, FW>(srcp, dstp, width, p, sc, bi, sm, mv, wb);
+    }
+}
+
+template <CvType TY, unsigned FW>
+void conv_plane_v_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                       const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename cv_traits<TY>::T T;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(cv_coeffs<TY>(p), p.matrixsize);
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        conv_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        T *dstp = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        conv_v_scanline<TY, FW>(srcp, dstp, width, p, sc, bi, sm, mv, wb);
+    }
+}
+
+// dot_h routes the horizontal half through the i8mm usdot scanline (byte only,
+// and only when the caller has checked conv_int8 + i8mm). It is a runtime flag,
+// not a template parameter, deliberately: it is read once per row, and
+// templating it would double this driver's instantiations for nothing.
+template <CvType TY, unsigned FW>
+void conv_plane_x_impl(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                       const vs_generic_params &p, unsigned width, unsigned height,
+                       [[maybe_unused]] bool dot_h = false)
+{
+    typedef typename cv_traits<TY>::T T;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(cv_coeffs<TY>(p), p.matrixsize);
+
+    T *tmp = static_cast<T *>(vsh::vsh_aligned_malloc(width * sizeof(T), 64));
+    if (!tmp) {
+        // Returning quietly would leave the destination plane as whatever the
+        // frame allocator handed out (possibly other frames' data). Zero is
+        // still wrong output, but deterministic and not an information leak.
+        for (unsigned i = 0; i < height; ++i)
+            std::memset(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride, 0, width * sizeof(T));
+        return;
+    }
+
+    for (unsigned i = 0; i < height; ++i) {
+        const void *srcp[25];
+        conv_v_select_rows(src, src_stride, srcp, i, height, p.matrixsize);
+        T *dstp = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * dst_stride);
+        conv_v_scanline<TY, FW>(srcp, tmp, width, p, sc, bi, sm, mv, wb);
+#ifdef VS_TARGET_ARM_I8MM
+        if constexpr (TY == CvType::Byte) {
+            if (dot_h) {
+                vs_generic_1d_conv_h_byte_scanline_neon_dot(tmp, dstp, &p, width);
+                continue;
+            }
+        }
+#endif
+        conv_h_scanline<TY, FW>(tmp, dstp, width, p, sc, bi, sm, mv, wb);
+    }
+
+    vsh::vsh_aligned_free(tmp);
+}
+
+// Compile-time tap counts for the fwidths the filter actually accepts (odd,
+// 3..25), mirroring x86's VS_CONV_SELECT. The switch runs once per plane, so
+// the row loop below it is fully specialised. FW = 0 is the runtime fallback
+// and stays reachable: matrixsize is validated elsewhere, but a shape this does
+// not enumerate must still produce correct output rather than fall off the end.
+#define VS_CONV_PLANE_SELECT(dir)                                                                  \
+template <CvType TY>                                                                               \
+void conv_plane_##dir##_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, \
+                             const vs_generic_params &p, unsigned width, unsigned height)          \
+{                                                                                                  \
+    switch (p.matrixsize) {                                                                        \
+    case 3:  return conv_plane_##dir##_impl<TY, 3>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 5:  return conv_plane_##dir##_impl<TY, 5>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 7:  return conv_plane_##dir##_impl<TY, 7>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 9:  return conv_plane_##dir##_impl<TY, 9>(src, src_stride, dst, dst_stride, p, width, height);  \
+    case 11: return conv_plane_##dir##_impl<TY, 11>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 13: return conv_plane_##dir##_impl<TY, 13>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 15: return conv_plane_##dir##_impl<TY, 15>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 17: return conv_plane_##dir##_impl<TY, 17>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 19: return conv_plane_##dir##_impl<TY, 19>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 21: return conv_plane_##dir##_impl<TY, 21>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 23: return conv_plane_##dir##_impl<TY, 23>(src, src_stride, dst, dst_stride, p, width, height); \
+    case 25: return conv_plane_##dir##_impl<TY, 25>(src, src_stride, dst, dst_stride, p, width, height); \
+    default: return conv_plane_##dir##_impl<TY, 0>(src, src_stride, dst, dst_stride, p, width, height);  \
+    }                                                                                              \
+}
+
+VS_CONV_PLANE_SELECT(h)
+VS_CONV_PLANE_SELECT(v)
+VS_CONV_PLANE_SELECT(x)
+
+#ifdef VS_TARGET_ARM_I8MM
+// Separable byte with the horizontal half on usdot. Same tap-count switch as
+// above; only the trailing dot_h differs, so it shares every instantiation of
+// conv_plane_x_impl<Byte, FW> with the plain separable entry.
+void conv_plane_x_byte_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                           const vs_generic_params &p, unsigned width, unsigned height)
+{
+    constexpr CvType TY = CvType::Byte;
+    switch (p.matrixsize) {
+    case 3:  return conv_plane_x_impl<TY, 3>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 5:  return conv_plane_x_impl<TY, 5>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 7:  return conv_plane_x_impl<TY, 7>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 9:  return conv_plane_x_impl<TY, 9>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 11: return conv_plane_x_impl<TY, 11>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 13: return conv_plane_x_impl<TY, 13>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 15: return conv_plane_x_impl<TY, 15>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 17: return conv_plane_x_impl<TY, 17>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 19: return conv_plane_x_impl<TY, 19>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 21: return conv_plane_x_impl<TY, 21>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 23: return conv_plane_x_impl<TY, 23>(src, src_stride, dst, dst_stride, p, width, height, true);
+    case 25: return conv_plane_x_impl<TY, 25>(src, src_stride, dst, dst_stride, p, width, height, true);
+    default: return conv_plane_x_impl<TY, 0>(src, src_stride, dst, dst_stride, p, width, height, true);
+    }
+}
+#endif
+
+// ---- 3x3 square (replicate edges, filter_plane_3x3 semantics) ------------------
+
+template <CvType TY>
+void conv_plane_3x3_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride,
+                         const vs_generic_params &p, unsigned width, unsigned height)
+{
+    typedef typename cv_traits<TY>::T T;
+    typedef typename cv_traits<TY>::Acc Acc;
+    const auto *coeffs = cv_coeffs<TY>(p);
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+    int32_t wb = word_bias_sum<TY>(coeffs, 9);
+    const bool satur = p.saturate != 0;   // local copy; see conv_h_scanline
+
+    // Float taps are 1 load : 1 FMA -- the only format with no arithmetic to hide
+    // a stray load behind (byte is 1:4, word/half 1:2) -- so a per-block coefficient
+    // reload lands on the FMA's critical path. Broadcasting once per plane is +21%
+    // on M4 and +2-7% on Graviton3/4/5, and is what puts this kernel back ahead of
+    // the C tier, whose autovectoriser was already hoisting. Float only: the same
+    // change on half measured -1.2% (it is conversion-bound, not load-starved).
+    [[maybe_unused]] float32x4_t cf[9];
+    if constexpr (TY == CvType::Float) {
+        for (unsigned i = 0; i < 9; ++i)
+            cf[i] = vdupq_n_f32(coeffs[i]);
+    }
+
+    auto src_row = [&](unsigned r) {
+        return reinterpret_cast<const T *>(static_cast<const unsigned char *>(src) + static_cast<ptrdiff_t>(r) * src_stride);
+    };
+    auto dst_row = [&](unsigned r) {
+        return reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(r) * dst_stride);
+    };
+    auto scalar_px3 = [&](const T *rt, const T *rm, const T *rb, unsigned a, unsigned b, unsigned c) -> T {
+        const T *rows[3] = { rt, rm, rb };
+        Acc accum = 0;
+        for (unsigned r = 0; r < 3; ++r) {
+            accum += coeffs[r * 3 + 0] * cv_sample<TY>(rows[r][a]);
+            accum += coeffs[r * 3 + 1] * cv_sample<TY>(rows[r][b]);
+            accum += coeffs[r * 3 + 2] * cv_sample<TY>(rows[r][c]);
+        }
+        return cv_scalar_store<TY>(static_cast<float>(accum), p.div, p.bias, p.saturate, p.maxval);
+    };
+
+    auto do_row = [&](unsigned i) {
+        unsigned above_idx = i == 0 ? 0 : i - 1;
+        unsigned below_idx = i == height - 1 ? height - 1 : i + 1;
+        const T *rows[3] = { src_row(above_idx), src_row(i), src_row(below_idx) };
+        T *dstp = dst_row(i);
+
+        auto scalar_px = [&](unsigned a, unsigned b, unsigned c) -> T {
+            return scalar_px3(rows[0], rows[1], rows[2], a, b, c);
+        };
+
+        dstp[0] = scalar_px(0, 0, width > 1 ? 1 : 0);
+
+        unsigned end = width > 1 ? width - 1 : 0;
+        unsigned j = 1;
+        auto block = [&](unsigned jj) {
+            typename std::conditional<TY == CvType::Byte || TY == CvType::Word, acc16_i32, acc16_f32>::type a;
+            if constexpr (TY == CvType::Float) {
+                float_tap16_init(a, rows[0] + jj - 1, cf[0]);
+                for (unsigned r = 0; r < 3; ++r) {
+                    for (unsigned k = r == 0 ? 1 : 0; k < 3; ++k) {
+                        const float *q = rows[r] + jj - 1 + k;
+                        float32x4_t w = cf[r * 3 + k];
+                        a.a0 = vfmaq_f32(a.a0, vld1q_f32(q), w);
+                        a.a1 = vfmaq_f32(a.a1, vld1q_f32(q + 4), w);
+                        a.a2 = vfmaq_f32(a.a2, vld1q_f32(q + 8), w);
+                        a.a3 = vfmaq_f32(a.a3, vld1q_f32(q + 12), w);
+                    }
+                }
+            } else {
+                tap16_init<TY>(a, rows[0] + jj - 1, coeffs[0]);
+                for (unsigned r = 0; r < 3; ++r)
+                    for (unsigned k = r == 0 ? 1 : 0; k < 3; ++k)
+                        tap16<TY>(a, rows[r] + jj - 1 + k, coeffs[r * 3 + k]);
+            }
+            store16_sat<TY>(dstp + jj, a, satur, wb, sc, bi, sm, mv);
+        };
+        if (end > 1) {
+            for (; j + 16 <= end; j += 16) block(j);
+            if (j < end && end >= 1 + 16) { block(end - 16); j = end; }
+            for (; j < end; ++j) {
+                unsigned a = j - 1, b = j, c = j + 1;
+                dstp[j] = scalar_px(a, b, c);
+            }
+        }
+
+        if (width > 1)
+            dstp[width - 1] = scalar_px(width - 2, width - 1, width - 1);
+    };
+
+    for (unsigned i = 0; i < height; ++i)
+        do_row(i);
+}
+
+} // namespace
+
+#define VS_CONV_NEON_ENTRY(KERNEL, FN, TY, TN) \
+    void vs_generic_##KERNEL##_##TN##_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { FN<CvType::TY>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+// 3x3 float has no NEON entry: it loses to its autovectorised C tier at a full
+// thread pool on M4, so it is dispatched to C (see genericSelectNEON).
+VS_CONV_NEON_ENTRY(3x3_conv, conv_plane_3x3_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(3x3_conv, conv_plane_3x3_neon, Word, word)
+VS_CONV_NEON_ENTRY(3x3_conv, conv_plane_3x3_neon, Half, half)
+
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Word, word)
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Float, float)
+VS_CONV_NEON_ENTRY(1d_conv_h, conv_plane_h_neon, Half, half)
+
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Word, word)
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Float, float)
+VS_CONV_NEON_ENTRY(1d_conv_v, conv_plane_v_neon, Half, half)
+
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Byte, byte)
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Word, word)
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Float, float)
+VS_CONV_NEON_ENTRY(2d_conv_sep, conv_plane_x_neon, Half, half)
+
+#ifdef VS_TARGET_ARM_I8MM
+void vs_generic_2d_conv_sep_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{ conv_plane_x_byte_dot(src, src_stride, dst, dst_stride, *params, width, height); }
+#endif

--- a/src/core/kernel/arm/lut_neon.cpp
+++ b/src/core/kernel/arm/lut_neon.cpp
@@ -1,0 +1,59 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* NEON byte -> byte Lut scanline. The whole 256-entry table lives in sixteen
+* vector registers; each block of 16 pixels resolves with four vqtbl4q
+* lookups (each covers a 64-entry window, returning 0 out of range) OR-ed
+* together. Like the scalar fallback, the row is processed in chunks that may
+* extend a few bytes past `w`; frame rows are padded, so this is safe.
+*/
+
+#include <arm_neon.h>
+#include <cstdint>
+
+void vs_lut1_b_b_neon(const uint8_t *src, uint8_t *dst, int w, const uint8_t *lut)
+{
+    uint8x16x4_t t0 = vld1q_u8_x4(lut);
+    uint8x16x4_t t1 = vld1q_u8_x4(lut + 64);
+    uint8x16x4_t t2 = vld1q_u8_x4(lut + 128);
+    uint8x16x4_t t3 = vld1q_u8_x4(lut + 192);
+    uint8x16_t c64 = vdupq_n_u8(64);
+
+    auto lookup16 = [&](uint8x16_t idx) -> uint8x16_t {
+        uint8x16_t r = vqtbl4q_u8(t0, idx);
+        idx = vsubq_u8(idx, c64);
+        r = vorrq_u8(r, vqtbl4q_u8(t1, idx));
+        idx = vsubq_u8(idx, c64);
+        r = vorrq_u8(r, vqtbl4q_u8(t2, idx));
+        idx = vsubq_u8(idx, c64);
+        return vorrq_u8(r, vqtbl4q_u8(t3, idx));
+    };
+
+    int x = 0;
+    for (; x + 16 <= w; x += 16)
+        vst1q_u8(dst + x, lookup16(vld1q_u8(src + x)));
+    // Tail: 8-pixel chunk with the same <= 7 byte overrun as the scalar path.
+    for (; x < w; x += 8) {
+        uint8x8_t idx8 = vld1_u8(src + x);
+        uint8x16_t r = lookup16(vcombine_u8(idx8, idx8));
+        vst1_u8(dst + x, vget_low_u8(r));
+    }
+}

--- a/src/core/kernel/arm/neon_common.h
+++ b/src/core/kernel/arm/neon_common.h
@@ -1,0 +1,142 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* Shared helpers for the AArch64 NEON convolution kernels.
+*
+* Store pipeline semantics match the C reference (and the x86 AVX2+ tiers):
+* int32/int64 accumulator -> float, fused multiply-add of (div, bias), optional
+* fabs via sign-bit mask, round to nearest-even, saturating narrow, min with
+* maxval for word. Integer accumulation orders are associative, so the integer
+* kernels are bit-exact with kernel/generic.cpp; float kernels use FMA and a
+* different summation order, matching the documented x86 AVX2/AVX-512 float
+* behaviour (not bit-exact with C by design).
+*
+* The scalar edge helpers replicate the C reference expressions exactly; on
+* AArch64 the reference C and these helpers compile to the same contracted
+* fmadd sequence, so edge columns match the C kernels on integer formats.
+*/
+
+#ifndef NEON_COMMON_H
+#define NEON_COMMON_H
+
+#include <arm_neon.h>
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+#include <type_traits>
+#include "conv_scalar.h"
+
+namespace {
+
+// tmp = accum * div + bias (fused); !saturate clears the sign bit (fabs).
+inline float32x4_t nc_scale_bias_sat(float32x4_t x, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    float32x4_t t = vfmaq_f32(bi, x, sc);
+    return vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(t), sm));
+}
+
+inline uint32x4_t nc_satmask(uint8_t saturate)
+{
+    return vdupq_n_u32(saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu);
+}
+
+// 8 byte pixels from two int32x4 accumulators. Signed saturate to i16 then
+// unsigned saturate to u8: same clamp as the scalar [0, 255] + lrint sequence.
+inline void nc_store_u8x8(uint8_t *dst, int32x4_t lo, int32x4_t hi, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    int32x4_t rlo = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(lo), sc, bi, sm));
+    int32x4_t rhi = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(hi), sc, bi, sm));
+    int16x8_t p = vcombine_s16(vqmovn_s32(rlo), vqmovn_s32(rhi));
+    vst1_u8(dst, vqmovun_s16(p));
+}
+
+// 8 word pixels from two int32x4 accumulators. Unsigned saturate to u16, then
+// clamp to maxval for sub-16-bit depths.
+inline void nc_store_u16x8(uint16_t *dst, int32x4_t lo, int32x4_t hi, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int32x4_t rlo = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(lo), sc, bi, sm));
+    int32x4_t rhi = vcvtnq_s32_f32(nc_scale_bias_sat(vcvtq_f32_s32(hi), sc, bi, sm));
+    uint16x8_t p = vcombine_u16(vqmovun_s32(rlo), vqmovun_s32(rhi));
+    vst1q_u16(dst, vminq_u16(p, mv));
+}
+
+// int64 -> float32 for the word 9x9/11x11 accumulators: exact via double
+// (|x| < 2^34), single rounding to float32 -- identical to the C reference's
+// direct int64 -> float conversion.
+inline float32x4_t nc_i64x4_to_f32(int64x2_t a, int64x2_t b)
+{
+    float32x2_t lo = vcvt_f32_f64(vcvtq_f64_s64(a));
+    return vcvt_high_f32_f64(lo, vcvtq_f64_s64(b));
+}
+
+inline void nc_store_u16x8_i64(uint16_t *dst, int64x2_t a, int64x2_t b, int64x2_t c, int64x2_t d,
+                               float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int32x4_t rlo = vcvtnq_s32_f32(nc_scale_bias_sat(nc_i64x4_to_f32(a, b), sc, bi, sm));
+    int32x4_t rhi = vcvtnq_s32_f32(nc_scale_bias_sat(nc_i64x4_to_f32(c, d), sc, bi, sm));
+    uint16x8_t p = vcombine_u16(vqmovun_s32(rlo), vqmovun_s32(rhi));
+    vst1q_u16(dst, vminq_u16(p, mv));
+}
+
+// float store: scale/bias/sat only, no clamp (matches C float semantics).
+inline void nc_store_f32x4(float *dst, float32x4_t acc, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    vst1q_f32(dst, nc_scale_bias_sat(acc, sc, bi, sm));
+}
+
+// half store: f32 -> f16 round-to-nearest-even, matching floatToHalf.
+inline void nc_store_h16x8(uint16_t *dst, float32x4_t a0, float32x4_t a1, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    float16x4_t lo = vcvt_f16_f32(nc_scale_bias_sat(a0, sc, bi, sm));
+    float16x8_t p = vcvt_high_f16_f32(lo, nc_scale_bias_sat(a1, sc, bi, sm));
+    vst1q_u16(dst, vreinterpretq_u16_f16(p));
+}
+
+// 16 byte pixels widened to two s16x8 (always non-negative).
+struct nc_byte16 {
+    int16x8_t lo, hi;
+};
+inline nc_byte16 nc_load_byte16(const uint8_t *p)
+{
+    uint8x16_t v = vld1q_u8(p);
+    return { vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(v))),
+             vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(v))) };
+}
+
+// 8 word pixels biased into signed range: u16 + INT16_MIN (xor 0x8000).
+inline int16x8_t nc_load_word_biased(const uint16_t *p)
+{
+    return vreinterpretq_s16_u16(veorq_u16(vld1q_u16(p), vdupq_n_u16(0x8000u)));
+}
+
+// 8 half pixels widened to two f32x4.
+struct nc_half8 {
+    float32x4_t lo, hi;
+};
+inline nc_half8 nc_load_half8(const uint16_t *p)
+{
+    float16x8_t v = vreinterpretq_f16_u16(vld1q_u16(p));
+    return { vcvt_f32_f16(vget_low_f16(v)), vcvt_high_f32_f16(v) };
+}
+
+} // namespace
+
+#endif // NEON_COMMON_H

--- a/src/core/kernel/arm/square_dot_neon.cpp
+++ b/src/core/kernel/arm/square_dot_neon.cpp
@@ -1,0 +1,383 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* FEAT_I8MM byte square NxN convolution, N in {5,7,9,11} -- a faster interior for
+* the byte path, dispatched only when every coefficient fits int8 (conv_int8) and
+* the CPU reports i8mm.
+*
+* This is the ARM analog of square_vnni_impl.h: usdot is the vpdpbusd equivalent,
+* reducing 4 uint8*int8 products into an int32 lane in one op with no byte->word
+* widening, and vqtbl1q_u8 plays the role of vpermb -- it builds the sliding
+* window so that 32-bit lane l holds the 4 pixels output j+l needs. The
+* accumulator therefore stays linear (lane l = output j+l) and the store needs no
+* un-scramble.
+*
+* Bit-exact with sq_interior_byte: the products and the int32 sum are the same
+* integers (integer addition is associative, so the regrouping into 4-tap chunks
+* cannot change the result), and the scale/bias/round/clamp reuses the same
+* nc_store_u8x8. |coeff| <= 127 under conv_int8, so 121 * 127 * 255 cannot
+* overflow int32.
+*
+* Coefficients are zero-padded to a multiple of 4 taps per row, so the window can
+* read up to 4G-N taps past the kernel; those pixels are multiplied by zero, but
+* they are still *read*, so the SIMD interior is bounded to keep every load inside
+* the row and the driver's scalar edge covers whatever is left.
+*
+* Compiled in its own TU with -march=...+i8mm (see meson.build). NEON baseline
+* code must not be built with +i8mm, hence the separate TU rather than a target
+* attribute.
+*/
+
+#include <cstdint>
+#include <cstring>
+#include "../generic.h"
+#include "conv_scalar.h"
+#include "neon_common.h"
+
+namespace {
+
+// Window indices: 32-bit lane l gets pixels {l, l+1, l+2, l+3} of the 8-byte load.
+alignas(16) const uint8_t NC_DOT_WIN[16] = {
+    0, 1, 2, 3,
+    1, 2, 3, 4,
+    2, 3, 4, 5,
+    3, 4, 5, 6,
+};
+
+template <unsigned N>
+unsigned sq_interior_byte_dot(const uint8_t *const *rows, uint8_t *dst, unsigned S, unsigned W,
+                              const int32_t *cg, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned G = (N + 3) / 4;                 // 4-tap groups per row
+    const uint8x16_t widx = vld1q_u8(NC_DOT_WIN);
+
+    auto block = [&](unsigned jj) {
+        int32x4_t a0 = vdupq_n_s32(0), a1 = vdupq_n_s32(0), a2 = vdupq_n_s32(0), a3 = vdupq_n_s32(0);
+        for (unsigned r = 0; r < N; ++r) {
+            const uint8_t *row = rows[r] + (jj - S);
+            for (unsigned g = 0; g < G; ++g) {
+                // The group's 4 coefficients, replicated into every 32-bit lane.
+                const int8x16_t w = vreinterpretq_s8_s32(vdupq_n_s32(cg[r * G + g]));
+                const uint8_t *q = row + 4 * g;
+                const uint8x16_t z = vdupq_n_u8(0);
+                uint8x16_t t0 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 0), vget_low_u8(z)), widx);
+                uint8x16_t t1 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 4), vget_low_u8(z)), widx);
+                uint8x16_t t2 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 8), vget_low_u8(z)), widx);
+                uint8x16_t t3 = vqtbl1q_u8(vcombine_u8(vld1_u8(q + 12), vget_low_u8(z)), widx);
+                a0 = vusdotq_s32(a0, t0, w);
+                a1 = vusdotq_s32(a1, t1, w);
+                a2 = vusdotq_s32(a2, t2, w);
+                a3 = vusdotq_s32(a3, t3, w);
+            }
+        }
+        nc_store_u8x8(dst + jj, a0, a1, sc, bi, sm);
+        nc_store_u8x8(dst + jj + 8, a2, a3, sc, bi, sm);
+    };
+
+    const unsigned end = W > S ? W - S : 0;
+    if (end < S + 16)
+        return S;
+
+    // Highest block start whose furthest load, row[(jj - S) + 4(G-1) + 12 + 7],
+    // still lands inside the row.
+    const long maxjj = static_cast<long>(W) + static_cast<long>(S) - 4L * static_cast<long>(G) - 16L;
+    if (maxjj < static_cast<long>(S))
+        return S;
+
+    unsigned j = S;
+    for (; j + 16 <= end && static_cast<long>(j) <= maxjj; j += 16)
+        block(j);
+
+    // Overlapping final block for the sub-vector remainder; re-storing already
+    // written columns is safe because this path is bit-exact with the scalar one.
+    if (j < end) {
+        long c = static_cast<long>(end) - 16;
+        if (c > maxjj)
+            c = maxjj;
+        if (c >= static_cast<long>(S) && static_cast<unsigned>(c) + 16 > j) {
+            block(static_cast<unsigned>(c));
+            j = static_cast<unsigned>(c) + 16;
+        }
+    }
+    return j;
+}
+
+template <unsigned N>
+void sq_plane_byte_dot(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                       const vs_generic_params &p, unsigned W, unsigned H)
+{
+    constexpr unsigned S = N / 2;
+    constexpr unsigned G = (N + 3) / 4;
+
+    // Pack each row's taps into 4-tap groups of int8, zero-filling the tail.
+    int32_t cg[N * G];
+    for (unsigned r = 0; r < N; ++r) {
+        for (unsigned g = 0; g < G; ++g) {
+            int8_t b[4];
+            for (unsigned t = 0; t < 4; ++t) {
+                const unsigned k = 4 * g + t;
+                b[t] = k < N ? static_cast<int8_t>(p.matrix[r * N + k]) : 0;
+            }
+            std::memcpy(&cg[r * G + g], b, 4);
+        }
+    }
+
+    const float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    const uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint8_t *rows[N];
+        for (unsigned r = 0; r < N; ++r)
+            rows[r] = static_cast<const uint8_t *>(src) +
+                static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(i) + static_cast<int>(r) - static_cast<int>(S), static_cast<int>(H))) * ss;
+        uint8_t *d = static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * ds;
+
+        const unsigned aend = sq_interior_byte_dot<N>(rows, d, S, W, cg, sc, bi, sm);
+
+        for (unsigned j = 0; j < S && j < W; ++j)
+            d[j] = nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+        for (unsigned j = (aend > S ? aend : S); j < W; ++j)
+            d[j] = nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+    }
+}
+
+// ---- 3x3 byte (replicate edges, conv_plane_3x3 semantics) ----------------------
+//
+// The 3x3 shape was originally skipped because the square driver above uses
+// MIRROR edges while 3x3 convolution replicates -- but the interior
+// (sq_interior_byte_dot<3>, G=1) is edge-agnostic, so all it needs is its own
+// replicate-edge driver. Same conv_int8 + i8mm gate, same bit-exactness
+// argument, and 3x3 byte is the most common convolution there is.
+
+inline uint8_t sq3_edge_px_byte(const uint8_t *const rows[3], const vs_generic_params &p,
+                                unsigned a, unsigned b, unsigned c)
+{
+    int32_t accum = 0;
+    for (unsigned r = 0; r < 3; ++r) {
+        accum += p.matrix[r * 3 + 0] * static_cast<int32_t>(rows[r][a]);
+        accum += p.matrix[r * 3 + 1] * static_cast<int32_t>(rows[r][b]);
+        accum += p.matrix[r * 3 + 2] * static_cast<int32_t>(rows[r][c]);
+    }
+    float tmp = static_cast<float>(accum) * p.div + p.bias;
+    tmp = p.saturate ? tmp : std::fabs(tmp);
+    float cl = std::min(std::max(tmp, 0.0f), 255.0f);
+    long v = std::lrint(cl);
+    return static_cast<uint8_t>(std::min<long>(v, p.maxval));
+}
+
+void sq_plane_byte_dot_3x3(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                           const vs_generic_params &p, unsigned W, unsigned H)
+{
+    // One 4-tap group per row: {c0, c1, c2, 0}.
+    int32_t cg[3];
+    for (unsigned r = 0; r < 3; ++r) {
+        int8_t b[4] = { static_cast<int8_t>(p.matrix[r * 3 + 0]),
+                        static_cast<int8_t>(p.matrix[r * 3 + 1]),
+                        static_cast<int8_t>(p.matrix[r * 3 + 2]), 0 };
+        std::memcpy(&cg[r], b, 4);
+    }
+
+    const float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    const uint32x4_t sm = nc_satmask(p.saturate);
+
+    for (unsigned i = 0; i < H; ++i) {
+        unsigned above = i == 0 ? 0 : i - 1;
+        unsigned below = i == H - 1 ? H - 1 : i + 1;
+        const uint8_t *rows[3] = {
+            static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(above) * ss,
+            static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(i) * ss,
+            static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(below) * ss,
+        };
+        uint8_t *d = static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * ds;
+
+        const unsigned aend = sq_interior_byte_dot<3>(rows, d, 1, W, cg, sc, bi, sm);
+
+        d[0] = sq3_edge_px_byte(rows, p, 0, 0, W > 1 ? 1 : 0);
+        for (unsigned j = std::max(aend, 1u); j < W; ++j)
+            d[j] = sq3_edge_px_byte(rows, p, j - 1, j, j == W - 1 ? W - 1 : j + 1);
+    }
+}
+
+// ---- 1D horizontal byte -------------------------------------------------------
+//
+// One row of the square machinery: the taps run along the scanline and
+// zero-pad to 4-tap groups exactly like a square row, so the window/usdot
+// form carries over with the row loop removed. One 1D-specific improvement:
+// consecutive groups overlap 3 of their 4 window loads (group g reads at
+// offsets 4g..4g+12, group g+1 at 4g+4..), so the group loop rolls the loads
+// forward instead of reloading -- the squares cannot do this because each
+// row has its own pointer. Bit-exact with vs_generic_1d_conv_h_byte_neon for
+// the same reason the squares are: integer regrouping is associative and the
+// store pipeline is shared. Vertical 1D does NOT transfer: its taps run
+// across rows, so there is no scanline window to build.
+
+// conv_h_edge_px<Byte> replica (convolution_neon.cpp); keep in sync. The 1D
+// kernels clamp edge taps instead of the squares' mirror.
+inline uint8_t h_edge_px_byte(const uint8_t *srcp, unsigned j, unsigned width, const vs_generic_params &p)
+{
+    unsigned fwidth = p.matrixsize;
+    unsigned support = fwidth / 2;
+    unsigned dist_from_right = width - 1 - j;
+
+    int32_t accum = 0;
+    for (unsigned k = 0; k < support; ++k) {
+        unsigned idx = j < support - k ? std::min(support - k - j - 1, width - 1) : j - support + k;
+        accum += p.matrix[k] * static_cast<int32_t>(srcp[idx]);
+    }
+    for (unsigned k = support; k < fwidth; ++k) {
+        unsigned idx = dist_from_right < k - support ? width - std::min(k - support - dist_from_right, width) : j - support + k;
+        accum += p.matrix[k] * static_cast<int32_t>(srcp[idx]);
+    }
+    float tmp = static_cast<float>(accum) * p.div + p.bias;
+    tmp = p.saturate ? tmp : std::fabs(tmp);
+    float c = std::min(std::max(tmp, 0.0f), 255.0f);
+    long v = std::lrint(c);
+    return static_cast<uint8_t>(std::min<long>(v, p.maxval));
+}
+
+// Everything that depends only on the filter, not on the row. Split out so the
+// plane driver can hoist it out of its row loop while the exported per-scanline
+// entry (used by the separable driver, which owns its own row loop) can build
+// it per call -- it is ~40 ops against a row of thousands of pixels.
+struct h_dot_ctx {
+    int32_t cg[7];                        // ceil(25/4) 4-tap int8 groups
+    unsigned S, G, end;
+    long maxjj;
+    float32x4_t sc, bi;
+    uint32x4_t sm;
+    uint8x16_t widx;
+};
+
+inline h_dot_ctx h_dot_make(const vs_generic_params &p, unsigned W)
+{
+    h_dot_ctx c;
+    const unsigned N = p.matrixsize;      // runtime, 3..25 odd
+    c.S = N / 2;
+    c.G = (N + 3) / 4;
+
+    // Taps packed into 4-tap int8 groups, zero-filled tail.
+    for (unsigned g = 0; g < c.G; ++g) {
+        int8_t b[4];
+        for (unsigned t = 0; t < 4; ++t) {
+            const unsigned k = 4 * g + t;
+            b[t] = k < N ? static_cast<int8_t>(p.matrix[k]) : 0;
+        }
+        std::memcpy(&c.cg[g], b, 4);
+    }
+
+    c.sc = vdupq_n_f32(p.div);
+    c.bi = vdupq_n_f32(p.bias);
+    c.sm = nc_satmask(p.saturate);
+    c.widx = vld1q_u8(NC_DOT_WIN);
+
+    // Same interior bounds as the squares: the furthest load of a block at jj
+    // is byte (jj - S) + 4(G-1) + 12 + 7; keep it inside the row.
+    c.end = W > c.S ? W - c.S : 0;
+    c.maxjj = static_cast<long>(W) + static_cast<long>(c.S) - 4L * static_cast<long>(c.G) - 16L;
+    return c;
+}
+
+inline void h_dot_scanline(const h_dot_ctx &c, const uint8_t *srcp, uint8_t *d, unsigned W, const vs_generic_params &p)
+{
+    const uint8x8_t zlo = vdup_n_u8(0);
+    const unsigned S = c.S, G = c.G, end = c.end;
+    const long maxjj = c.maxjj;
+
+    auto block = [&](unsigned jj) {
+        const uint8_t *q = srcp + (jj - S);
+        int32x4_t a0 = vdupq_n_s32(0), a1 = vdupq_n_s32(0), a2 = vdupq_n_s32(0), a3 = vdupq_n_s32(0);
+        uint8x8_t v0 = vld1_u8(q), v1 = vld1_u8(q + 4), v2 = vld1_u8(q + 8);
+        for (unsigned g = 0; g < G; ++g) {
+            uint8x8_t v3 = vld1_u8(q + 4 * g + 12);
+            const int8x16_t w = vreinterpretq_s8_s32(vdupq_n_s32(c.cg[g]));
+            a0 = vusdotq_s32(a0, vqtbl1q_u8(vcombine_u8(v0, zlo), c.widx), w);
+            a1 = vusdotq_s32(a1, vqtbl1q_u8(vcombine_u8(v1, zlo), c.widx), w);
+            a2 = vusdotq_s32(a2, vqtbl1q_u8(vcombine_u8(v2, zlo), c.widx), w);
+            a3 = vusdotq_s32(a3, vqtbl1q_u8(vcombine_u8(v3, zlo), c.widx), w);
+            v0 = v1; v1 = v2; v2 = v3;
+        }
+        nc_store_u8x8(d + jj, a0, a1, c.sc, c.bi, c.sm);
+        nc_store_u8x8(d + jj + 8, a2, a3, c.sc, c.bi, c.sm);
+    };
+
+    unsigned j = S;
+    if (end >= S + 16 && maxjj >= static_cast<long>(S)) {
+        for (; j + 16 <= end && static_cast<long>(j) <= maxjj; j += 16)
+            block(j);
+        // Overlapping final block; safe because this path is bit-exact.
+        if (j < end) {
+            long cc = static_cast<long>(end) - 16;
+            if (cc > maxjj)
+                cc = maxjj;
+            if (cc >= static_cast<long>(S) && static_cast<unsigned>(cc) + 16 > j) {
+                block(static_cast<unsigned>(cc));
+                j = static_cast<unsigned>(cc) + 16;
+            }
+        }
+    }
+
+    for (unsigned jj = 0; jj < S && jj < W; ++jj)
+        d[jj] = h_edge_px_byte(srcp, jj, W, p);
+    for (unsigned jj = std::max(j, S); jj < W; ++jj)
+        d[jj] = h_edge_px_byte(srcp, jj, W, p);
+}
+
+void h_plane_byte_dot(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                      const vs_generic_params &p, unsigned W, unsigned H)
+{
+    const h_dot_ctx c = h_dot_make(p, W);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const uint8_t *srcp = static_cast<const uint8_t *>(src) + static_cast<ptrdiff_t>(i) * ss;
+        uint8_t *d = static_cast<uint8_t *>(dst) + static_cast<ptrdiff_t>(i) * ds;
+        h_dot_scanline(c, srcp, d, W, p);
+    }
+}
+
+} // namespace
+
+void vs_generic_1d_conv_h_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{
+    h_plane_byte_dot(src, src_stride, dst, dst_stride, *params, width, height);
+}
+
+// One scanline, for the separable driver's horizontal half: that driver owns
+// the row loop (it interleaves a vertical pass through a tmp scanline), and it
+// lives in a TU built without i8mm, so it cannot inline this.
+void vs_generic_1d_conv_h_byte_scanline_neon_dot(const void *srcp, void *dstp, const struct vs_generic_params *params, unsigned width)
+{
+    const h_dot_ctx c = h_dot_make(*params, width);
+    h_dot_scanline(c, static_cast<const uint8_t *>(srcp), static_cast<uint8_t *>(dstp), width, *params);
+}
+
+void vs_generic_3x3_conv_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height)
+{
+    sq_plane_byte_dot_3x3(src, src_stride, dst, dst_stride, *params, width, height);
+}
+
+#define VS_SQUARE_DOT_ENTRY(SZ, N) \
+    void vs_generic_##SZ##_conv_byte_neon_dot(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sq_plane_byte_dot<N>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SQUARE_DOT_ENTRY(5x5, 5)
+VS_SQUARE_DOT_ENTRY(7x7, 7)
+VS_SQUARE_DOT_ENTRY(9x9, 9)
+VS_SQUARE_DOT_ENTRY(11x11, 11)

--- a/src/core/kernel/arm/square_neon.cpp
+++ b/src/core/kernel/arm/square_neon.cpp
@@ -1,0 +1,441 @@
+/*
+* Copyright (c) 2012-2026 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* NEON square (non-separable) NxN convolution, N in {3,5,7,9,11}.
+*
+* Same structure as the x86 square_impl.h kernels: scalar mirror-edge columns,
+* SIMD interior, and an overlapping final vector to cover the sub-vector
+* interior remainder (re-storing already-written columns is safe because the
+* SIMD interior is bit-exact with the scalar reference on integer formats).
+*
+* byte:  u8 widens to s16 (non-negative), per-tap vmlal_s16 into int32.
+*        Worst case 121 * 1023 * 255 < INT32_MAX -- never overflows.
+* word:  u16 biased by INT16_MIN into s16, per-tap vmlal_s16 into int32.
+*        N <= 7: 49 * 1023 * 32768 < INT32_MAX; the coefficient*bias sum is
+*        subtracted afterwards (exact), so results match the C reference.
+*        N >= 9: per-row int32 sums (11 * 1023 * 32768 fits) spill into int64
+*        accumulators; int64 -> float via double is exact, bit-identical to
+*        the int64 C reference.
+* float: per-tap FMA; like the x86 AVX2+ tiers this is not bit-exact with the
+*        non-FMA scalar reference (allowed for float).
+* half:  samples widen to float32, float math, narrow on store.
+*
+* The 3x3 square entry (vs_generic_3x3_conv_*) uses replicate edges and a
+* separate driver (see convolution_neon.cpp); this file is 5x5 and up.
+*/
+
+#include <cstdint>
+#include "../generic.h"
+#include "neon_common.h"
+
+namespace {
+
+// ---- per-row lane-form coefficients (integer squares) ----
+//
+// The obvious way to feed a coefficient to vmlal_s16 is vdup_n_s16(m[...]),
+// but the compiler cannot hoist that broadcast out of the block: p.matrix is
+// caller memory and the block stores through dst, which may alias it, so every
+// tap of every 16-px block re-emits an address `sub` plus an `ld1r.8h`
+// (verified in the emitted asm). That is 2 of the ~10 ops per tap, one of them
+// a load.
+//
+// vmlal_laneq_s16 instead reads the coefficient from a lane of a register, so
+// the matrix can be loaded once per scanline. Coefficients are staged per ROW,
+// not per matrix: RQ = ceil(N/8) vectors hold one row's taps (tap k -> vector
+// k/8, lane k%8), and the row loop stays rolled, so only one row's coefficients
+// and loads are in flight at a time.
+//
+// Staging the WHOLE matrix and unrolling all N*N taps was measurably worse:
+// it lets the scheduler hoist every tap's loads to the top of the block, which
+// needs more registers than gcc 13.3 has. gcc emits the lane forms correctly
+// and then spills around them (-35..-47% on Neoverse V1/V2/V3); clang gained
+// less than the per-row form does. Per-row wins on both compilers, so unlike
+// the whole-matrix float hoist this replaced, it needs no __clang__ gate.
+//
+// Bit-exact: vmlal_laneq_s16 with lane L computes the same widening MLA as
+// vmlal_s16 against a dup of the same coefficient, and the tap order is
+// unchanged, so results are identical to the plain path.
+
+template <unsigned N>
+constexpr unsigned sq_row_q() { return (N + 7) / 8; }
+
+template <unsigned N>
+inline void sq_load_row_coeffs(int16x8_t *cq, const int16_t *m)
+{
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16_t cpad[N * RQ * 8] = {};
+    for (unsigned r = 0; r < N; ++r)
+        for (unsigned k = 0; k < N; ++k)
+            cpad[(r * RQ + k / 8) * 8 + k % 8] = m[r * N + k];
+    for (unsigned i = 0; i < N * RQ; ++i)
+        cq[i] = vld1q_s16(cpad + 8 * i);
+}
+
+// One row's N taps over 16 byte pixels.
+template <unsigned N, unsigned K>
+inline void sq_tap_byte_row(int32x4_t (&a)[4], const uint8_t *p, const int16x8_t *crow)
+{
+    nc_byte16 x = nc_load_byte16(p + K);
+    a[0] = vmlal_laneq_s16(a[0], vget_low_s16(x.lo), crow[K / 8], K % 8);
+    a[1] = vmlal_laneq_s16(a[1], vget_high_s16(x.lo), crow[K / 8], K % 8);
+    a[2] = vmlal_laneq_s16(a[2], vget_low_s16(x.hi), crow[K / 8], K % 8);
+    a[3] = vmlal_laneq_s16(a[3], vget_high_s16(x.hi), crow[K / 8], K % 8);
+    if constexpr (K + 1 < N)
+        sq_tap_byte_row<N, K + 1>(a, p, crow);
+}
+
+// One row's N taps over 16 word pixels.
+template <unsigned N, unsigned K>
+inline void sq_tap_word_row(int32x4_t (&a)[4], const uint16_t *p, const int16x8_t *crow)
+{
+    int16x8_t x0 = nc_load_word_biased(p + K);
+    int16x8_t x1 = nc_load_word_biased(p + K + 8);
+    a[0] = vmlal_laneq_s16(a[0], vget_low_s16(x0), crow[K / 8], K % 8);
+    a[1] = vmlal_laneq_s16(a[1], vget_high_s16(x0), crow[K / 8], K % 8);
+    a[2] = vmlal_laneq_s16(a[2], vget_low_s16(x1), crow[K / 8], K % 8);
+    a[3] = vmlal_laneq_s16(a[3], vget_high_s16(x1), crow[K / 8], K % 8);
+    if constexpr (K + 1 < N)
+        sq_tap_word_row<N, K + 1>(a, p, crow);
+}
+
+// One row's N taps over 8 word pixels, into the int32 per-row sums that the
+// int64 path widens from.
+template <unsigned N, unsigned K>
+inline void sq_tap_word8_row(int32x4_t &r0, int32x4_t &r1, const uint16_t *p, const int16x8_t *crow)
+{
+    int16x8_t x = nc_load_word_biased(p + K);
+    r0 = vmlal_laneq_s16(r0, vget_low_s16(x), crow[K / 8], K % 8);
+    r1 = vmlal_laneq_s16(r1, vget_high_s16(x), crow[K / 8], K % 8);
+    if constexpr (K + 1 < N)
+        sq_tap_word8_row<N, K + 1>(r0, r1, p, crow);
+}
+
+// ---- byte ----
+
+template <unsigned N>
+unsigned sq_interior_byte(const uint8_t *const *rows, uint8_t *dst, unsigned S, unsigned W,
+                          const int16_t *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16x8_t cq[N * RQ];
+    sq_load_row_coeffs<N>(cq, m);
+    const uint8_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        int32x4_t a[4] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0) };
+        for (unsigned r = 0; r < N; ++r)
+            sq_tap_byte_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+        nc_store_u8x8(dst + jj, a[0], a[1], sc, bi, sm);
+        nc_store_u8x8(dst + jj + 8, a[2], a[3], sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- word, int32 accumulation (N <= 7) ----
+
+template <unsigned N>
+unsigned sq_interior_word_i32(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                              const int16_t *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int32_t wb = 0;
+    for (unsigned i = 0; i < N * N; ++i) wb += static_cast<int32_t>(INT16_MIN) * m[i];
+    int32x4_t wbv = vdupq_n_s32(wb);
+
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16x8_t cq[N * RQ];
+    sq_load_row_coeffs<N>(cq, m);
+    const uint16_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        int32x4_t a[4] = { vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0), vdupq_n_s32(0) };
+        for (unsigned r = 0; r < N; ++r)
+            sq_tap_word_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+        nc_store_u16x8(dst + jj, vsubq_s32(a[0], wbv), vsubq_s32(a[1], wbv), sc, bi, sm, mv);
+        nc_store_u16x8(dst + jj + 8, vsubq_s32(a[2], wbv), vsubq_s32(a[3], wbv), sc, bi, sm, mv);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- word, int64 accumulation (N >= 9) ----
+
+template <unsigned N>
+unsigned sq_interior_word_i64(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                              const int16_t *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm, uint16x8_t mv)
+{
+    int64_t wb = 0;
+    for (unsigned i = 0; i < N * N; ++i) wb += static_cast<int64_t>(INT16_MIN) * m[i];
+    int64x2_t wbv = vdupq_n_s64(wb);
+
+    constexpr unsigned RQ = sq_row_q<N>();
+    int16x8_t cq[N * RQ];
+    sq_load_row_coeffs<N>(cq, m);
+    const uint16_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        int64x2_t a0 = vdupq_n_s64(0), a1 = vdupq_n_s64(0), a2 = vdupq_n_s64(0), a3 = vdupq_n_s64(0);
+        for (unsigned r = 0; r < N; ++r) {
+            int32x4_t r0 = vdupq_n_s32(0), r1 = vdupq_n_s32(0);
+            sq_tap_word8_row<N, 0>(r0, r1, lrows[r] + (jj - S), cq + r * RQ);
+            a0 = vaddw_s32(a0, vget_low_s32(r0));
+            a1 = vaddw_s32(a1, vget_high_s32(r0));
+            a2 = vaddw_s32(a2, vget_low_s32(r1));
+            a3 = vaddw_s32(a3, vget_high_s32(r1));
+        }
+        nc_store_u16x8_i64(dst + jj, vsubq_s64(a0, wbv), vsubq_s64(a1, wbv),
+                           vsubq_s64(a2, wbv), vsubq_s64(a3, wbv), sc, bi, sm, mv);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 8 <= end; j += 8) block(j);
+    if (j < end && end >= S + 8) { block(end - 8); j = end; }
+    return j;
+}
+
+// ---- float ----
+
+// Float coefficients staged per row, exactly like the integer squares above:
+// RQ = ceil(N/4) vectors per row, tap k -> vector k/4, lane k%4, row loop left
+// rolled. Float taps are 1 load : 1 FMA, so the per-tap coefficient reload the
+// compiler cannot hoist (see the integer note) lands right on the FMA critical
+// path.
+//
+// This replaces an earlier 5x5-only variant that staged the whole 25-tap matrix
+// and unrolled every tap. That one had to be gated on __clang__: it was +7-10%
+// on M4 / +18% on Graviton5-with-clang, but -22% under gcc 13.3, which could
+// not keep the coefficients live across the fully unrolled block. The per-row
+// form keeps one row's coefficients in flight instead of the whole matrix, wins
+// on both toolchains, and so needs no compiler gate and no N == 5 restriction.
+//
+// Tap order matches the plain r/k loops exactly, and vfmaq_laneq_f32 computes
+// the same FMA as vfmaq_f32 with a dup'd scalar, so this is bit-identical to
+// the plain path.
+//
+// 7x7 float is EXCLUDED and keeps the plain loops: it is the one shape that
+// measured slower with per-row coefficients under gcc 13.3 (-3.9% G3, -7.9%
+// G4b, -6.9% G5, three interleaved runs each, while clang 17 gained +1.4%).
+// Every other float size wins on gcc (5x5 +5..15%, 9x9 +41..49%, 11x11
+// +78..81%). The cause was not isolated -- gcc emits no spills for it, and
+// outlining the block cannot be it either, since 9x9/11x11 are outlined too
+// and win big. 7x7 was also the shape the earlier whole-matrix hoist could not
+// help (it spilled even under clang), so this size seems to sit right at a
+// scheduling cliff. Re-measure before extending per-row to it.
+template <unsigned N>
+constexpr bool sq_float_lane() { return N != 7; }
+
+template <unsigned N>
+constexpr unsigned sq_row_qf() { return (N + 3) / 4; }
+
+template <unsigned N>
+inline void sq_load_row_coeffs_f(float32x4_t *cq, const float *m)
+{
+    constexpr unsigned RQ = sq_row_qf<N>();
+    float cpad[N * RQ * 4] = {};
+    for (unsigned r = 0; r < N; ++r)
+        for (unsigned k = 0; k < N; ++k)
+            cpad[(r * RQ + k / 4) * 4 + k % 4] = m[r * N + k];
+    for (unsigned i = 0; i < N * RQ; ++i)
+        cq[i] = vld1q_f32(cpad + 4 * i);
+}
+
+template <unsigned N, unsigned K>
+inline void sq_tap_float_row(float32x4_t (&a)[4], const float *p, const float32x4_t *crow)
+{
+    a[0] = vfmaq_laneq_f32(a[0], vld1q_f32(p + K), crow[K / 4], K % 4);
+    a[1] = vfmaq_laneq_f32(a[1], vld1q_f32(p + K + 4), crow[K / 4], K % 4);
+    a[2] = vfmaq_laneq_f32(a[2], vld1q_f32(p + K + 8), crow[K / 4], K % 4);
+    a[3] = vfmaq_laneq_f32(a[3], vld1q_f32(p + K + 12), crow[K / 4], K % 4);
+    if constexpr (K + 1 < N)
+        sq_tap_float_row<N, K + 1>(a, p, crow);
+}
+
+template <unsigned N>
+unsigned sq_interior_float(const float *const *rows, float *dst, unsigned S, unsigned W,
+                           const float *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned RQ = sq_row_qf<N>();
+    [[maybe_unused]] float32x4_t cq[N * RQ];
+    [[maybe_unused]] const float *lrows[N];
+    if constexpr (sq_float_lane<N>()) {
+        sq_load_row_coeffs_f<N>(cq, m);
+        for (unsigned r = 0; r < N; ++r)
+            lrows[r] = rows[r];
+    }
+
+    auto block = [&](unsigned jj) {
+        if constexpr (sq_float_lane<N>()) {
+            float32x4_t a[4] = { vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0) };
+            for (unsigned r = 0; r < N; ++r)
+                sq_tap_float_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+            nc_store_f32x4(dst + jj, a[0], sc, bi, sm);
+            nc_store_f32x4(dst + jj + 4, a[1], sc, bi, sm);
+            nc_store_f32x4(dst + jj + 8, a[2], sc, bi, sm);
+            nc_store_f32x4(dst + jj + 12, a[3], sc, bi, sm);
+            return;
+        }
+        float32x4_t a0 = vdupq_n_f32(0), a1 = vdupq_n_f32(0), a2 = vdupq_n_f32(0), a3 = vdupq_n_f32(0);
+        for (unsigned r = 0; r < N; ++r) {
+            const float *row = rows[r] + (jj - S);
+            for (unsigned k = 0; k < N; ++k) {
+                float32x4_t w = vdupq_n_f32(m[r * N + k]);
+                a0 = vfmaq_f32(a0, vld1q_f32(row + k), w);
+                a1 = vfmaq_f32(a1, vld1q_f32(row + k + 4), w);
+                a2 = vfmaq_f32(a2, vld1q_f32(row + k + 8), w);
+                a3 = vfmaq_f32(a3, vld1q_f32(row + k + 12), w);
+            }
+        }
+        nc_store_f32x4(dst + jj, a0, sc, bi, sm);
+        nc_store_f32x4(dst + jj + 4, a1, sc, bi, sm);
+        nc_store_f32x4(dst + jj + 8, a2, sc, bi, sm);
+        nc_store_f32x4(dst + jj + 12, a3, sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- half ----
+
+// Per-row lane coefficients, as for float above. This path only runs for
+// coefficients that do not narrow exactly to f16 (conv_f16) or on CPUs without
+// FEAT_FHM; everything else dispatches to the fmlal kernels.
+template <unsigned N, unsigned K>
+inline void sq_tap_half_row(float32x4_t (&a)[4], const uint16_t *p, const float32x4_t *crow)
+{
+    nc_half8 x0 = nc_load_half8(p + K);
+    nc_half8 x1 = nc_load_half8(p + K + 8);
+    a[0] = vfmaq_laneq_f32(a[0], x0.lo, crow[K / 4], K % 4);
+    a[1] = vfmaq_laneq_f32(a[1], x0.hi, crow[K / 4], K % 4);
+    a[2] = vfmaq_laneq_f32(a[2], x1.lo, crow[K / 4], K % 4);
+    a[3] = vfmaq_laneq_f32(a[3], x1.hi, crow[K / 4], K % 4);
+    if constexpr (K + 1 < N)
+        sq_tap_half_row<N, K + 1>(a, p, crow);
+}
+
+template <unsigned N>
+unsigned sq_interior_half(const uint16_t *const *rows, uint16_t *dst, unsigned S, unsigned W,
+                          const float *m, float32x4_t sc, float32x4_t bi, uint32x4_t sm)
+{
+    constexpr unsigned RQ = sq_row_qf<N>();
+    float32x4_t cq[N * RQ];
+    sq_load_row_coeffs_f<N>(cq, m);
+    const uint16_t *lrows[N];
+    for (unsigned r = 0; r < N; ++r)
+        lrows[r] = rows[r];
+
+    auto block = [&](unsigned jj) {
+        float32x4_t a[4] = { vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0), vdupq_n_f32(0) };
+        for (unsigned r = 0; r < N; ++r)
+            sq_tap_half_row<N, 0>(a, lrows[r] + (jj - S), cq + r * RQ);
+        nc_store_h16x8(dst + jj, a[0], a[1], sc, bi, sm);
+        nc_store_h16x8(dst + jj + 8, a[2], a[3], sc, bi, sm);
+    };
+    unsigned end = W > S ? W - S : 0, j = S;
+    for (; j + 16 <= end; j += 16) block(j);
+    if (j < end && end >= S + 16) { block(end - 16); j = end; }
+    return j;
+}
+
+// ---- plane driver: scalar mirror edges + SIMD interior ----
+
+enum class SqType { Byte, Word, Float, Half };
+
+template <SqType TY, unsigned N>
+void sq_plane(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const vs_generic_params &p, unsigned W, unsigned H)
+{
+    typedef typename std::conditional<TY == SqType::Float, float, typename std::conditional<TY == SqType::Byte, uint8_t, uint16_t>::type>::type T;
+    constexpr unsigned S = N / 2;
+    float32x4_t sc = vdupq_n_f32(p.div), bi = vdupq_n_f32(p.bias);
+    uint32x4_t sm = nc_satmask(p.saturate);
+    uint16x8_t mv = vdupq_n_u16(p.maxval);
+
+    for (unsigned i = 0; i < H; ++i) {
+        const T *rows[N];
+        for (unsigned r = 0; r < N; ++r)
+            rows[r] = reinterpret_cast<const T *>(static_cast<const unsigned char *>(src) +
+                static_cast<ptrdiff_t>(nc_mirror(static_cast<int>(i) + static_cast<int>(r) - static_cast<int>(S), static_cast<int>(H))) * ss);
+        T *d = reinterpret_cast<T *>(static_cast<unsigned char *>(dst) + static_cast<ptrdiff_t>(i) * ds);
+
+        unsigned aend;
+        if constexpr (TY == SqType::Byte)
+            aend = sq_interior_byte<N>(rows, d, S, W, p.matrix, sc, bi, sm);
+        else if constexpr (TY == SqType::Word) {
+            if constexpr (N > 7)
+                aend = sq_interior_word_i64<N>(rows, d, S, W, p.matrix, sc, bi, sm, mv);
+            else
+                aend = sq_interior_word_i32<N>(rows, d, S, W, p.matrix, sc, bi, sm, mv);
+        } else if constexpr (TY == SqType::Float)
+            aend = sq_interior_float<N>(rows, d, S, W, p.matrixf, sc, bi, sm);
+        else
+            aend = sq_interior_half<N>(rows, d, S, W, p.matrixf, sc, bi, sm);
+
+        auto scalar_px = [&](unsigned j) -> T {
+            if constexpr (TY == SqType::Byte)
+                return nc_sq_scalar_px<uint8_t, int32_t, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+            else if constexpr (TY == SqType::Word) {
+                typedef typename std::conditional<(N > 5), int64_t, int32_t>::type Acc;
+                return nc_sq_scalar_px<uint16_t, Acc, int16_t, N>(rows, j, S, W, p.matrix, p.div, p.bias, p.saturate, p.maxval);
+            } else if constexpr (TY == SqType::Float)
+                return nc_sq_scalar_px<float, float, float, N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate, p.maxval);
+            else
+                return nc_sq_scalar_px_half<N>(rows, j, S, W, p.matrixf, p.div, p.bias, p.saturate);
+        };
+
+        for (unsigned j = 0; j < S && j < W; ++j)
+            d[j] = scalar_px(j);
+        for (unsigned j = (aend > S ? aend : S); j < W; ++j)
+            d[j] = scalar_px(j);
+    }
+}
+
+} // namespace
+
+#define VS_SQUARE_NEON_ENTRY(SZ, N, TY, TN) \
+    void vs_generic_##SZ##_conv_##TN##_neon(const void *src, ptrdiff_t src_stride, void *dst, ptrdiff_t dst_stride, const struct vs_generic_params *params, unsigned width, unsigned height) \
+    { sq_plane<SqType::TY, N>(src, src_stride, dst, dst_stride, *params, width, height); }
+
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Byte,  byte)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Byte,  byte)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Byte,  byte)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Byte,  byte)
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Word,  word)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Word,  word)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Word,  word)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Word,  word)
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Float, float)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Float, float)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Float, float)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Float, float)
+VS_SQUARE_NEON_ENTRY(5x5,   5,  Half,  half)
+VS_SQUARE_NEON_ENTRY(7x7,   7,  Half,  half)
+VS_SQUARE_NEON_ENTRY(9x9,   9,  Half,  half)
+VS_SQUARE_NEON_ENTRY(11x11, 11, Half,  half)

--- a/src/core/kernel/cpulevel.cpp
+++ b/src/core/kernel/cpulevel.cpp
@@ -40,6 +40,9 @@ int vs_cpulevel_from_str(const char *name) {
         return VS_CPU_LEVEL_AVX2;
     else if (!strcmp(name, "avx512"))
         return VS_CPU_LEVEL_AVX512;
+#elif defined(VS_TARGET_CPU_ARM64)
+    else if (!strcmp(name, "neon"))
+        return VS_CPU_LEVEL_NEON;
 #endif
     else
         return VS_CPU_LEVEL_MAX;
@@ -55,6 +58,9 @@ const char *vs_cpulevel_to_str(int level) {
         return "avx2";
     else if (level <= VS_CPU_LEVEL_AVX512)
         return "avx512";
+#elif defined(VS_TARGET_CPU_ARM64)
+    else if (level <= VS_CPU_LEVEL_NEON)
+        return "neon";
 #endif
     else
         return "";

--- a/src/core/kernel/cpulevel.h
+++ b/src/core/kernel/cpulevel.h
@@ -33,6 +33,9 @@ enum {
     VS_CPU_LEVEL_SSE2 = 1,
     VS_CPU_LEVEL_AVX2 = 2,
     VS_CPU_LEVEL_AVX512 = 3,
+#elif defined(VS_TARGET_CPU_ARM64)
+    /* NEON is the AArch64 baseline. */
+    VS_CPU_LEVEL_NEON = 1,
 #endif
     VS_CPU_LEVEL_MAX = INT_MAX
 };

--- a/src/core/kernel/generic.h
+++ b/src/core/kernel/generic.h
@@ -316,6 +316,80 @@ DECL(11x11_conv, byte, avx512vnni)
 
 #endif /* VS_TARGET_CPU_X86 */
 
+#ifdef VS_TARGET_CPU_ARM64
+/* NEON baseline kernels: the whole convolution family (square 3x3..11x11,
+   1D horizontal/vertical, separable) for byte/word/float/half. Integer paths
+   are bit-exact with the C reference; float/half use FMA. */
+DECL_3x3(conv, byte, neon)
+DECL_3x3(conv, word, neon)
+/* 3x3 float: no NEON kernel -- loses to its autovectorised C tier at a full
+   thread pool on M4, so it is dispatched to C. */
+DECL_3x3(conv, half, neon)
+
+DECL(5x5_conv, byte, neon)
+DECL(7x7_conv, byte, neon)
+DECL(9x9_conv, byte, neon)
+DECL(11x11_conv, byte, neon)
+DECL(5x5_conv, word, neon)
+DECL(7x7_conv, word, neon)
+DECL(9x9_conv, word, neon)
+DECL(11x11_conv, word, neon)
+DECL(5x5_conv, float, neon)
+DECL(7x7_conv, float, neon)
+DECL(9x9_conv, float, neon)
+DECL(11x11_conv, float, neon)
+DECL(5x5_conv, half, neon)
+DECL(7x7_conv, half, neon)
+DECL(9x9_conv, half, neon)
+DECL(11x11_conv, half, neon)
+
+DECL(1d_conv_h, byte, neon)
+DECL(1d_conv_h, word, neon)
+DECL(1d_conv_h, float, neon)
+DECL(1d_conv_h, half, neon)
+
+DECL(1d_conv_v, byte, neon)
+DECL(1d_conv_v, word, neon)
+DECL(1d_conv_v, float, neon)
+DECL(1d_conv_v, half, neon)
+
+DECL(2d_conv_sep, byte, neon)
+DECL(2d_conv_sep, word, neon)
+DECL(2d_conv_sep, float, neon)
+DECL(2d_conv_sep, half, neon)
+
+#ifdef VS_TARGET_ARM_I8MM
+/* usdot byte square conv; valid only when every coefficient fits int8. */
+DECL_3x3(conv, byte, neon_dot)
+DECL(5x5_conv, byte, neon_dot)
+DECL(7x7_conv, byte, neon_dot)
+DECL(9x9_conv, byte, neon_dot)
+DECL(11x11_conv, byte, neon_dot)
+DECL(1d_conv_h, byte, neon_dot)
+/* Separable byte: vmlal vertical pass, usdot horizontal pass. Same int8
+   coefficient requirement as the rest of this block. */
+DECL(2d_conv_sep, byte, neon_dot)
+/* One horizontal scanline of the above, exported from the i8mm TU so the
+   separable driver (built without i8mm) can call it per row. */
+void vs_generic_1d_conv_h_byte_scanline_neon_dot(const void *srcp, void *dstp, const struct vs_generic_params *params, unsigned width);
+#endif /* VS_TARGET_ARM_I8MM */
+
+#ifdef VS_TARGET_ARM_FHM
+/* fmlal widening f16 MAC; valid only when coefficients are f16-exact (conv_f16). */
+DECL_3x3(conv, half, neon_fhm)
+DECL(5x5_conv, half, neon_fhm)
+DECL(7x7_conv, half, neon_fhm)
+DECL(9x9_conv, half, neon_fhm)
+DECL(11x11_conv, half, neon_fhm)
+DECL(1d_conv_h, half, neon_fhm)
+DECL(1d_conv_v, half, neon_fhm)
+/* Separable: both halves are half-format, so this drives its own row loop and
+   runs the vertical and horizontal passes on fmlal. */
+DECL(2d_conv_sep, half, neon_fhm)
+#endif /* VS_TARGET_ARM_FHM */
+
+#endif /* VS_TARGET_CPU_ARM64 */
+
 #undef DECL_3x3
 #undef DECL
 

--- a/src/core/lutfilters.cpp
+++ b/src/core/lutfilters.cpp
@@ -42,6 +42,9 @@ using namespace vsh;
 #ifdef VS_TARGET_CPU_X86
 void vs_lut1_b_b_avx512vbmi(const uint8_t *src, uint8_t *dst, int w, const uint8_t *lut);
 #endif
+#ifdef VS_TARGET_CPU_ARM64
+void vs_lut1_b_b_neon(const uint8_t *src, uint8_t *dst, int w, const uint8_t *lut);
+#endif
 
 namespace {
 
@@ -51,6 +54,7 @@ typedef struct LutDataExtra {
     void *lut;
     bool process[3];
     bool use_vbmi;
+    bool use_neon;
     ~LutDataExtra() { free(lut); };
 } LutDataExtra;
 
@@ -88,6 +92,18 @@ static const VSFrame *VS_CC lutGetframe(int n, int activationReason, void *insta
                     if (d->use_vbmi) {
                         for (int hl = 0; hl < h; hl++) {
                             vs_lut1_b_b_avx512vbmi(srcp, dstp, w, lut);
+                            dstp += dst_stride / sizeof(U);
+                            srcp += src_stride / sizeof(T);
+                        }
+                        continue; // plane done; skip the scalar fallback
+                    }
+                }
+#endif
+#ifdef VS_TARGET_CPU_ARM64
+                if constexpr (std::is_same_v<T, uint8_t> && std::is_same_v<U, uint8_t>) {
+                    if (d->use_neon) {
+                        for (int hl = 0; hl < h; hl++) {
+                            vs_lut1_b_b_neon(srcp, dstp, w, lut);
                             dstp += dst_stride / sizeof(U);
                             srcp += src_stride / sizeof(T);
                         }
@@ -303,9 +319,13 @@ static void VS_CC lutCreate(const VSMap *in, VSMap *out, void *userData, VSCore 
         vsapi->queryVideoFormat(&d->vi_out.format, d->vi->format.colorFamily, floatout ? stFloat : stInteger, bitsout, d->vi->format.subSamplingW, d->vi->format.subSamplingH, core);
 
         d->use_vbmi = false;
+        d->use_neon = false;
 #ifdef VS_TARGET_CPU_X86
         if (getCPUFeatures()->avx512_vbmi && vs_get_cpulevel(core) >= VS_CPU_LEVEL_AVX512)
             d->use_vbmi = true;
+#elif defined(VS_TARGET_CPU_ARM64)
+        if (vs_get_cpulevel(core) >= VS_CPU_LEVEL_NEON)
+            d->use_neon = true;
 #endif
 
         if (d->vi->format.bytesPerSample == 1 && bitsout == 8)
@@ -350,7 +370,7 @@ void vs_lut2_gather_bw_w_avx512(const uint8_t *, const uint16_t *, uint16_t *, i
 void vs_lut2_gather_bw_b_avx512(const uint8_t *, const uint16_t *, uint8_t *, int, const uint8_t *, int, unsigned, unsigned);
 #endif
 
-/* Dispatch one row to the AVX-512 gather kernel for the current type combo.
+/* Dispatch one row to the gather kernel for the current type combo.
    Returns false (compile-time) for combos without a kernel so the caller falls
    back to the scalar path; only ever called when d->use_gather is set. */
 template<typename T, typename U, typename V>


### PR DESCRIPTION
Introduces arm64/AArch64 NEON vector kernels for the generic convolution family and the byte LUT filter, dispatched by runtime CPU feature detection:

- NEON kernels: baseline arm64 kernels for convolution (separable, squares, 1D scanlines) and byte LUT, selected on all arm64 CPUs.
- usdot (FEAT_I8MM) byte square/horizontal/separable convolutions, used when every coefficient fits int8 (bit-exact with the baseline kernels).
- fmlal (FEAT_FHM) widening half-precision kernels, used when every coefficient survives f32->f16 narrowing exactly (bit-identical results, single f32 rounding per MAC).
- Build wiring (meson options, cpufeatures, cpulevel) and filter dispatch in genericfilters.cpp / lutfilters.cpp alongside the existing x86_64 kernels.

Every shipped kernel beats the C tier on the hardware it dispatches on; 3x3 float has no NEON kernel (it loses to its autovectorised C tier at a full thread pool on Apple Silicon) and dispatches to C. This is a deliberately NEON-only cut: no SVE or SME kernels are built or dispatched. Runtime detection of SVE/SVE2/SME stays in cpufeatures so wider-vector tiers can be added later without re-plumbing. Past winning SME and SVE (for 256-wide CPUs) kernels can be found in the PR this one supercedes: vapoursynth/vapoursynth#1238.

## Benchmarking

FPS with a streaming source (distinct frames sized past last-level cache, so source loads are real) at 1920x1080 and 3840x2160, single-thread and all-cores. NEON throughput is shown as a multiple of the C path. A blank NEON cell means no kernel dispatches for that shape (s3x3 float) and the filter runs the C tier. Main tables use int8-representable coefficients; the wide-coefficient tables at the end show the byte shapes whose usdot kernels decline and fall back to the plain NEON kernels.

An M4 Max was swept as well; its NEON-vs-C ratios match the M5 within noise on every shape (the same portability of ratios @myrsloik observed between the M2 Pro and M4 on the earlier attempt), so only the M5 tables are shown for Apple Silicon.

### Apple M5 (MacBook Pro, 10 cores)
#### 1080p, single thread
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 1018.1 | 2908.4 | 2.86x |
| s3x3 | word | 962.7 | 1684.5 | 1.75x |
| s3x3 | half | 1549.2 | 2388.1 | 1.54x |
| s3x3 | float | 1806.9 |  |  |
| s5x5 | byte | 310.8 | 1440.0 | 4.63x |
| s5x5 | word | 300.1 | 644.4 | 2.15x |
| s5x5 | half | 416.4 | 656.4 | 1.58x |
| s5x5 | float | 461.0 | 683.7 | 1.48x |
| s7x7 | byte | 135.3 | 1063.5 | 7.86x |
| s7x7 | word | 52.3 | 326.1 | 6.24x |
| s7x7 | half | 142.8 | 281.2 | 1.97x |
| s7x7 | float | 159.1 | 299.1 | 1.88x |
| s9x9 | byte | 132.7 | 522.1 | 3.93x |
| s9x9 | word | 49.0 | 204.0 | 4.16x |
| s9x9 | half | 115.4 | 157.8 | 1.37x |
| s9x9 | float | 113.8 | 167.3 | 1.47x |
| s11x11 | byte | 89.5 | 422.6 | 4.72x |
| s11x11 | word | 33.4 | 128.7 | 3.85x |
| s11x11 | half | 64.7 | 101.2 | 1.56x |
| s11x11 | float | 75.8 | 109.8 | 1.45x |
| h25 | byte | 181.5 | 908.4 | 5.00x |
| h25 | word | 179.9 | 599.0 | 3.33x |
| h25 | half | 132.8 | 661.5 | 4.98x |
| h25 | float | 157.8 | 692.5 | 4.39x |
| v25 | byte | 81.1 | 659.7 | 8.13x |
| v25 | word | 73.0 | 580.2 | 7.95x |
| v25 | half | 69.8 | 683.1 | 9.79x |
| v25 | float | 70.1 | 528.7 | 7.54x |
| hv9 | byte | 128.7 | 915.5 | 7.11x |
| hv9 | word | 122.0 | 808.1 | 6.62x |
| hv9 | half | 122.5 | 1114.8 | 9.10x |
| hv9 | float | 117.8 | 959.7 | 8.15x |
| lut | byte | 2962.0 | 6807.4 | 2.30x |

#### 1080p, all cores (10 threads)
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 5968.5 | 17262.5 | 2.89x |
| s3x3 | word | 5712.9 | 9829.0 | 1.72x |
| s3x3 | half | 8914.8 | 10752.8 | 1.21x |
| s3x3 | float | 7177.1 |  |  |
| s5x5 | byte | 1865.5 | 8652.6 | 4.64x |
| s5x5 | word | 1809.2 | 3947.8 | 2.18x |
| s5x5 | half | 2134.4 | 3903.5 | 1.83x |
| s5x5 | float | 2827.4 | 4220.8 | 1.49x |
| s7x7 | byte | 811.1 | 6471.7 | 7.98x |
| s7x7 | word | 334.4 | 2007.0 | 6.00x |
| s7x7 | half | 839.4 | 1730.4 | 2.06x |
| s7x7 | float | 973.0 | 1841.8 | 1.89x |
| s9x9 | byte | 877.7 | 3207.2 | 3.65x |
| s9x9 | word | 260.1 | 1172.6 | 4.51x |
| s9x9 | half | 734.7 | 984.8 | 1.34x |
| s9x9 | float | 696.5 | 1031.1 | 1.48x |
| s11x11 | byte | 606.3 | 2555.6 | 4.22x |
| s11x11 | word | 174.8 | 765.0 | 4.38x |
| s11x11 | half | 359.0 | 639.3 | 1.78x |
| s11x11 | float | 465.6 | 680.4 | 1.46x |
| h25 | byte | 1106.6 | 5386.3 | 4.87x |
| h25 | word | 983.6 | 3452.5 | 3.51x |
| h25 | half | 716.3 | 3836.8 | 5.36x |
| h25 | float | 848.7 | 4050.6 | 4.77x |
| v25 | byte | 473.0 | 3907.0 | 8.26x |
| v25 | word | 436.3 | 3222.9 | 7.39x |
| v25 | half | 415.5 | 3672.9 | 8.84x |
| v25 | float | 410.9 | 2474.5 | 6.02x |
| hv9 | byte | 741.0 | 5447.1 | 7.35x |
| hv9 | word | 695.8 | 4569.5 | 6.57x |
| hv9 | half | 727.0 | 6303.4 | 8.67x |
| hv9 | float | 730.1 | 4570.5 | 6.26x |
| lut | byte | 17256.9 | 27860.1 | 1.61x |

#### UHD (3840x2160), single thread
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 241.2 | 709.2 | 2.94x |
| s3x3 | word | 234.4 | 412.7 | 1.76x |
| s3x3 | half | 377.4 | 582.1 | 1.54x |
| s3x3 | float | 462.4 |  |  |
| s5x5 | byte | 73.0 | 359.5 | 4.92x |
| s5x5 | word | 71.5 | 157.8 | 2.21x |
| s5x5 | half | 99.7 | 160.9 | 1.61x |
| s5x5 | float | 113.6 | 169.6 | 1.49x |
| s7x7 | byte | 32.4 | 270.8 | 8.36x |
| s7x7 | word | 12.9 | 81.1 | 6.29x |
| s7x7 | half | 34.6 | 69.3 | 2.00x |
| s7x7 | float | 38.9 | 74.4 | 1.91x |
| s9x9 | byte | 32.5 | 137.4 | 4.23x |
| s9x9 | word | 12.2 | 51.6 | 4.23x |
| s9x9 | half | 29.5 | 39.3 | 1.33x |
| s9x9 | float | 29.0 | 41.5 | 1.43x |
| s11x11 | byte | 22.1 | 109.8 | 4.97x |
| s11x11 | word | 8.4 | 35.2 | 4.19x |
| s11x11 | half | 16.5 | 25.5 | 1.55x |
| s11x11 | float | 19.4 | 27.6 | 1.42x |
| h25 | byte | 46.2 | 264.0 | 5.71x |
| h25 | word | 45.8 | 160.7 | 3.51x |
| h25 | half | 33.6 | 179.4 | 5.34x |
| h25 | float | 40.0 | 186.1 | 4.65x |
| v25 | byte | 18.0 | 168.1 | 9.34x |
| v25 | word | 18.3 | 148.7 | 8.13x |
| v25 | half | 17.6 | 173.0 | 9.83x |
| v25 | float | 17.5 | 129.6 | 7.41x |
| hv9 | byte | 30.6 | 236.5 | 7.73x |
| hv9 | word | 30.4 | 208.4 | 6.86x |
| hv9 | half | 30.9 | 288.9 | 9.35x |
| hv9 | float | 29.2 | 235.6 | 8.07x |
| lut | byte | 756.3 | 1770.9 | 2.34x |

#### UHD (3840x2160), all cores (10 threads)
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 1454.2 | 4305.9 | 2.96x |
| s3x3 | word | 1406.6 | 2354.7 | 1.67x |
| s3x3 | half | 2095.1 | 2694.0 | 1.29x |
| s3x3 | float | 1757.3 |  |  |
| s5x5 | byte | 443.0 | 2218.7 | 5.01x |
| s5x5 | word | 426.2 | 967.1 | 2.27x |
| s5x5 | half | 516.0 | 961.9 | 1.86x |
| s5x5 | float | 679.6 | 1043.5 | 1.54x |
| s7x7 | byte | 195.4 | 1624.7 | 8.31x |
| s7x7 | word | 81.9 | 487.7 | 5.95x |
| s7x7 | half | 203.8 | 427.8 | 2.10x |
| s7x7 | float | 235.1 | 443.8 | 1.89x |
| s9x9 | byte | 217.1 | 799.0 | 3.68x |
| s9x9 | word | 63.8 | 290.6 | 4.55x |
| s9x9 | half | 184.2 | 247.8 | 1.35x |
| s9x9 | float | 174.6 | 259.8 | 1.49x |
| s11x11 | byte | 155.0 | 644.7 | 4.16x |
| s11x11 | word | 43.6 | 197.8 | 4.54x |
| s11x11 | half | 92.0 | 161.1 | 1.75x |
| s11x11 | float | 119.3 | 168.4 | 1.41x |
| h25 | byte | 278.9 | 1551.4 | 5.56x |
| h25 | word | 248.2 | 896.7 | 3.61x |
| h25 | half | 177.5 | 1003.2 | 5.65x |
| h25 | float | 210.4 | 1059.6 | 5.04x |
| v25 | byte | 108.8 | 929.0 | 8.54x |
| v25 | word | 109.3 | 766.2 | 7.01x |
| v25 | half | 101.3 | 861.9 | 8.51x |
| v25 | float | 100.1 | 574.2 | 5.74x |
| hv9 | byte | 179.2 | 1379.2 | 7.70x |
| hv9 | word | 171.6 | 1118.9 | 6.52x |
| hv9 | half | 173.9 | 1567.4 | 9.01x |
| hv9 | float | 176.3 | 1079.3 | 6.12x |
| lut | byte | 4558.0 | 7349.4 | 1.61x |

Wide-coefficient byte squares and horizontal 1D (coefficients past int8,
so the usdot kernels decline and the plain NEON kernels dispatch):

_1080p, single thread:_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 1014.1 | 1772.5 | 1.75x |
| s5x5 | byte | 309.7 | 691.8 | 2.23x |
| s7x7 | byte | 135.0 | 333.7 | 2.47x |
| s9x9 | byte | 132.2 | 186.8 | 1.41x |
| s11x11 | byte | 89.5 | 124.5 | 1.39x |
| h25 | byte | 181.5 | 582.8 | 3.21x |
| hv9 | byte | 128.7 | 834.5 | 6.48x |

_1080p, all cores (10 threads):_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 5982.9 | 10728.8 | 1.79x |
| s5x5 | byte | 1872.4 | 4148.9 | 2.22x |
| s7x7 | byte | 813.7 | 2054.2 | 2.52x |
| s9x9 | byte | 871.7 | 1191.1 | 1.37x |
| s11x11 | byte | 609.0 | 792.4 | 1.30x |
| h25 | byte | 1107.1 | 3415.9 | 3.09x |
| hv9 | byte | 731.1 | 4968.3 | 6.80x |

_UHD (3840x2160), single thread:_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 241.0 | 426.2 | 1.77x |
| s5x5 | byte | 73.0 | 167.4 | 2.29x |
| s7x7 | byte | 32.5 | 81.6 | 2.51x |
| s9x9 | byte | 32.5 | 45.3 | 1.39x |
| s11x11 | byte | 22.1 | 30.7 | 1.39x |
| h25 | byte | 46.2 | 156.7 | 3.39x |
| hv9 | byte | 30.5 | 210.9 | 6.91x |

_UHD (3840x2160), all cores (10 threads):_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 1454.3 | 2658.3 | 1.83x |
| s5x5 | byte | 453.8 | 1021.0 | 2.25x |
| s7x7 | byte | 197.2 | 510.7 | 2.59x |
| s9x9 | byte | 215.7 | 294.1 | 1.36x |
| s11x11 | byte | 154.1 | 200.5 | 1.30x |
| h25 | byte | 281.2 | 911.0 | 3.24x |
| hv9 | byte | 176.9 | 1190.4 | 6.73x |


### AWS Graviton5 (c9g.4xlarge, Neoverse-V3, 16 vCPU)
#### 1080p, single thread
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 90.6 | 1272.7 | 14.05x |
| s3x3 | word | 91.2 | 681.3 | 7.47x |
| s3x3 | half | 212.6 | 1145.7 | 5.39x |
| s3x3 | float | 1139.4 |  |  |
| s5x5 | byte | 32.5 | 673.4 | 20.72x |
| s5x5 | word | 33.2 | 335.8 | 10.11x |
| s5x5 | half | 76.8 | 383.8 | 5.00x |
| s5x5 | float | 267.8 | 438.5 | 1.64x |
| s7x7 | byte | 22.5 | 398.0 | 17.69x |
| s7x7 | word | 21.5 | 185.3 | 8.62x |
| s7x7 | half | 31.1 | 220.0 | 7.07x |
| s7x7 | float | 38.8 | 249.0 | 6.42x |
| s9x9 | byte | 12.6 | 252.1 | 20.01x |
| s9x9 | word | 12.6 | 87.0 | 6.90x |
| s9x9 | half | 24.2 | 136.2 | 5.63x |
| s9x9 | float | 49.7 | 146.5 | 2.95x |
| s11x11 | byte | 13.9 | 200.9 | 14.45x |
| s11x11 | word | 14.1 | 65.6 | 4.65x |
| s11x11 | half | 16.9 | 72.7 | 4.30x |
| s11x11 | float | 34.7 | 96.5 | 2.78x |
| h25 | byte | 31.8 | 568.8 | 17.89x |
| h25 | word | 24.4 | 268.7 | 11.01x |
| h25 | half | 50.0 | 406.1 | 8.12x |
| h25 | float | 55.6 | 422.4 | 7.60x |
| v25 | byte | 26.3 | 301.4 | 11.46x |
| v25 | word | 26.5 | 237.1 | 8.95x |
| v25 | half | 45.7 | 273.0 | 5.97x |
| v25 | float | 44.3 | 185.3 | 4.18x |
| hv9 | byte | 32.8 | 460.0 | 14.02x |
| hv9 | word | 26.6 | 366.9 | 13.79x |
| hv9 | half | 63.7 | 546.3 | 8.58x |
| hv9 | float | 64.9 | 507.4 | 7.82x |
| lut | byte | 2128.4 | 4491.2 | 2.11x |

#### 1080p, all cores (16 threads)
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 1355.1 | 17163.9 | 12.67x |
| s3x3 | word | 1356.5 | 9591.8 | 7.07x |
| s3x3 | half | 3111.5 | 13821.4 | 4.44x |
| s3x3 | float | 9480.9 |  |  |
| s5x5 | byte | 486.8 | 9774.0 | 20.08x |
| s5x5 | word | 496.1 | 4924.0 | 9.93x |
| s5x5 | half | 1146.0 | 5602.9 | 4.89x |
| s5x5 | float | 3904.7 | 5705.9 | 1.46x |
| s7x7 | byte | 336.4 | 5629.5 | 16.73x |
| s7x7 | word | 320.7 | 2753.6 | 8.59x |
| s7x7 | half | 463.3 | 3272.6 | 7.06x |
| s7x7 | float | 579.0 | 3644.8 | 6.29x |
| s9x9 | byte | 189.2 | 3746.0 | 19.80x |
| s9x9 | word | 188.8 | 1295.2 | 6.86x |
| s9x9 | half | 360.5 | 2025.0 | 5.62x |
| s9x9 | float | 742.8 | 2173.1 | 2.93x |
| s11x11 | byte | 207.6 | 3009.9 | 14.50x |
| s11x11 | word | 211.9 | 980.0 | 4.62x |
| s11x11 | half | 253.5 | 1086.3 | 4.29x |
| s11x11 | float | 519.7 | 1435.5 | 2.76x |
| h25 | byte | 481.1 | 8306.7 | 17.27x |
| h25 | word | 364.6 | 3969.3 | 10.89x |
| h25 | half | 722.4 | 5927.3 | 8.21x |
| h25 | float | 744.9 | 5783.2 | 7.76x |
| v25 | byte | 395.1 | 4458.1 | 11.28x |
| v25 | word | 396.9 | 3450.9 | 8.69x |
| v25 | half | 667.6 | 3872.9 | 5.80x |
| v25 | float | 665.1 | 2516.8 | 3.78x |
| hv9 | byte | 488.7 | 6615.6 | 13.54x |
| hv9 | word | 398.9 | 5377.5 | 13.48x |
| hv9 | half | 901.5 | 7814.4 | 8.67x |
| hv9 | float | 974.0 | 5662.7 | 5.81x |
| lut | byte | 28304.7 | 41590.1 | 1.47x |

#### UHD (3840x2160), single thread
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 22.8 | 326.1 | 14.30x |
| s3x3 | word | 22.8 | 172.8 | 7.58x |
| s3x3 | half | 53.4 | 291.8 | 5.46x |
| s3x3 | float | 279.9 |  |  |
| s5x5 | byte | 8.2 | 178.9 | 21.82x |
| s5x5 | word | 8.3 | 85.5 | 10.30x |
| s5x5 | half | 19.2 | 97.0 | 5.05x |
| s5x5 | float | 67.4 | 109.7 | 1.63x |
| s7x7 | byte | 5.6 | 103.8 | 18.54x |
| s7x7 | word | 5.4 | 47.3 | 8.76x |
| s7x7 | half | 7.8 | 56.1 | 7.19x |
| s7x7 | float | 9.7 | 61.5 | 6.34x |
| s9x9 | byte | 3.2 | 67.3 | 21.03x |
| s9x9 | word | 3.2 | 22.1 | 6.91x |
| s9x9 | half | 6.2 | 34.9 | 5.63x |
| s9x9 | float | 12.5 | 37.6 | 3.01x |
| s11x11 | byte | 3.5 | 54.0 | 15.43x |
| s11x11 | word | 3.5 | 16.7 | 4.77x |
| s11x11 | half | 4.2 | 18.6 | 4.43x |
| s11x11 | float | 8.7 | 24.9 | 2.86x |
| h25 | byte | 8.1 | 174.0 | 21.48x |
| h25 | word | 6.1 | 74.5 | 12.21x |
| h25 | half | 12.6 | 112.4 | 8.92x |
| h25 | float | 14.0 | 118.7 | 8.48x |
| v25 | byte | 6.6 | 69.9 | 10.59x |
| v25 | word | 6.7 | 63.2 | 9.43x |
| v25 | half | 11.6 | 76.5 | 6.59x |
| v25 | float | 11.7 | 68.1 | 5.82x |
| hv9 | byte | 8.1 | 119.5 | 14.75x |
| hv9 | word | 6.7 | 95.0 | 14.18x |
| hv9 | half | 15.7 | 133.6 | 8.51x |
| hv9 | float | 14.5 | 133.9 | 9.23x |
| lut | byte | 545.2 | 1183.8 | 2.17x |

#### UHD (3840x2160), all cores (16 threads)
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 283.9 | 3957.9 | 13.94x |
| s3x3 | word | 285.1 | 2111.2 | 7.41x |
| s3x3 | half | 657.8 | 3354.9 | 5.10x |
| s3x3 | float | 1997.2 |  |  |
| s5x5 | byte | 101.8 | 2207.9 | 21.69x |
| s5x5 | word | 103.5 | 1061.6 | 10.26x |
| s5x5 | half | 239.5 | 1203.0 | 5.02x |
| s5x5 | float | 800.4 | 1197.3 | 1.50x |
| s7x7 | byte | 70.2 | 1291.2 | 18.39x |
| s7x7 | word | 67.1 | 588.7 | 8.77x |
| s7x7 | half | 96.9 | 697.4 | 7.20x |
| s7x7 | float | 121.0 | 757.9 | 6.26x |
| s9x9 | byte | 39.5 | 837.8 | 21.21x |
| s9x9 | word | 39.7 | 275.1 | 6.93x |
| s9x9 | half | 77.4 | 434.4 | 5.61x |
| s9x9 | float | 155.7 | 467.9 | 3.01x |
| s11x11 | byte | 43.8 | 676.8 | 15.45x |
| s11x11 | word | 44.4 | 208.7 | 4.70x |
| s11x11 | half | 53.1 | 232.4 | 4.38x |
| s11x11 | float | 108.3 | 311.2 | 2.87x |
| h25 | byte | 100.9 | 2157.6 | 21.38x |
| h25 | word | 76.3 | 927.7 | 12.16x |
| h25 | half | 156.2 | 1390.2 | 8.90x |
| h25 | float | 174.9 | 1303.0 | 7.45x |
| v25 | byte | 82.4 | 873.5 | 10.60x |
| v25 | word | 84.2 | 785.1 | 9.32x |
| v25 | half | 143.4 | 937.5 | 6.54x |
| v25 | float | 147.4 | 819.4 | 5.56x |
| hv9 | byte | 101.6 | 1484.2 | 14.61x |
| hv9 | word | 83.9 | 1176.5 | 14.02x |
| hv9 | half | 195.9 | 1639.4 | 8.37x |
| hv9 | float | 209.5 | 1358.9 | 6.49x |
| lut | byte | 5915.0 | 10066.4 | 1.70x |

Wide-coefficient byte squares and horizontal 1D (coefficients past int8,
so the usdot kernels decline and the plain NEON kernels dispatch):

_1080p, single thread:_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 116.7 | 743.4 | 6.37x |
| s5x5 | byte | 36.1 | 340.4 | 9.43x |
| s7x7 | byte | 21.3 | 180.1 | 8.46x |
| s9x9 | byte | 12.3 | 109.6 | 8.91x |
| s11x11 | byte | 14.2 | 76.0 | 5.35x |
| h25 | byte | 34.9 | 286.5 | 8.21x |
| hv9 | byte | 41.0 | 396.8 | 9.68x |

_1080p, all cores (16 threads):_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 1743.6 | 10927.9 | 6.27x |
| s5x5 | byte | 540.2 | 5051.9 | 9.35x |
| s7x7 | byte | 318.0 | 2686.1 | 8.45x |
| s9x9 | byte | 184.9 | 1636.6 | 8.85x |
| s11x11 | byte | 212.5 | 1135.9 | 5.35x |
| h25 | byte | 520.0 | 4210.4 | 8.10x |
| hv9 | byte | 613.4 | 5866.6 | 9.56x |

_UHD (3840x2160), single thread:_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 29.3 | 188.0 | 6.42x |
| s5x5 | byte | 9.0 | 86.6 | 9.62x |
| s7x7 | byte | 5.3 | 45.8 | 8.64x |
| s9x9 | byte | 3.1 | 28.0 | 9.03x |
| s11x11 | byte | 3.6 | 19.5 | 5.42x |
| h25 | byte | 8.7 | 77.8 | 8.94x |
| hv9 | byte | 10.2 | 101.3 | 9.93x |

_UHD (3840x2160), all cores (16 threads):_
| case | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| s3x3 | byte | 365.4 | 2336.4 | 6.39x |
| s5x5 | byte | 112.9 | 1078.5 | 9.55x |
| s7x7 | byte | 66.4 | 571.0 | 8.60x |
| s9x9 | byte | 38.6 | 349.7 | 9.06x |
| s11x11 | byte | 44.8 | 243.3 | 5.43x |
| h25 | byte | 109.4 | 967.4 | 8.84x |
| hv9 | byte | 127.4 | 1259.2 | 9.88x |

An x86_64 build of this branch was A/B'd against its parent commit; no change outside arm64.

## Numerical Accuracy Audit

Max |err| of each SIMD tier vs the C reference, relative to accumulation magnitude for float/half. The differing cells between machines (s3x3/h25/hv9 tails) track compiler FMA contraction in the C reference (clang on the Macs, gcc on Graviton), the same split the earlier audit showed.

Integer paths (convolution + lut) are bit-exact on every machine and tier

| fmt | shape | coeff | x86:sse2 | x86:avx2 | x86:avx512 | M4:neon | M5:neon | G5:neon |
|---|---|---|---|---|---|---|---|---|
| half | s3x3 | f16 | 0 | 2.73e-04 | 2.73e-04 | 0 | 0 | 0 |
| half | s3x3 | arb | 0 | 1.37e-04 | 1.37e-04 | 0 | 0 | 1.37e-04 |
| half | s5x5 | f16 | 0 | 0 | 0 | 5.66e-05 | 5.66e-05 | 5.66e-05 |
| half | s5x5 | arb | 0 | 0 | 0 | 1.13e-04 | 1.13e-04 | 1.13e-04 |
| half | s7x7 | f16 | 0 | 0 | 0 | 7.29e-05 | 7.29e-05 | 7.29e-05 |
| half | s7x7 | arb | 0 | 0 | 0 | 7.29e-05 | 7.29e-05 | 7.29e-05 |
| half | s9x9 | f16 | 0 | 0 | 0 | 1.09e-04 | 1.09e-04 | 1.09e-04 |
| half | s9x9 | arb | 0 | 0 | 0 | 5.44e-05 | 5.44e-05 | 5.44e-05 |
| half | s11x11 | f16 | 0 | 0 | 0 | 6.68e-05 | 6.68e-05 | 6.68e-05 |
| half | s11x11 | arb | 0 | 0 | 0 | 6.68e-05 | 6.68e-05 | 6.68e-05 |
| half | h25 | f16 | 0 | 0 | 0 | 0 | 0 | 0 |
| half | h25 | arb | 0 | 0 | 0 | 5.66e-05 | 5.66e-05 | 0 |
| half | v25 | f16 | 0 | 0 | 0 | 0 | 0 | 0 |
| half | v25 | arb | 0 | 0 | 0 | 0 | 0 | 0 |
| half | hv9 | f16 | 0 | 0 | 0 | 0 | 0 | 0 |
| half | hv9 | arb | 0 | 0 | 0 | 1.37e-04 | 1.37e-04 | 0 |
| float | s3x3 | f16 | 1.00e-07 | 1.00e-07 | 1.00e-07 | 0 | 0 | 0 |
| float | s3x3 | arb | 1.00e-07 | 1.00e-07 | 1.00e-07 | 0 | 0 | 0 |
| float | s5x5 | f16 | 0 | 6.91e-08 | 6.91e-08 | 6.91e-08 | 6.91e-08 | 6.91e-08 |
| float | s5x5 | arb | 0 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 5.53e-08 |
| float | s7x7 | f16 | 0 | 8.90e-08 | 8.90e-08 | 8.90e-08 | 8.90e-08 | 8.90e-08 |
| float | s7x7 | arb | 0 | 8.90e-08 | 8.90e-08 | 7.12e-08 | 7.12e-08 | 7.12e-08 |
| float | s9x9 | f16 | 0 | 8.64e-08 | 8.64e-08 | 8.64e-08 | 8.64e-08 | 8.64e-08 |
| float | s9x9 | arb | 0 | 7.97e-08 | 7.97e-08 | 7.97e-08 | 7.97e-08 | 7.97e-08 |
| float | s11x11 | f16 | 0 | 8.15e-08 | 8.15e-08 | 8.15e-08 | 8.15e-08 | 8.15e-08 |
| float | s11x11 | arb | 0 | 7.33e-08 | 7.33e-08 | 7.33e-08 | 7.33e-08 | 7.33e-08 |
| float | h25 | f16 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 0 |
| float | h25 | arb | 6.22e-08 | 6.22e-08 | 6.22e-08 | 5.53e-08 | 5.53e-08 | 0 |
| float | v25 | f16 | 5.53e-08 | 5.53e-08 | 5.53e-08 | 0 | 0 | 0 |
| float | v25 | arb | 6.91e-08 | 6.91e-08 | 6.91e-08 | 0 | 0 | 0 |
| float | hv9 | f16 | 1.33e-07 | 1.33e-07 | 1.33e-07 | 8.34e-08 | 8.34e-08 | 0 |
| float | hv9 | arb | 1.33e-07 | 1.33e-07 | 1.00e-07 | 1.00e-07 | 1.00e-07 | 0 |

A `0` can mean the tier has no kernel for that shape and fell back to C.

[convolution_accuracy.py](https://github.com/user-attachments/files/30216695/convolution_accuracy.py)  
[convolution_benchmark.py](https://github.com/user-attachments/files/30216700/convolution_benchmark.py)


To reproduce:
```sh
python convolution_benchmark.py --sweep --preset 1080p --threads 1  --frames 150
python convolution_benchmark.py --sweep --preset 1080p --threads 16 --frames 150 --reps 5
python convolution_benchmark.py --sweep --preset uhd   --threads 1  --frames 50
python convolution_benchmark.py --sweep --preset uhd   --threads 16 --frames 50  --reps 5
python convolution_accuracy.py --levels neon
```