### PR TITLE
Add Neon-tier arm64 kernels for the 3x3 neighborhood family

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -440,6 +440,7 @@ else
         # NEON is the AArch64 baseline; its kernels ride with the plugin proper.
         arm_filter_sources += files(
             'src/core/kernel/arm/convolution_neon.cpp',
+            'src/core/kernel/arm/generic_neon.cpp',
             'src/core/kernel/arm/lut_neon.cpp',
             'src/core/kernel/arm/square_neon.cpp',
         )
@@ -468,7 +469,8 @@ else
             # LTO build. Only f16 h25 gives up ~3% because they're
             # self-contained with header inlines as helpers.
             arm_vlibs += static_library('vsfilters_fhm',
-                files('src/core/kernel/arm/convolution_fhm_neon.cpp'),
+                files('src/core/kernel/arm/convolution_fhm_neon.cpp',
+                      'src/core/kernel/arm/generic_fp16_neon.cpp'),
                 cpp_args: arm_fhm_args,
                 gnu_symbol_visibility: 'hidden',
                 include_directories: incdir,

--- a/msvc_project/CoreFilters/CoreFilters.vcxproj
+++ b/msvc_project/CoreFilters/CoreFilters.vcxproj
@@ -164,7 +164,7 @@
     <ClInclude Include="..\..\src\core\kernel\planestats.h" />
     <ClInclude Include="..\..\src\core\kernel\transpose.h" />
     <ClInclude Include="..\..\src\core\kernel\x86\convolution_impl.h" />
-    <ClInclude Include="..\..\src\core\kernel\x86\generic_impl.h" />
+    <ClInclude Include="..\..\src\core\kernel\generic_impl.h" />
     <ClInclude Include="..\..\src\core\kernel\x86\square_impl.h" />
     <ClInclude Include="..\..\src\core\kernel\x86\square_vnni_impl.h" />
   </ItemGroup>

--- a/msvc_project/CoreFilters/CoreFilters.vcxproj.filters
+++ b/msvc_project/CoreFilters/CoreFilters.vcxproj.filters
@@ -149,7 +149,7 @@
     <ClInclude Include="..\..\src\core\kernel\x86\convolution_impl.h">
       <Filter>Header Files\kernel</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\core\kernel\x86\generic_impl.h">
+    <ClInclude Include="..\..\src\core\kernel\generic_impl.h">
       <Filter>Header Files\kernel</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\core\kernel\merge.h">

--- a/src/core/genericfilters.cpp
+++ b/src/core/genericfilters.cpp
@@ -548,10 +548,81 @@ static bool convByteDot(const GenericData *d) {
 static bool convByteDot(const GenericData *) { return false; }
 #endif
 
-// Only the convolution family has hand-written ARM kernels; every other op
-// falls through to the (auto-vectorised) C tier.
+// The convolution family has hand-written ARM kernels; the rest of the 3x3
+// neighborhood family comes from the generic_impl.h Backend instantiation in
+// generic_neon.cpp (fixed-stencil min/max specialisation happens inside those
+// entry points, keyed on params.stencil, exactly like x86).
 template <GenericOperations op>
 static decltype(&vs_generic_3x3_conv_byte_c) genericSelectNEON(const VSVideoFormat *fi, GenericData *d) {
+    if (fi->sampleType == stInteger && fi->bytesPerSample == 1) {
+        switch (op) {
+        case GenericPrewitt: return vs_generic_3x3_prewitt_byte_neon;
+        case GenericSobel: return vs_generic_3x3_sobel_byte_neon;
+        case GenericMinimum: return vs_generic_3x3_min_byte_neon;
+        case GenericMaximum: return vs_generic_3x3_max_byte_neon;
+        case GenericMedian: return vs_generic_3x3_median_byte_neon;
+        // Deflate/Inflate stay on the plain NEON kernels: a usdot ones-matrix
+        // variant won +3-17% at a full pool on M4 but regressed inflate 6-8%
+        // on Neoverse-V3/gcc, so it does not replace a kernel that wins on
+        // both.
+        case GenericDeflate: return vs_generic_3x3_deflate_byte_neon;
+        case GenericInflate: return vs_generic_3x3_inflate_byte_neon;
+        default: break;
+        }
+    } else if (fi->sampleType == stInteger && fi->bytesPerSample == 2) {
+        // Deflate/Inflate word: the C tier autovectorises the u32 accumulation
+        // tighter than the ported unpack+add32 shape (0.8x under streaming on
+        // M4), so like 3x3 conv float they fall through to C.
+        switch (op) {
+        case GenericPrewitt: return vs_generic_3x3_prewitt_word_neon;
+        case GenericSobel: return vs_generic_3x3_sobel_word_neon;
+        case GenericMinimum: return vs_generic_3x3_min_word_neon;
+        case GenericMaximum: return vs_generic_3x3_max_word_neon;
+        case GenericMedian: return vs_generic_3x3_median_word_neon;
+        default: break;
+        }
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 4) {
+        // Only min/max/median earn their float dispatch; the C tier
+        // autovectorises deflate/inflate/prewitt/sobel float to parity or
+        // better at a full thread pool.
+        switch (op) {
+        case GenericMinimum: return vs_generic_3x3_min_float_neon;
+        case GenericMaximum: return vs_generic_3x3_max_float_neon;
+        case GenericMedian: return vs_generic_3x3_median_float_neon;
+        default: break;
+        }
+    } else if (fi->sampleType == stFloat && fi->bytesPerSample == 2) {
+        // Sobel half loses to C (the two extra scaling multiplies per
+        // gradient tip it under); Prewitt half wins and stays.
+        // Min/Max/Median take the native-f16 kernels (8 lanes, comparisons
+        // are exact in any precision) when the CPU has FEAT_FP16; the fhm
+        // flag is a strict superset of that requirement.
+        switch (op) {
+        case GenericPrewitt: return vs_generic_3x3_prewitt_half_neon;
+        case GenericMinimum:
+#ifdef VS_TARGET_ARM_FHM
+            if (getCPUFeatures()->fhm)
+                return vs_generic_3x3_min_half_neon_fp16;
+#endif
+            return vs_generic_3x3_min_half_neon;
+        case GenericMaximum:
+#ifdef VS_TARGET_ARM_FHM
+            if (getCPUFeatures()->fhm)
+                return vs_generic_3x3_max_half_neon_fp16;
+#endif
+            return vs_generic_3x3_max_half_neon;
+        case GenericMedian:
+#ifdef VS_TARGET_ARM_FHM
+            if (getCPUFeatures()->fhm)
+                return vs_generic_3x3_median_half_neon_fp16;
+#endif
+            return vs_generic_3x3_median_half_neon;
+        case GenericDeflate: return vs_generic_3x3_deflate_half_neon;
+        case GenericInflate: return vs_generic_3x3_inflate_half_neon;
+        default: break;
+        }
+    }
+
     if (op != GenericConvolution)
         return nullptr;
 

--- a/src/core/kernel/arm/generic_fp16_neon.cpp
+++ b/src/core/kernel/arm/generic_fp16_neon.cpp
@@ -1,0 +1,121 @@
+/*
+* Copyright (c) 2012-2019 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+/*
+* FEAT_FP16 native-f16 Minimum/Maximum/Median for the half format: comparisons
+* are exact in ANY precision, so doing them in f16 at 8 lanes/vector (instead
+* of converting to f32 at 4 lanes like the baseline half kernels) changes no
+* min/max/median RESULT bits. The one non-comparison step, the Min/Max
+* threshold clamp, rounds a11+-threshold to f16 where the C reference keeps it
+* in f32 until the final store -- identical for the default (unlimited) and
+* zero thresholds, and at most one f16 ulp apart for finite ones (eps-class,
+* same bucket as the accumulation-order deviations on float).
+*
+* Deflate/Inflate/Prewitt/Sobel half deliberately stay on the f32 kernels:
+* their arithmetic accumulates, and per-op f16 rounding would diverge from the
+* C reference beyond the contract.
+*
+* Lives in the FHM static lib (built with +fp16+fp16fml, LTO off) and is
+* dispatch-gated on the fhm cpu flag, which is a strict superset of the actual
+* FEAT_FP16 requirement (FHM implies FP16); a dedicated asimdhp probe can
+* replace the gate if a chip with FP16-but-not-FHM ever matters.
+*
+* Earns its dispatch under streaming sources at 1 thread and a full pool on
+* both primary targets: 2.2-2.5x over the f32 half kernels on M4/clang and
+* 3.6-4.5x on Neoverse-V3/gcc (where the scalar half C tier is slowest).
+*/
+
+#include <cstdint>
+#include <arm_neon.h>
+
+#include "../generic_impl.h"
+
+namespace {
+
+// Minimal float-domain backend for generic_impl.h's MinMax/Median templates
+// with fvec = float16x8_t. Only the members those templates touch exist.
+struct Backend_F16 {
+    typedef float16x8_t fvec;
+    static fvec set1_f(float x) { return vdupq_n_f16(static_cast<float16_t>(x)); }
+    static fvec fmin(fvec a, fvec b) { return vminq_f16(a, b); }
+    static fvec fmax(fvec a, fvec b) { return vmaxq_f16(a, b); }
+    static fvec fadd(fvec a, fvec b) { return vaddq_f16(a, b); }
+    static fvec fsub(fvec a, fvec b) { return vsubq_f16(a, b); }
+};
+
+// Memory adapter for filter_plane_3x3: the plane is raw binary16 (uint16_t),
+// loaded/stored as f16 lanes with no conversion at all.
+template <class Op>
+struct F16Mem : Op {
+    using Op::Op;
+    typedef uint16_t T;
+    static constexpr unsigned vec_len = 8;
+    static float16x8_t load(const uint16_t *p) { return vreinterpretq_f16_u16(vld1q_u16(p)); }
+    static float16x8_t loadu(const uint16_t *p) { return load(p); }
+    static void store(uint16_t *p, float16x8_t x) { vst1q_u16(p, vreinterpretq_u16_f16(x)); }
+    static float16x8_t shl_insert_lo(float16x8_t x, uint16_t y)
+    {
+        return vextq_f16(vreinterpretq_f16_u16(vdupq_n_u16(y)), x, 7);
+    }
+    static float16x8_t shr_insert(float16x8_t x, uint16_t y, unsigned idx)
+    {
+        static const uint16_t iota[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        uint16x8_t shifted = vextq_u16(vreinterpretq_u16_f16(x), vdupq_n_u16(0), 1);
+        uint16x8_t mask = vceqq_u16(vld1q_u16(iota), vdupq_n_u16(static_cast<uint16_t>(idx)));
+        return vreinterpretq_f16_u16(vbslq_u16(mask, vdupq_n_u16(y), shifted));
+    }
+};
+
+template <uint8_t Stencil, bool Max>
+void f16_minmax_fixed(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                      const vs_generic_params &p, unsigned w, unsigned h)
+{
+    filter_plane_3x3<F16Mem<MinMaxFixedFloat<Backend_F16, Stencil, Max>>>(src, ss, dst, ds, p, w, h);
+}
+
+template <bool Max>
+void f16_minmax(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds,
+                const vs_generic_params &p, unsigned w, unsigned h)
+{
+    switch (p.stencil) {
+    case STENCIL_H: f16_minmax_fixed<STENCIL_H, Max>(src, ss, dst, ds, p, w, h); break;
+    case STENCIL_V: f16_minmax_fixed<STENCIL_V, Max>(src, ss, dst, ds, p, w, h); break;
+    case STENCIL_PLUS: f16_minmax_fixed<STENCIL_PLUS, Max>(src, ss, dst, ds, p, w, h); break;
+    case STENCIL_ALL: f16_minmax_fixed<STENCIL_ALL, Max>(src, ss, dst, ds, p, w, h); break;
+    default: filter_plane_3x3<F16Mem<MinMaxFloat<Backend_F16, Max>>>(src, ss, dst, ds, p, w, h); break;
+    }
+}
+
+} // namespace
+
+void vs_generic_3x3_min_half_neon_fp16(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{
+    f16_minmax<false>(src, ss, dst, ds, *p, w, h);
+}
+
+void vs_generic_3x3_max_half_neon_fp16(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{
+    f16_minmax<true>(src, ss, dst, ds, *p, w, h);
+}
+
+void vs_generic_3x3_median_half_neon_fp16(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{
+    filter_plane_3x3<F16Mem<MedianFloat<Backend_F16>>>(src, ss, dst, ds, *p, w, h);
+}

--- a/src/core/kernel/arm/generic_neon.cpp
+++ b/src/core/kernel/arm/generic_neon.cpp
@@ -1,0 +1,226 @@
+/*
+* Copyright (c) 2012-2019 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include <cstdint>
+#include <arm_neon.h>
+
+namespace {
+
+// NEON primitive layer for generic_impl.h. 128-bit: 16 byte / 8 word / 4 float
+// lanes. The word domain is native unsigned like the AVX2 backend
+// (wsign/wunsign are identity, wmin/wmax map to vmin/vmaxq_u16, pack_word to a
+// signed->unsigned saturating narrow). ivec is uint8x16_t with reinterprets at
+// the op boundaries (NEON's typed vectors vs the untyped __m128i the impl was
+// written against). cvt_i uses FCVTNS (nearest-even), matching the x86 tiers'
+// default MXCSR rounding and the C reference's lrint, and fsqrt is the
+// IEEE-rounded FSQRT, so the integer Prewitt/Sobel paths stay bit-exact.
+//
+// The half tier needs no feature gate: FCVTL/FCVTN (f16<->f32 conversion) are
+// baseline AArch64; FEAT_FP16 is only required for f16 *arithmetic*, which
+// this backend does not use (arithmetic stays in float32, like F16C on x86).
+struct Backend_NEON {
+    typedef uint8x16_t ivec;
+    typedef float32x4_t fvec;
+    static constexpr unsigned BYTE_LEN = 16;
+    static constexpr unsigned WORD_LEN = 8;
+    static constexpr unsigned FLOAT_LEN = 4;
+
+    static uint16x8_t as_u16(ivec x) { return vreinterpretq_u16_u8(x); }
+    static int16x8_t as_s16(ivec x) { return vreinterpretq_s16_u8(x); }
+    static uint32x4_t as_u32(ivec x) { return vreinterpretq_u32_u8(x); }
+    static int32x4_t as_s32(ivec x) { return vreinterpretq_s32_u8(x); }
+    static ivec from_u16(uint16x8_t x) { return vreinterpretq_u8_u16(x); }
+    static ivec from_s16(int16x8_t x) { return vreinterpretq_u8_s16(x); }
+    static ivec from_u32(uint32x4_t x) { return vreinterpretq_u8_u32(x); }
+    static ivec from_s32(int32x4_t x) { return vreinterpretq_u8_s32(x); }
+
+    static ivec zero_i() { return vdupq_n_u8(0); }
+    static ivec set1_i8(int x) { return vdupq_n_u8(static_cast<uint8_t>(x)); }
+    static ivec set1_i16(int x) { return from_u16(vdupq_n_u16(static_cast<uint16_t>(x))); }
+    static ivec set1_i32(int x) { return from_u32(vdupq_n_u32(static_cast<uint32_t>(x))); }
+
+    static ivec add16(ivec a, ivec b) { return from_u16(vaddq_u16(as_u16(a), as_u16(b))); }
+    static ivec sub16(ivec a, ivec b) { return from_u16(vsubq_u16(as_u16(a), as_u16(b))); }
+    static ivec slli16(ivec a) { return from_u16(vshlq_n_u16(as_u16(a), 1)); }
+    static ivec add32(ivec a, ivec b) { return from_u32(vaddq_u32(as_u32(a), as_u32(b))); }
+    static ivec sub32(ivec a, ivec b) { return from_u32(vsubq_u32(as_u32(a), as_u32(b))); }
+    static ivec slli32(ivec a) { return from_u32(vshlq_n_u32(as_u32(a), 1)); }
+    static ivec srli16_3(ivec a) { return from_u16(vshrq_n_u16(as_u16(a), 3)); }
+    static ivec srli32_3(ivec a) { return from_u32(vshrq_n_u32(as_u32(a), 3)); }
+    // pmaddwd: widening multiply + pairwise add reproduces it exactly (the
+    // impl's operands never reach the wrap/saturate corner cases).
+    static ivec madd16(ivec a, ivec b)
+    {
+        int32x4_t lo = vmull_s16(vget_low_s16(as_s16(a)), vget_low_s16(as_s16(b)));
+        int32x4_t hi = vmull_s16(vget_high_s16(as_s16(a)), vget_high_s16(as_s16(b)));
+        return from_s32(vpaddq_s32(lo, hi));
+    }
+    static ivec unpacklo8(ivec a, ivec b) { return vzip1q_u8(a, b); }
+    static ivec unpackhi8(ivec a, ivec b) { return vzip2q_u8(a, b); }
+    static ivec unpacklo16(ivec a, ivec b) { return from_u16(vzip1q_u16(as_u16(a), as_u16(b))); }
+    static ivec unpackhi16(ivec a, ivec b) { return from_u16(vzip2q_u16(as_u16(a), as_u16(b))); }
+    static ivec min_u8(ivec a, ivec b) { return vminq_u8(a, b); }
+    static ivec max_u8(ivec a, ivec b) { return vmaxq_u8(a, b); }
+    static ivec adds_u8(ivec a, ivec b) { return vqaddq_u8(a, b); }
+    static ivec subs_u8(ivec a, ivec b) { return vqsubq_u8(a, b); }
+    static ivec adds_u16(ivec a, ivec b) { return from_u16(vqaddq_u16(as_u16(a), as_u16(b))); }
+    static ivec subs_u16(ivec a, ivec b) { return from_u16(vqsubq_u16(as_u16(a), as_u16(b))); }
+    static ivec and_i(ivec a, ivec b) { return vandq_u8(a, b); }
+    static ivec or_i(ivec a, ivec b) { return vorrq_u8(a, b); }
+    static ivec packs32(ivec a, ivec b) { return from_s16(vcombine_s16(vqmovn_s32(as_s32(a)), vqmovn_s32(as_s32(b)))); }
+    static ivec packus16(ivec a, ivec b) { return vcombine_u8(vqmovun_s16(as_s16(a)), vqmovun_s16(as_s16(b))); }
+
+    // Word domain (native unsigned).
+    static ivec pack_word(ivec a, ivec b) { return from_u16(vcombine_u16(vqmovun_s32(as_s32(a)), vqmovun_s32(as_s32(b)))); }
+    static ivec wsign(ivec x) { return x; }
+    static ivec wunsign(ivec x) { return x; }
+    static ivec wsign32(ivec x) { return x; }
+    static ivec wmin(ivec a, ivec b) { return from_u16(vminq_u16(as_u16(a), as_u16(b))); }
+    static ivec wmax(ivec a, ivec b) { return from_u16(vmaxq_u16(as_u16(a), as_u16(b))); }
+    static ivec wmaxval(uint16_t mv) { return from_u16(vdupq_n_u16(mv)); }
+
+    // Float.
+    static fvec cvt_f(ivec x) { return vcvtq_f32_s32(as_s32(x)); }
+    static ivec cvt_i(fvec x) { return from_s32(vcvtnq_s32_f32(x)); }
+    static fvec set1_f(float x) { return vdupq_n_f32(x); }
+    static fvec fadd(fvec a, fvec b) { return vaddq_f32(a, b); }
+    static fvec fsub(fvec a, fvec b) { return vsubq_f32(a, b); }
+    static fvec fmul(fvec a, fvec b) { return vmulq_f32(a, b); }
+    static fvec fmin(fvec a, fvec b) { return vminq_f32(a, b); }
+    static fvec fmax(fvec a, fvec b) { return vmaxq_f32(a, b); }
+    static fvec fsqrt(fvec a) { return vsqrtq_f32(a); }
+    // a*a + b*b as fma(a, a, b*b): clang contracts the C reference's
+    // "float(gx)*gx + float(gy)*gy" into exactly this FMLA shape on AArch64,
+    // and matching it is what keeps integer Prewitt/Sobel word bit-exact
+    // (byte is exact either way: its squares stay under 2^24).
+    static fvec fsumsq(fvec a, fvec b) { return vfmaq_f32(vmulq_f32(b, b), a, a); }
+    static fvec fand(fvec a, fvec b) { return vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(a), vreinterpretq_u32_f32(b))); }
+    static fvec fmadd(fvec a, fvec b, fvec c) { return vfmaq_f32(c, a, b); }
+    static fvec satmask(uint8_t saturate) { return vreinterpretq_f32_u32(vdupq_n_u32(saturate ? 0xFFFFFFFFu : 0x7FFFFFFFu)); }
+
+    // Memory. NEON loads carry no alignment contract, so load == loadu.
+    static ivec byte_load(const uint8_t *p) { return vld1q_u8(p); }
+    static ivec byte_loadu(const uint8_t *p) { return vld1q_u8(p); }
+    static void byte_store(uint8_t *p, ivec x) { vst1q_u8(p, x); }
+    static ivec word_load(const uint16_t *p) { return from_u16(vld1q_u16(p)); }
+    static ivec word_loadu(const uint16_t *p) { return from_u16(vld1q_u16(p)); }
+    static void word_store(uint16_t *p, ivec x) { vst1q_u16(p, as_u16(x)); }
+    static fvec float_load(const float *p) { return vld1q_f32(p); }
+    static fvec float_loadu(const float *p) { return vld1q_f32(p); }
+    static void float_store(float *p, fvec x) { vst1q_f32(p, x); }
+
+    // Half (float16): FCVTL/FCVTN on load/store; arithmetic stays float32.
+    // FCVTN rounds nearest-even (FPCR default), matching floatToHalf and F16C.
+    static fvec half_load(const uint16_t *p) { return vcvt_f32_f16(vreinterpret_f16_u16(vld1_u16(p))); }
+    static fvec half_loadu(const uint16_t *p) { return half_load(p); }
+    static void half_store(uint16_t *p, fvec x) { vst1_u16(p, vreinterpret_u16_f16(vcvt_f16_f32(x))); }
+
+    // Edge inserts: shift the lane block by one with the scalar replicated in,
+    // via ext against a dup vector; the runtime-index insert is an iota
+    // compare + bsl (the NEON spelling of the SSE2 cmpeq+blend).
+    static uint8x16_t iota8()
+    {
+        static const uint8_t v[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+        return vld1q_u8(v);
+    }
+    static uint16x8_t iota16()
+    {
+        static const uint16_t v[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+        return vld1q_u16(v);
+    }
+    static uint32x4_t iota32()
+    {
+        static const uint32_t v[4] = { 0, 1, 2, 3 };
+        return vld1q_u32(v);
+    }
+
+    static ivec byte_shl_insert_lo(ivec x, uint8_t y)
+    {
+        return vextq_u8(vdupq_n_u8(y), x, 15);
+    }
+    static ivec byte_shr_insert(ivec x, uint8_t y, unsigned idx)
+    {
+        uint8x16_t shifted = vextq_u8(x, vdupq_n_u8(0), 1);
+        uint8x16_t mask = vceqq_u8(iota8(), vdupq_n_u8(static_cast<uint8_t>(idx)));
+        return vbslq_u8(mask, vdupq_n_u8(y), shifted);
+    }
+    static ivec word_shl_insert_lo(ivec x, uint16_t y)
+    {
+        return from_u16(vextq_u16(vdupq_n_u16(y), as_u16(x), 7));
+    }
+    static ivec word_shr_insert(ivec x, uint16_t y, unsigned idx)
+    {
+        uint16x8_t shifted = vextq_u16(as_u16(x), vdupq_n_u16(0), 1);
+        uint16x8_t mask = vceqq_u16(iota16(), vdupq_n_u16(static_cast<uint16_t>(idx)));
+        return from_u16(vbslq_u16(mask, vdupq_n_u16(y), shifted));
+    }
+    static fvec float_shl_insert_lo(fvec x, float y)
+    {
+        return vextq_f32(vdupq_n_f32(y), x, 3);
+    }
+    static fvec float_shr_insert(fvec x, float y, unsigned idx)
+    {
+        float32x4_t shifted = vextq_f32(x, vdupq_n_f32(0.0f), 1);
+        uint32x4_t mask = vceqq_u32(iota32(), vdupq_n_u32(idx));
+        return vbslq_f32(mask, vdupq_n_f32(y), shifted);
+    }
+};
+
+} // namespace
+
+#define BACKEND Backend_NEON
+#include "../generic_impl.h"
+
+// The convolution entry points are deliberately NOT emitted: the hand-written
+// kernels in convolution_neon.cpp already cover 3x3 conv and beat what this
+// port generates (madd16 is a 3-op emulation on NEON).
+//
+// Formats that do not beat their (auto-vectorised) C tier under a streaming
+// source at 1 thread AND a full pool (measured on M4 and Graviton5) are not
+// emitted either, the same treatment as 3x3 conv float:
+//   deflate/inflate word   - the u32 unpack+add shape loses ~20% to C
+//   deflate/inflate float  - pure tie; C already autovectorises optimally
+//   prewitt float          - tie at 1 thread, loses at full pool
+//   sobel float, half      - loses at both
+// Ops with a partial format set get their surviving entry points emitted by
+// hand below instead of via the all-format macros.
+VS_GENERIC_MINMAX(min, false, neon)
+VS_GENERIC_MINMAX(max, true, neon)
+VS_GENERIC_3X3(median, Median, neon)
+
+VS_GENERIC_MINMAX_HALF(min, false, neon)
+VS_GENERIC_MINMAX_HALF(max, true, neon)
+VS_GENERIC_3X3_HALF(median, Median, neon)
+VS_GENERIC_3X3_B_HALF(prewitt, PrewittSobel, false, neon)
+VS_GENERIC_3X3_B_HALF(deflate, DeflateInflate, false, neon)
+VS_GENERIC_3X3_B_HALF(inflate, DeflateInflate, true, neon)
+
+void vs_generic_3x3_prewitt_byte_neon(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{ filter_plane_3x3<PrewittSobelByte<Backend_NEON, false>>(src, ss, dst, ds, *p, w, h); }
+void vs_generic_3x3_prewitt_word_neon(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{ filter_plane_3x3<PrewittSobelWord<Backend_NEON, false>>(src, ss, dst, ds, *p, w, h); }
+void vs_generic_3x3_sobel_byte_neon(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{ filter_plane_3x3<PrewittSobelByte<Backend_NEON, true>>(src, ss, dst, ds, *p, w, h); }
+void vs_generic_3x3_sobel_word_neon(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{ filter_plane_3x3<PrewittSobelWord<Backend_NEON, true>>(src, ss, dst, ds, *p, w, h); }
+void vs_generic_3x3_deflate_byte_neon(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{ filter_plane_3x3<DeflateInflateByte<Backend_NEON, false>>(src, ss, dst, ds, *p, w, h); }
+void vs_generic_3x3_inflate_byte_neon(const void *src, ptrdiff_t ss, void *dst, ptrdiff_t ds, const struct vs_generic_params *p, unsigned w, unsigned h)
+{ filter_plane_3x3<DeflateInflateByte<Backend_NEON, true>>(src, ss, dst, ds, *p, w, h); }

--- a/src/core/kernel/generic.h
+++ b/src/core/kernel/generic.h
@@ -317,6 +317,41 @@ DECL(11x11_conv, byte, avx512vnni)
 #endif /* VS_TARGET_CPU_X86 */
 
 #ifdef VS_TARGET_CPU_ARM64
+/* NEON 3x3 neighborhood family (generic_neon.cpp, a Backend instantiation of
+   generic_impl.h). Integer paths are bit-exact with the C reference; the half
+   tier converts f16<->f32 at the loads/stores (baseline AArch64, no feature
+   gate) and keeps arithmetic in float32 like the x86 F16C tiers.
+   Formats with no declaration here (deflate/inflate word+float, prewitt
+   float, sobel float+half) lose or tie against their autovectorised C tier
+   under streaming sources on M4 and are not built, like 3x3 conv float. */
+DECL_3x3(prewitt, byte, neon)
+DECL_3x3(prewitt, word, neon)
+DECL_3x3(prewitt, half, neon)
+
+DECL_3x3(sobel, byte, neon)
+DECL_3x3(sobel, word, neon)
+
+DECL_3x3(min, byte, neon)
+DECL_3x3(min, word, neon)
+DECL_3x3(min, float, neon)
+DECL_3x3(min, half, neon)
+
+DECL_3x3(max, byte, neon)
+DECL_3x3(max, word, neon)
+DECL_3x3(max, float, neon)
+DECL_3x3(max, half, neon)
+
+DECL_3x3(median, byte, neon)
+DECL_3x3(median, word, neon)
+DECL_3x3(median, float, neon)
+DECL_3x3(median, half, neon)
+
+DECL_3x3(deflate, byte, neon)
+DECL_3x3(deflate, half, neon)
+
+DECL_3x3(inflate, byte, neon)
+DECL_3x3(inflate, half, neon)
+
 /* NEON baseline kernels: the whole convolution family (square 3x3..11x11,
    1D horizontal/vertical, separable) for byte/word/float/half. Integer paths
    are bit-exact with the C reference; float/half use FMA. */
@@ -386,6 +421,12 @@ DECL(1d_conv_v, half, neon_fhm)
 /* Separable: both halves are half-format, so this drives its own row loop and
    runs the vertical and horizontal passes on fmlal. */
 DECL(2d_conv_sep, half, neon_fhm)
+/* Native-f16 half Min/Max/Median (8 lanes, no f32 conversion; comparisons are
+   exact in any precision). Needs only FEAT_FP16; lives in the FHM TU and is
+   gated on the fhm flag, a strict superset. */
+DECL_3x3(min, half, neon_fp16)
+DECL_3x3(max, half, neon_fp16)
+DECL_3x3(median, half, neon_fp16)
 #endif /* VS_TARGET_ARM_FHM */
 
 #endif /* VS_TARGET_CPU_ARM64 */

--- a/src/core/kernel/generic_impl.h
+++ b/src/core/kernel/generic_impl.h
@@ -42,8 +42,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include "../generic.h"
-#include "../../float16_helper.h"
+#include "generic.h"
+#include "../float16_helper.h"
 
 #ifdef _MSC_VER
 #define FORCE_INLINE inline __forceinline
@@ -213,18 +213,17 @@ struct PrewittSobelWord : PrewittSobelTraits, WordTraits<B> {
         gy_hi = B::sub32(gy_hi, Sobel ? B::slli32(HI(a10)) : HI(a10));
         gy_hi = B::sub32(gy_hi, HI(a20));
 
-        auto gxsq_lo = B::cvt_f(gx_lo);
-        auto gxsq_hi = B::cvt_f(gx_hi);
-        auto gysq_lo = B::cvt_f(gy_lo);
-        auto gysq_hi = B::cvt_f(gy_hi);
-        gxsq_lo = B::fmul(gxsq_lo, gxsq_lo);
-        gxsq_hi = B::fmul(gxsq_hi, gxsq_hi);
-        gysq_lo = B::fmul(gysq_lo, gysq_lo);
-        gysq_hi = B::fmul(gysq_hi, gysq_hi);
+        auto gxf_lo = B::cvt_f(gx_lo);
+        auto gxf_hi = B::cvt_f(gx_hi);
+        auto gyf_lo = B::cvt_f(gy_lo);
+        auto gyf_hi = B::cvt_f(gy_hi);
 
+        // gx*gx + gy*gy goes through the backend's fsumsq so each tier can
+        // reproduce what the compiler does to the C reference's expression on
+        // that architecture (arm contracts it to an FMA; x86 baseline cannot).
         auto sc = B::set1_f(scale);
-        auto gxy_lo = B::fmul(B::fsqrt(B::fadd(gxsq_lo, gysq_lo)), sc);
-        auto gxy_hi = B::fmul(B::fsqrt(B::fadd(gxsq_hi, gysq_hi)), sc);
+        auto gxy_lo = B::fmul(B::fsqrt(B::fsumsq(gxf_lo, gyf_lo)), sc);
+        auto gxy_hi = B::fmul(B::fsqrt(B::fsumsq(gxf_hi, gyf_hi)), sc);
 
         auto tmpi_lo = B::wsign32(B::cvt_i(gxy_lo));
         auto tmpi_hi = B::wsign32(B::cvt_i(gxy_hi));
@@ -259,9 +258,7 @@ struct PrewittSobelFloat : PrewittSobelTraits, FloatTraits<B> {
         gy = B::fsub(gy, Sobel ? B::fmul(a10, two) : a10);
         gy = B::fsub(gy, a20);
 
-        gx = B::fmul(gx, gx);
-        gy = B::fmul(gy, gy);
-        auto tmp = B::fsqrt(B::fadd(gx, gy));
+        auto tmp = B::fsqrt(B::fsumsq(gx, gy));
         return B::fmul(tmp, B::set1_f(scale));
     }
 };

--- a/src/core/kernel/x86/generic_avx2.cpp
+++ b/src/core/kernel/x86/generic_avx2.cpp
@@ -100,6 +100,23 @@ struct Backend_AVX2 {
     static fvec fmin(fvec a, fvec b) { return _mm256_min_ps(a, b); }
     static fvec fmax(fvec a, fvec b) { return _mm256_max_ps(a, b); }
     static fvec fsqrt(fvec a) { return _mm256_sqrt_ps(a); }
+    // a*a + b*b; kept as mul+add (NOT fmadd) to stay bit-identical with the
+    // baseline-compiled (never-fused) C reference. The asm barrier stops
+    // gcc's -ffp-contract=fast from fusing it -- this TU is always built
+    // with -mfma, so without the barrier gcc contracts it even on default
+    // targets; see the SSE2 backend's note.
+    static fvec fsumsq(fvec a, fvec b)
+    {
+        fvec asq = _mm256_mul_ps(a, a);
+        fvec bsq = _mm256_mul_ps(b, b);
+#if !defined(_MSC_VER) || defined(__clang__)
+        // clang-cl defines _MSC_VER but contracts like clang and supports
+        // GNU asm, so it takes the barrier; only true MSVC cl (which never
+        // contracts intrinsics) goes without.
+        __asm__("" : "+x"(asq), "+x"(bsq));
+#endif
+        return _mm256_add_ps(asq, bsq);
+    }
     static fvec fand(fvec a, fvec b) { return _mm256_and_ps(a, b); }
     static fvec fmadd(fvec a, fvec b, fvec c) { return _mm256_fmadd_ps(a, b, c); }
     static fvec satmask(uint8_t saturate) { return _mm256_castsi256_ps(_mm256_set1_epi32(saturate ? 0xFFFFFFFF : 0x7FFFFFFF)); }
@@ -156,7 +173,7 @@ struct Backend_AVX2 {
 } // namespace
 
 #define BACKEND Backend_AVX2
-#include "generic_impl.h"
+#include "../generic_impl.h"
 
 VS_GENERIC_ENTRYPOINTS(avx2)
 VS_GENERIC_ENTRYPOINTS_HALF(avx2)

--- a/src/core/kernel/x86/generic_avx512.cpp
+++ b/src/core/kernel/x86/generic_avx512.cpp
@@ -103,6 +103,23 @@ struct Backend_AVX512 {
     static fvec fmin(fvec a, fvec b) { return _mm512_min_ps(a, b); }
     static fvec fmax(fvec a, fvec b) { return _mm512_max_ps(a, b); }
     static fvec fsqrt(fvec a) { return _mm512_sqrt_ps(a); }
+    // a*a + b*b; kept as mul+add (NOT fmadd) to stay bit-identical with the
+    // baseline-compiled (never-fused) C reference. The asm barrier stops
+    // gcc's -ffp-contract=fast from fusing it -- this TU always has FMA
+    // available; "+v" because __m512 needs the EVEX register class. See the
+    // SSE2 backend's note.
+    static fvec fsumsq(fvec a, fvec b)
+    {
+        fvec asq = _mm512_mul_ps(a, a);
+        fvec bsq = _mm512_mul_ps(b, b);
+#if !defined(_MSC_VER) || defined(__clang__)
+        // clang-cl defines _MSC_VER but contracts like clang and supports
+        // GNU asm, so it takes the barrier; only true MSVC cl (which never
+        // contracts intrinsics) goes without.
+        __asm__("" : "+v"(asq), "+v"(bsq));
+#endif
+        return _mm512_add_ps(asq, bsq);
+    }
     static fvec fand(fvec a, fvec b) { return _mm512_and_ps(a, b); }
     static fvec fmadd(fvec a, fvec b, fvec c) { return _mm512_fmadd_ps(a, b, c); }
     static fvec satmask(uint8_t saturate) { return _mm512_castsi512_ps(_mm512_set1_epi32(saturate ? 0xFFFFFFFF : 0x7FFFFFFF)); }
@@ -167,7 +184,7 @@ struct Backend_AVX512 {
 } // namespace
 
 #define BACKEND Backend_AVX512
-#include "generic_impl.h"
+#include "../generic_impl.h"
 
 VS_GENERIC_ENTRYPOINTS(avx512)
 VS_GENERIC_ENTRYPOINTS_HALF(avx512)

--- a/src/core/kernel/x86/generic_sse2.cpp
+++ b/src/core/kernel/x86/generic_sse2.cpp
@@ -86,6 +86,25 @@ struct Backend_SSE2 {
     static fvec fmin(fvec a, fvec b) { return _mm_min_ps(a, b); }
     static fvec fmax(fvec a, fvec b) { return _mm_max_ps(a, b); }
     static fvec fsqrt(fvec a) { return _mm_sqrt_ps(a); }
+    // a*a + b*b, contraction-proof. gcc implements the arithmetic intrinsics
+    // as plain vector ops and its default -ffp-contract=fast fuses mul+add
+    // ACROSS statements whenever the target arch has FMA (-march=native, or
+    // distro defaults like x86-64-v3), silently changing word Prewitt/Sobel
+    // by +-1 vs the never-fused baseline C tier. The empty asm makes the
+    // products opaque so the add can never contract; MSVC never contracts
+    // intrinsics and needs no barrier.
+    static fvec fsumsq(fvec a, fvec b)
+    {
+        fvec asq = _mm_mul_ps(a, a);
+        fvec bsq = _mm_mul_ps(b, b);
+#if !defined(_MSC_VER) || defined(__clang__)
+        // clang-cl defines _MSC_VER but contracts like clang and supports
+        // GNU asm, so it takes the barrier; only true MSVC cl (which never
+        // contracts intrinsics) goes without.
+        __asm__("" : "+x"(asq), "+x"(bsq));
+#endif
+        return _mm_add_ps(asq, bsq);
+    }
     static fvec fand(fvec a, fvec b) { return _mm_and_ps(a, b); }
     static fvec fmadd(fvec a, fvec b, fvec c) { return _mm_add_ps(_mm_mul_ps(a, b), c); }
     static fvec satmask(uint8_t saturate) { return _mm_castsi128_ps(_mm_set1_epi32(saturate ? 0xFFFFFFFF : 0x7FFFFFFF)); }
@@ -137,6 +156,6 @@ struct Backend_SSE2 {
 } // namespace
 
 #define BACKEND Backend_SSE2
-#include "generic_impl.h"
+#include "../generic_impl.h"
 
 VS_GENERIC_ENTRYPOINTS(sse2)


### PR DESCRIPTION
Introduces arm64 NEON kernels for the 3x3 neighborhood filter family (`std`'s `Prewitt`, `Sobel`, `Minimum`, `Maximum`, `Median`, `Deflate`, `Inflate`), dispatched by runtime CPU feature detection alongside the existing convolution kernels:

- The x86 3x3 implementation layer (`generic_impl.h`) turns out to be fully ISA-neutral: every op, the fixed-stencil Minimum/Maximum specializations, and the vectorized edge-handling driver are written against an abstract Backend of SIMD primitives. This PR moves it up out of kernel/x86/ and instantiates it with a 128-bit NEON backend, so the integer paths are bit-exact with the C reference (and with x86) by construction rather than by re-derivation. The word domain uses native unsigned min/max like the AVX2 backend.
- A half (float16) tier comes with it: f16<->f32 conversion is baseline AArch64 NEON (FEAT_FP16 is only needed for f16 arithmetic), so unlike the x86 F16C tiers it needs no feature gate at all.
- Native-f16 `Minimum`/`Maximum`/`Median` (`FEAT_FP16`, gated on the fhm cpu flag, a strict superset) run the comparison networks at 8 lanes with no conversion; comparisons are exact in any precision, so results are unchanged. These are the largest wins in the family since the scalar half fallback does not auto-vectorize.
- Sum-of-squares in Prewitt/Sobel goes through a new per-backend fsumsq primitive: compilers contract the C reference's `gx*gx + gy*gy` into an FMA on AArch64, so the NEON backend matches that exact FMLA shape (measured bit-exact against both clang- and gcc-built C tiers), while the x86 backends pin their historical never-fused mul+add with an asm barrier so x86 output is unchanged under every compiler.

Dispatch policy matches the convolution PRs: a kernel ships only if it beats the auto-vectorized C tier under a streaming source (distinct frames sized past the last-level cache) at one thread AND at a full thread pool, on both Apple Silicon and Graviton. Shapes where the C tier already ties or wins are not built and fall through to C, like 3x3 convolution float: deflate/inflate word and float, prewitt float, and sobel float and half. A usdot variant of deflate/inflate byte was measured and parked (it wins on M4 but regresses inflate on Neoverse-V3).

x86_64 is verified unchanged: the sse2/avx2/avx512 tiers were A/B'd against the parent commit on Zen 5 and Xeon 6 under gcc, and on Windows under both MSVC and clang-cl (the toolchain the release wheels build with), with identical integer accuracy in every configuration.

## Benchmarking

FPS with a streaming source at 1920x1080 and 3840x2160, single-thread and all-cores; NEON throughput as a multiple of the C path. A blank NEON cell means no kernel dispatches for that shape and the filter runs the C tier. Main tables use default filter parameters; the second table per config shows plus-shaped `coordinates` on Minimum/Maximum, which dispatches the fixed-stencil specialization. All-core sweeps use 5 timing reps; two M4 all-core cells whose C column is known-noisy at high fps (inflate half, max byte stencil) were re-measured at 7 reps and those medians are shown.

### Apple M4 (macOS, clang)
#### 1080p, single thread
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 2210.7 | 7783.3 | 3.52x |
| Min | word | 1504.1 | 3397.3 | 2.26x |
| Min | half | 684.1 | 3487.1 | 5.10x |
| Min | float | 713.5 | 1529.5 | 2.14x |
| Max | byte | 2309.9 | 6877.9 | 2.98x |
| Max | word | 1576.3 | 3232.7 | 2.05x |
| Max | half | 672.2 | 3421.0 | 5.09x |
| Max | float | 713.2 | 1534.6 | 2.15x |
| Median | byte | 3158.3 | 3799.9 | 1.20x |
| Median | word | 1820.4 | 1956.4 | 1.07x |
| Median | half | 423.3 | 2006.0 | 4.74x |
| Median | float | 505.0 | 947.9 | 1.88x |
| Deflate | byte | 1572.8 | 3016.0 | 1.92x |
| Deflate | word | 1928.1 |  |  |
| Deflate | half | 1281.2 | 1411.1 | 1.10x |
| Deflate | float | 1480.6 |  |  |
| Inflate | byte | 1615.4 | 2911.9 | 1.80x |
| Inflate | word | 2078.5 |  |  |
| Inflate | half | 1278.7 | 1396.5 | 1.09x |
| Inflate | float | 1471.3 |  |  |
| Prewitt | byte | 780.7 | 1552.9 | 1.99x |
| Prewitt | word | 909.3 | 1135.6 | 1.25x |
| Prewitt | half | 1148.9 | 1276.9 | 1.11x |
| Prewitt | float | 1559.8 |  |  |
| Sobel | byte | 805.5 | 1391.7 | 1.73x |
| Sobel | word | 824.9 | 1007.9 | 1.22x |
| Sobel | half | 1149.3 |  |  |
| Sobel | float | 1404.6 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 2191.6 | 10728.0 | 4.90x |
| Min | word | 1521.2 | 6300.6 | 4.14x |
| Min | half | 675.9 | 6302.8 | 9.33x |
| Min | float | 775.1 | 2442.7 | 3.15x |
| Max | byte | 2425.2 | 11176.6 | 4.61x |
| Max | word | 1686.0 | 6308.3 | 3.74x |
| Max | half | 671.6 | 6269.7 | 9.34x |
| Max | float | 773.7 | 2415.4 | 3.12x |

#### 1080p, all cores (16 threads)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 21034.9 | 25199.6 | 1.20x |
| Min | word | 16291.1 | 29388.7 | 1.80x |
| Min | half | 7746.2 | 30525.0 | 3.94x |
| Min | float | 7873.5 | 14411.0 | 1.83x |
| Max | byte | 22718.3 | 27621.8 | 1.22x |
| Max | word | 17023.2 | 28758.5 | 1.69x |
| Max | half | 7749.6 | 29653.8 | 3.83x |
| Max | float | 7512.2 | 14575.6 | 1.94x |
| Median | byte | 24583.7 | 28866.5 | 1.17x |
| Median | word | 18246.4 | 19927.8 | 1.09x |
| Median | half | 5024.2 | 20170.7 | 4.01x |
| Median | float | 6105.3 | 10469.4 | 1.71x |
| Deflate | byte | 16723.6 | 27094.8 | 1.62x |
| Deflate | word | 20318.1 |  |  |
| Deflate | half | 14598.9 | 15270.8 | 1.05x |
| Deflate | float | 14614.3 |  |  |
| Inflate | byte | 17417.7 | 27494.6 | 1.58x |
| Inflate | word | 21534.4 |  |  |
| Inflate | half | 14677.6 | 16066.1 | 1.09x |
| Inflate | float | 13481.0 |  |  |
| Prewitt | byte | 8637.8 | 17184.5 | 1.99x |
| Prewitt | word | 10605.7 | 13162.0 | 1.24x |
| Prewitt | half | 12339.0 | 12424.4 | 1.01x |
| Prewitt | float | 13250.9 |  |  |
| Sobel | byte | 9406.3 | 16181.6 | 1.72x |
| Sobel | word | 9654.3 | 11546.6 | 1.20x |
| Sobel | half | 13124.6 |  |  |
| Sobel | float | 14256.4 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 21471.1 | 24296.7 | 1.13x |
| Min | word | 16769.6 | 30403.2 | 1.81x |
| Min | half | 7659.1 | 29150.1 | 3.81x |
| Min | float | 8648.4 | 18099.1 | 2.09x |
| Max | byte | 22098.1 | 22771.5 | 1.03x |
| Max | word | 18092.4 | 28559.0 | 1.58x |
| Max | half | 7724.0 | 32007.9 | 4.14x |
| Max | float | 6647.1 | 16836.1 | 2.53x |

#### UHD (3840x2160), single thread
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 515.6 | 1555.2 | 3.02x |
| Min | word | 351.6 | 740.5 | 2.11x |
| Min | half | 156.9 | 712.0 | 4.54x |
| Min | float | 170.4 | 380.2 | 2.23x |
| Max | byte | 592.1 | 1527.6 | 2.58x |
| Max | word | 376.9 | 690.4 | 1.83x |
| Max | half | 156.5 | 729.0 | 4.66x |
| Max | float | 172.1 | 385.9 | 2.24x |
| Median | byte | 767.1 | 932.7 | 1.22x |
| Median | word | 392.9 | 438.9 | 1.12x |
| Median | half | 101.2 | 443.4 | 4.38x |
| Median | float | 122.6 | 240.9 | 1.96x |
| Deflate | byte | 362.4 | 727.6 | 2.01x |
| Deflate | word | 431.4 |  |  |
| Deflate | half | 296.7 | 310.5 | 1.05x |
| Deflate | float | 374.9 |  |  |
| Inflate | byte | 395.6 | 746.8 | 1.89x |
| Inflate | word | 478.0 |  |  |
| Inflate | half | 291.7 | 329.4 | 1.13x |
| Inflate | float | 373.7 |  |  |
| Prewitt | byte | 188.3 | 392.0 | 2.08x |
| Prewitt | word | 207.0 | 261.2 | 1.26x |
| Prewitt | half | 271.1 | 289.6 | 1.07x |
| Prewitt | float | 382.4 |  |  |
| Sobel | byte | 198.6 | 343.6 | 1.73x |
| Sobel | word | 189.6 | 229.7 | 1.21x |
| Sobel | half | 246.6 |  |  |
| Sobel | float | 359.2 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 533.6 | 3055.7 | 5.73x |
| Min | word | 344.9 | 1072.1 | 3.11x |
| Min | half | 157.7 | 1131.4 | 7.17x |
| Min | float | 192.4 | 711.4 | 3.70x |
| Max | byte | 614.7 | 2970.7 | 4.83x |
| Max | word | 388.4 | 1106.5 | 2.85x |
| Max | half | 158.8 | 1084.6 | 6.83x |
| Max | float | 191.2 | 709.4 | 3.71x |

#### UHD (3840x2160), all cores (16 threads)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 6476.8 | 16475.3 | 2.54x |
| Min | word | 4314.8 | 8052.6 | 1.87x |
| Min | half | 1889.0 | 7708.8 | 4.08x |
| Min | float | 2002.4 | 3753.1 | 1.87x |
| Max | byte | 6893.7 | 14040.8 | 2.04x |
| Max | word | 4576.0 | 8298.2 | 1.81x |
| Max | half | 1917.7 | 7648.8 | 3.99x |
| Max | float | 1933.3 | 3725.8 | 1.93x |
| Median | byte | 8701.8 | 10304.3 | 1.18x |
| Median | word | 4897.8 | 5249.9 | 1.07x |
| Median | half | 1255.9 | 5442.4 | 4.33x |
| Median | float | 1420.1 | 2679.3 | 1.89x |
| Deflate | byte | 4688.0 | 8688.0 | 1.85x |
| Deflate | word | 5244.6 |  |  |
| Deflate | half | 3803.1 | 3831.7 | 1.01x |
| Deflate | float | 3772.3 |  |  |
| Inflate | byte | 4973.4 | 8542.9 | 1.72x |
| Inflate | word | 5421.9 |  |  |
| Inflate | half | 3677.5 | 3774.1 | 1.03x |
| Inflate | float | 3694.3 |  |  |
| Prewitt | byte | 2278.3 | 4687.3 | 2.06x |
| Prewitt | word | 2488.9 | 3143.4 | 1.26x |
| Prewitt | half | 2630.3 | 3357.1 | 1.28x |
| Prewitt | float | 3823.1 |  |  |
| Sobel | byte | 2390.1 | 4211.4 | 1.76x |
| Sobel | word | 2412.8 | 2878.2 | 1.19x |
| Sobel | half | 3032.9 |  |  |
| Sobel | float | 3646.1 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 6670.1 | 17139.6 | 2.57x |
| Min | word | 4373.7 | 9771.9 | 2.23x |
| Min | half | 1969.3 | 9661.2 | 4.91x |
| Min | float | 2204.0 | 4694.2 | 2.13x |
| Max | byte | 7411.1 | 19776.0 | 2.67x |
| Max | word | 4975.7 | 9884.1 | 1.99x |
| Max | half | 1990.9 | 9766.1 | 4.91x |
| Max | float | 2091.1 | 4867.6 | 2.33x |

### AWS Graviton5 (c9g.4xlarge, Neoverse-V3, 16 vCPU, gcc)
#### 1080p, single thread
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 932.3 | 4532.0 | 4.86x |
| Min | word | 748.1 | 2377.8 | 3.18x |
| Min | half | 43.1 | 2396.4 | 55.60x |
| Min | float | 139.5 | 1220.2 | 8.75x |
| Max | byte | 1570.3 | 4550.1 | 2.90x |
| Max | word | 796.6 | 2384.1 | 2.99x |
| Max | half | 43.3 | 2397.4 | 55.37x |
| Max | float | 139.5 | 1227.5 | 8.80x |
| Median | byte | 1151.6 | 2646.2 | 2.30x |
| Median | word | 724.8 | 1362.1 | 1.88x |
| Median | half | 15.3 | 1272.1 | 83.14x |
| Median | float | 221.2 | 633.8 | 2.87x |
| Deflate | byte | 1431.7 | 1916.0 | 1.34x |
| Deflate | word | 1119.2 |  |  |
| Deflate | half | 61.2 | 570.2 | 9.32x |
| Deflate | float | 980.2 |  |  |
| Inflate | byte | 1406.5 | 2007.9 | 1.43x |
| Inflate | word | 1219.4 |  |  |
| Inflate | half | 60.4 | 570.5 | 9.45x |
| Inflate | float | 983.8 |  |  |
| Prewitt | byte | 66.3 | 831.1 | 12.54x |
| Prewitt | word | 66.0 | 656.4 | 9.95x |
| Prewitt | half | 197.8 | 537.1 | 2.72x |
| Prewitt | float | 976.2 |  |  |
| Sobel | byte | 70.0 | 816.3 | 11.66x |
| Sobel | word | 68.9 | 577.5 | 8.38x |
| Sobel | half | 172.9 |  |  |
| Sobel | float | 817.3 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 933.6 | 7823.1 | 8.38x |
| Min | word | 747.2 | 4249.4 | 5.69x |
| Min | half | 47.6 | 4172.9 | 87.67x |
| Min | float | 170.6 | 2291.8 | 13.43x |
| Max | byte | 1575.8 | 7767.3 | 4.93x |
| Max | word | 796.5 | 4198.5 | 5.27x |
| Max | half | 47.3 | 4200.3 | 88.80x |
| Max | float | 170.5 | 2247.9 | 13.18x |

#### 1080p, all cores (16 threads)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 12712.5 | 36194.9 | 2.85x |
| Min | word | 10187.1 | 18575.1 | 1.82x |
| Min | half | 658.1 | 17636.9 | 26.80x |
| Min | float | 2125.3 | 9540.3 | 4.49x |
| Max | byte | 20640.5 | 35555.5 | 1.72x |
| Max | word | 11436.5 | 18152.2 | 1.59x |
| Max | half | 663.2 | 18059.7 | 27.23x |
| Max | float | 2122.6 | 9470.8 | 4.46x |
| Median | byte | 15370.3 | 31419.7 | 2.04x |
| Median | word | 10501.3 | 17230.3 | 1.64x |
| Median | half | 234.6 | 15975.9 | 68.10x |
| Median | float | 3410.3 | 8269.6 | 2.42x |
| Deflate | byte | 19163.3 | 25130.2 | 1.31x |
| Deflate | word | 14872.5 |  |  |
| Deflate | half | 938.2 | 8454.6 | 9.01x |
| Deflate | float | 9466.2 |  |  |
| Inflate | byte | 18351.4 | 26141.8 | 1.42x |
| Inflate | word | 15417.6 |  |  |
| Inflate | half | 926.4 | 8519.5 | 9.20x |
| Inflate | float | 9494.1 |  |  |
| Prewitt | byte | 1022.5 | 12061.3 | 11.80x |
| Prewitt | word | 1020.1 | 9717.3 | 9.53x |
| Prewitt | half | 2984.8 | 8059.7 | 2.70x |
| Prewitt | float | 9466.1 |  |  |
| Sobel | byte | 1068.0 | 12155.6 | 11.38x |
| Sobel | word | 1052.9 | 8625.8 | 8.19x |
| Sobel | half | 2630.8 |  |  |
| Sobel | float | 9155.6 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 13667.2 | 36021.2 | 2.64x |
| Min | word | 10891.2 | 21097.1 | 1.94x |
| Min | half | 729.3 | 19749.6 | 27.08x |
| Min | float | 2586.9 | 9920.5 | 3.83x |
| Max | byte | 21067.5 | 36240.1 | 1.72x |
| Max | word | 11479.0 | 20262.2 | 1.77x |
| Max | half | 726.3 | 20797.6 | 28.63x |
| Max | float | 2592.4 | 9891.1 | 3.82x |

#### UHD (3840x2160), single thread
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 241.6 | 1231.0 | 5.10x |
| Min | word | 189.3 | 612.7 | 3.24x |
| Min | half | 10.8 | 617.6 | 57.19x |
| Min | float | 35.0 | 303.5 | 8.67x |
| Max | byte | 417.3 | 1223.7 | 2.93x |
| Max | word | 204.4 | 621.8 | 3.04x |
| Max | half | 10.8 | 625.9 | 57.95x |
| Max | float | 35.0 | 302.7 | 8.65x |
| Median | byte | 322.4 | 693.2 | 2.15x |
| Median | word | 189.4 | 349.4 | 1.84x |
| Median | half | 3.8 | 348.6 | 91.74x |
| Median | float | 56.8 | 174.6 | 3.07x |
| Deflate | byte | 377.2 | 519.2 | 1.38x |
| Deflate | word | 287.1 |  |  |
| Deflate | half | 15.3 | 144.2 | 9.42x |
| Deflate | float | 250.4 |  |  |
| Inflate | byte | 384.7 | 519.3 | 1.35x |
| Inflate | word | 320.2 |  |  |
| Inflate | half | 15.1 | 144.2 | 9.55x |
| Inflate | float | 251.8 |  |  |
| Prewitt | byte | 16.6 | 211.1 | 12.72x |
| Prewitt | word | 16.6 | 166.1 | 10.01x |
| Prewitt | half | 49.7 | 135.8 | 2.73x |
| Prewitt | float | 248.5 |  |  |
| Sobel | byte | 17.5 | 207.7 | 11.87x |
| Sobel | word | 17.3 | 146.0 | 8.44x |
| Sobel | half | 43.6 |  |  |
| Sobel | float | 208.4 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 241.8 | 2269.5 | 9.39x |
| Min | word | 190.6 | 1133.0 | 5.94x |
| Min | half | 11.9 | 1142.1 | 95.97x |
| Min | float | 42.8 | 563.1 | 13.16x |
| Max | byte | 417.6 | 2250.4 | 5.39x |
| Max | word | 204.3 | 1144.8 | 5.60x |
| Max | half | 11.9 | 1154.1 | 96.98x |
| Max | float | 42.9 | 559.5 | 13.04x |

#### UHD (3840x2160), all cores (16 threads)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 3670.5 | 9787.8 | 2.67x |
| Min | word | 2803.1 | 4569.7 | 1.63x |
| Min | half | 165.5 | 4915.5 | 29.70x |
| Min | float | 498.3 | 2588.4 | 5.19x |
| Max | byte | 6298.5 | 9370.1 | 1.49x |
| Max | word | 3102.8 | 5008.6 | 1.61x |
| Max | half | 166.4 | 5019.8 | 30.17x |
| Max | float | 500.3 | 2544.6 | 5.09x |
| Median | byte | 4831.5 | 8417.7 | 1.74x |
| Median | word | 2866.0 | 4272.7 | 1.49x |
| Median | half | 58.7 | 4394.3 | 74.86x |
| Median | float | 811.4 | 2054.3 | 2.53x |
| Deflate | byte | 5649.9 | 7523.0 | 1.33x |
| Deflate | word | 3942.5 |  |  |
| Deflate | half | 235.6 | 2193.4 | 9.31x |
| Deflate | float | 2486.2 |  |  |
| Inflate | byte | 5740.7 | 7376.5 | 1.28x |
| Inflate | word | 4095.4 |  |  |
| Inflate | half | 232.6 | 2189.1 | 9.41x |
| Inflate | float | 2440.5 |  |  |
| Prewitt | byte | 257.0 | 3208.1 | 12.48x |
| Prewitt | word | 253.8 | 2518.8 | 9.92x |
| Prewitt | half | 751.3 | 2065.2 | 2.75x |
| Prewitt | float | 2463.4 |  |  |
| Sobel | byte | 269.0 | 3167.1 | 11.77x |
| Sobel | word | 265.3 | 2213.1 | 8.34x |
| Sobel | half | 664.4 |  |  |
| Sobel | float | 2377.9 |  |  |

##### plus-shaped `coordinates` (fixed-stencil specialisation)
| filter | fmt | C fps | neon fps | neon vs C |
|---|---|--:|--:|--:|
| Min | byte | 3676.2 | 10297.7 | 2.80x |
| Min | word | 2881.3 | 5181.6 | 1.80x |
| Min | half | 182.7 | 5073.1 | 27.77x |
| Min | float | 611.9 | 2624.4 | 4.29x |
| Max | byte | 6258.6 | 10049.8 | 1.61x |
| Max | word | 3088.3 | 5155.1 | 1.67x |
| Max | half | 182.5 | 4936.6 | 27.05x |
| Max | float | 611.9 | 2631.4 | 4.30x |

## Numerical Accuracy Audit

Integer paths are bit-exact with the C reference on every machine and tier, with one caveat class inherited from the reference itself: integer Prewitt/Sobel is the only integer op with float math inside, and the C tier's `sqrt(gx*gx + gy*gy)` changes by one ULP depending on whether the compiler contracts it into an FMA. The NEON kernels match the AArch64 contraction shape exactly (measured 0 vs both clang and gcc C tiers); on x86, -march-variant C tiers fuse while the kernels deterministically do not, so those combinations read at most ±1. All other integer ops are exactly 0 everywhere, including 10-bit word clamping and 4x4-minimum edge geometry.

Every dispatched float row is exactly 0: the shipped float kernels (min/max/median) are pure comparison networks, and the float shapes with accumulation arithmetic run the C tier. That is at or above the existing x86 tiers, whose dispatched deflate/inflate/prewitt/sobel float kernels sit 1-2 ULP from C (accumulation order) on every platform measured. Half min/max/median are exactly 0 for default and zero thresholds and within one f16 ULP for finite ones (the threshold clamp rounds to f16 where C rounds once at the store).

Measured (`accuracy_3x3.py`, 375 integer measurements per machine): max integer mismatch 0 on M4 (clang) and Graviton5 (gcc); every float row exactly 0; half min/max at 1.8-1.9e-04 (one f16 ULP) for finite thresholds only, all other half rows exactly 0. On x86, the sse2, avx2 and avx512 tiers measure exactly 0 against never-fused C tiers: the baseline-arch variant everywhere, and every variant under MSVC, which does not contract at all (1125 measurements at 0 on Windows). Against FMA-fused `-march-variant` C tiers they show exactly the excused ±1 Prewitt/Sobel skew and nothing else, verified on Zen 5 and Xeon 6 under gcc and on Windows under clang-cl.

[accuracy_3x3.py](https://github.com/user-attachments/files/30331595/accuracy_3x3.py)  
[bench_stream_3x3.py](https://github.com/user-attachments/files/30331596/bench_stream_3x3.py)

To reproduce:
```sh
python bench_stream_3x3.py --sweep --threads 1
python bench_stream_3x3.py --sweep --threads 0 --reps 5
python bench_stream_3x3.py --sweep --preset uhd --threads 1
python bench_stream_3x3.py --sweep --preset uhd --threads 0 --reps 5
python accuracy_3x3.py --levels neon
```
