### PR TITLE
Use roundevenf for std.AverageFrames rounding on arm64 

### DIFF
--- a/src/core/averageframesfilter.cpp
+++ b/src/core/averageframesfilter.cpp
@@ -46,7 +46,14 @@ namespace {
 // Round to nearest, ties to even (matches SSE cvtps_epi32).
 static inline int32_t round_nearest_i32(float x)
 {
+#if defined(__aarch64__)
+    // lrintf returns long, so the vectorizer widens through f64 (frintx + fcvtl +
+    // fcvtzs.2d + repack per half). roundevenf keeps 32-bit lanes (frintn + fcvtzs)
+    // and gives the same ties-to-even result independent of the rounding mode.
+    return static_cast<int32_t>(__builtin_roundevenf(x));
+#else
     return static_cast<int32_t>(std::lrintf(x));
+#endif
 }
 
 template <class T, unsigned N>


### PR DESCRIPTION
When @Myrsloik reworked `std.AverageFrames` into autovectorizer-friendly C (42aacd61), the bet paid off on x86 because `lrintf` lowers to a single `cvtps2dq`. On arm64, `lrintf` returns `long`, so the 64-bit result type poisons the vectorized rounding step:
- clang vectorizes the integer paths but rounds through f64: `frintx.2s` + `fcvtl` + `fcvtzs.2d` + `uzp1` repack, roughly 7 instructions per 4 pixels for what should be one convert.
- gcc 13 has no vector lowering for `lrintf` on AArch64 at all, so the u8/u16 loops never vectorize and run fully scalar.

This change makes `round_nearest_i32` use `(int32_t)__builtin_roundevenf(x)` under `#if defined(__aarch64__)`. clang then emits `frintn.4s` + `fcvtzs.4s`, and gcc fuses further to a single `fcvtns` and finally vectorizes the loops.

**Output is bit-identical.** `roundevenf` is round-to-nearest, ties-to-even, which is exactly what `lrintf` produces under the default rounding mode (and what SSE `cvtps_epi32` does on x86). Verified empirically on both compilers: 13 dump cases (u8, u16, 10-bit, YUV chroma bias path, half, float, negative weights, explicit non-integral scale) are byte-exact between baseline and patched builds on Apple M4 Max (clang) and Graviton5/Neoverse-V3 (gcc 13.3).

Measured with an interleaved A/B at 1080p, 240 frames per case, median of 3 runs, single thread (fps):

| case | M4 base | M4 patched | ratio | G5 base | G5 patched | ratio |
| --- | --- | --- | --- | --- | --- | --- |
| u8 n=3 [1,2,1] | 1439 | 1919 | 1.33x | 441 | 938 | 2.12x |
| u8 n=5 binomial | 1143 | 1433 | 1.25x | 278 | 724 | 2.61x |
| u8 n=7 flat | 935 | 1124 | 1.20x | 205 | 557 | 2.72x |
| u16 n=3 [1,2,1] | 1419 | 1923 | 1.36x | 437 | 965 | 2.21x |
| 10-bit n=5 | 1132 | 1413 | 1.25x | 297 | 748 | 2.52x |
| YUV420P8 n=3 | 944 | 1261 | 1.34x | 290 | 624 | 2.15x |
| float n=5 (control) | 2273 | 2300 | 1.01x | 882 | 862 | 0.98x |

The gains hold at full thread pools (+18-32% on a 16-core M4 Max). The 15-tap flat cases sit at parity (load-bound on 15 source planes), and the float and half paths are untouched; they already vectorize cleanly.

Toolchain coverage:
- MSVC `cl.exe` defines `_M_ARM64` but never `__aarch64__`, so it keeps the `lrintf` path and compiles unchanged.
- clang-cl targeting ARM64 defines both macros and has the builtin (verified: it lowers inline to `frintn` for `aarch64-pc-windows-msvc`), so Windows ARM64 clang-cl builds get the fast path.
- `__builtin_roundevenf` is available in gcc 10+ and all clangs that target AArch64, and `__aarch64__` is only ever defined by GNU-style compilers.
- x86 codegen is untouched by construction.

The `linux_aarch64` and `macosx_arm64` CI jobs compile and test this path.