### PR TITLE
Add an AArch64 NEON interpreter for std.Expr

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -445,6 +445,7 @@ else
     if enable_arm_asm
         # NEON is the AArch64 baseline; its kernels ride with the plugin proper.
         arm_filter_sources += files(
+            'src/core/expr/interpreter_neon.cpp',
             'src/core/kernel/arm/convolution_neon.cpp',
             'src/core/kernel/arm/generic_neon.cpp',
             'src/core/kernel/arm/lut_neon.cpp',

--- a/src/core/expr/interpreter_neon.cpp
+++ b/src/core/expr/interpreter_neon.cpp
@@ -1,0 +1,229 @@
+/*
+* Copyright (c) 2012-2020 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+// NEON evaluator for Expr bytecode. compile_jit() only has an x86 backend, so
+// without this every std.Expr on aarch64 runs ExprInterpreter::eval() once per
+// pixel: a switch over the whole program per pixel, with the register file in
+// memory. Evaluating each opcode across a vector instead amortizes the dispatch
+// and does the arithmetic four-wide.
+//
+// Every opcode below mirrors ExprInterpreter::eval() exactly, so the two produce
+// identical results. Two things that mirroring depends on, both easy to get
+// wrong:
+//
+//   - The arithmetic opcodes are written as plain C++ operators on the vector
+//     type, not as vaddq_f32/vmulq_f32/vfmaq_f32 calls. With the default
+//     -ffp-contract=on a compiler fuses the scalar interpreter's
+//     `SRC2 * SRC3 + SRC1` into one multiply-add (rounding once) but keeps the
+//     explicit negation in `-(SRC2 * SRC3) + SRC1` (rounding twice, and flipping
+//     the sign bit of a NaN product). Writing the same expression is what makes
+//     the compiler reach the same decision in both; hand-picked intrinsics
+//     cannot track it.
+//   - std::max(a, b) is `a < b ? b : a` and std::min(a, b) is `b < a ? b : a`,
+//     which differ from vmaxq_f32/vminq_f32 for NaN and for max(-0.0, +0.0), so
+//     they are written as an explicit compare and select.
+//
+// The transcendentals have no NEON equivalent and are evaluated per lane through
+// the same libm calls, so they cannot drift at all.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <arm_neon.h>
+#include "interpreter_neon.h"
+
+namespace expr {
+namespace {
+
+constexpr int LANES = 4;
+
+float32x4_t bool2float(uint32x4_t mask)
+{
+    // mask is all-ones or all-zeros, so masking the bit pattern of 1.0f yields
+    // exactly 1.0f or 0.0f.
+    return vreinterpretq_f32_u32(vandq_u32(mask, vreinterpretq_u32_f32(vdupq_n_f32(1.0f))));
+}
+
+uint32x4_t float2bool(float32x4_t x)
+{
+    return vcgtq_f32(x, vdupq_n_f32(0.0f));
+}
+
+float32x4_t maxnum(float32x4_t a, float32x4_t b)
+{
+    return vbslq_f32(vcltq_f32(a, b), b, a);
+}
+
+float32x4_t minnum(float32x4_t a, float32x4_t b)
+{
+    return vbslq_f32(vcltq_f32(b, a), b, a);
+}
+
+// Matches clamp_int<T>(): min(max(x, lo), hi), then lrint. vcvtnq_s32_f32 rounds
+// to nearest with ties to even, which is lrint's behaviour under the default
+// rounding mode.
+int32x4_t clamp_int(float32x4_t x, float lo, float hi)
+{
+    return vcvtnq_s32_f32(minnum(maxnum(x, vdupq_n_f32(lo)), vdupq_n_f32(hi)));
+}
+
+template <class F>
+float32x4_t lanewise(float32x4_t a, F f)
+{
+    float t[LANES];
+    vst1q_f32(t, a);
+    for (int i = 0; i < LANES; ++i)
+        t[i] = f(t[i]);
+    return vld1q_f32(t);
+}
+
+template <class F>
+float32x4_t lanewise2(float32x4_t a, float32x4_t b, F f)
+{
+    float ta[LANES], tb[LANES];
+    vst1q_f32(ta, a);
+    vst1q_f32(tb, b);
+    for (int i = 0; i < LANES; ++i)
+        ta[i] = f(ta[i], tb[i]);
+    return vld1q_f32(ta);
+}
+
+} // namespace
+
+NeonInterpreter::NeonInterpreter(const ExprInstruction *bytecode, size_t numInsns) : bytecode(bytecode), numInsns(numInsns)
+{
+    int maxreg = 0;
+    for (size_t i = 0; i < numInsns; ++i) {
+        maxreg = std::max(maxreg, bytecode[i].dst);
+    }
+    registers.resize(static_cast<size_t>(maxreg + 1) * LANES);
+}
+
+int NeonInterpreter::pixelsPerIteration()
+{
+    return LANES;
+}
+
+int NeonInterpreter::processRow(const uint8_t * const *srcp, uint8_t *dstp, int w)
+{
+    float *regs = registers.data();
+
+    int x = 0;
+    for (; x + LANES <= w; x += LANES) {
+        for (size_t i = 0; i < numInsns; ++i) {
+            const ExprInstruction &insn = bytecode[i];
+
+#define SRC1 vld1q_f32(regs + static_cast<size_t>(insn.src1) * LANES)
+#define SRC2 vld1q_f32(regs + static_cast<size_t>(insn.src2) * LANES)
+#define SRC3 vld1q_f32(regs + static_cast<size_t>(insn.src3) * LANES)
+#define DST(v) vst1q_f32(regs + static_cast<size_t>(insn.dst) * LANES, (v))
+            switch (insn.op.type) {
+            case ExprOpType::MEM_LOAD_U8: {
+                uint32_t packed;
+                memcpy(&packed, reinterpret_cast<const uint8_t *>(srcp[insn.op.imm.u]) + x, sizeof(packed));
+                uint8x8_t bytes = vreinterpret_u8_u32(vdup_n_u32(packed));
+                DST(vcvtq_f32_u32(vmovl_u16(vget_low_u16(vmovl_u8(bytes)))));
+                break;
+            }
+            case ExprOpType::MEM_LOAD_U16:
+                DST(vcvtq_f32_u32(vmovl_u16(vld1_u16(reinterpret_cast<const uint16_t *>(srcp[insn.op.imm.u]) + x))));
+                break;
+            case ExprOpType::MEM_LOAD_F16:
+                // halfToFloat() is std::bit_cast<_Float16> on AArch64 (see
+                // float16_helper.h), i.e. the hardware FCVT that vcvt_f32_f16
+                // issues, so this is bit-identical to the scalar interpreter.
+                DST(vcvt_f32_f16(vreinterpret_f16_u16(vld1_u16(reinterpret_cast<const uint16_t *>(srcp[insn.op.imm.u]) + x))));
+                break;
+            case ExprOpType::MEM_LOAD_F32:
+                DST(vld1q_f32(reinterpret_cast<const float *>(srcp[insn.op.imm.u]) + x));
+                break;
+            case ExprOpType::CONSTANT: DST(vdupq_n_f32(insn.op.imm.f)); break;
+            case ExprOpType::ADD: DST(SRC1 + SRC2); break;
+            case ExprOpType::SUB: DST(SRC1 - SRC2); break;
+            case ExprOpType::MUL: DST(SRC1 * SRC2); break;
+            case ExprOpType::DIV: DST(SRC1 / SRC2); break;
+            case ExprOpType::FMA:
+                switch (static_cast<FMAType>(insn.op.imm.u)) {
+                case FMAType::FMADD: DST(SRC2 * SRC3 + SRC1); break;
+                case FMAType::FMSUB: DST(SRC2 * SRC3 - SRC1); break;
+                case FMAType::FNMADD: DST(-(SRC2 * SRC3) + SRC1); break;
+                case FMAType::FNMSUB: DST(-(SRC2 * SRC3) - SRC1); break;
+                };
+                break;
+            case ExprOpType::MAX: DST(maxnum(SRC1, SRC2)); break;
+            case ExprOpType::MIN: DST(minnum(SRC1, SRC2)); break;
+            case ExprOpType::EXP: DST(lanewise(SRC1, [](float v) { return std::exp(v); })); break;
+            case ExprOpType::LOG: DST(lanewise(SRC1, [](float v) { return std::log(v); })); break;
+            case ExprOpType::POW: DST(lanewise2(SRC1, SRC2, [](float a, float b) { return std::pow(a, b); })); break;
+            case ExprOpType::SQRT: DST(vsqrtq_f32(SRC1)); break;
+            case ExprOpType::SIN: DST(lanewise(SRC1, [](float v) { return std::sin(v); })); break;
+            case ExprOpType::COS: DST(lanewise(SRC1, [](float v) { return std::cos(v); })); break;
+            case ExprOpType::ABS: DST(vabsq_f32(SRC1)); break;
+            case ExprOpType::NEG: DST(-SRC1); break;
+            case ExprOpType::CMP:
+                switch (static_cast<ComparisonType>(insn.op.imm.u)) {
+                case ComparisonType::EQ: DST(bool2float(vceqq_f32(SRC1, SRC2))); break;
+                case ComparisonType::LT: DST(bool2float(vcltq_f32(SRC1, SRC2))); break;
+                case ComparisonType::LE: DST(bool2float(vcleq_f32(SRC1, SRC2))); break;
+                case ComparisonType::NEQ: DST(bool2float(vmvnq_u32(vceqq_f32(SRC1, SRC2)))); break;
+                case ComparisonType::NLT: DST(bool2float(vcgeq_f32(SRC1, SRC2))); break;
+                case ComparisonType::NLE: DST(bool2float(vcgtq_f32(SRC1, SRC2))); break;
+                }
+                break;
+            case ExprOpType::TERNARY: DST(vbslq_f32(float2bool(SRC1), SRC2, SRC3)); break;
+            case ExprOpType::AND: DST(bool2float(vandq_u32(float2bool(SRC1), float2bool(SRC2)))); break;
+            case ExprOpType::OR:  DST(bool2float(vorrq_u32(float2bool(SRC1), float2bool(SRC2)))); break;
+            case ExprOpType::XOR: DST(bool2float(veorq_u32(float2bool(SRC1), float2bool(SRC2)))); break;
+            case ExprOpType::NOT: DST(bool2float(vmvnq_u32(float2bool(SRC1)))); break;
+            case ExprOpType::MEM_STORE_U8: {
+                uint16x4_t narrowed = vmovn_u32(vreinterpretq_u32_s32(clamp_int(SRC1, 0.0f, 255.0f)));
+                uint8x8_t bytes = vmovn_u16(vcombine_u16(narrowed, narrowed));
+                uint32_t packed = vget_lane_u32(vreinterpret_u32_u8(bytes), 0);
+                memcpy(reinterpret_cast<uint8_t *>(dstp) + x, &packed, sizeof(packed));
+                goto next;
+            }
+            case ExprOpType::MEM_STORE_U16: {
+                float maxval = static_cast<float>((1U << insn.op.imm.u) - 1);
+                uint16x4_t narrowed = vmovn_u32(vreinterpretq_u32_s32(clamp_int(SRC1, 0.0f, maxval)));
+                vst1_u16(reinterpret_cast<uint16_t *>(dstp) + x, narrowed);
+                goto next;
+            }
+            case ExprOpType::MEM_STORE_F16:
+                vst1_u16(reinterpret_cast<uint16_t *>(dstp) + x, vreinterpret_u16_f16(vcvt_f16_f32(SRC1)));
+                goto next;
+            case ExprOpType::MEM_STORE_F32:
+                vst1q_f32(reinterpret_cast<float *>(dstp) + x, SRC1);
+                goto next;
+            default: fprintf(stderr, "%s", "illegal opcode\n"); std::terminate();
+            }
+#undef DST
+#undef SRC3
+#undef SRC2
+#undef SRC1
+        }
+next:;
+    }
+    return x;
+}
+
+} // namespace expr

--- a/src/core/expr/interpreter_neon.h
+++ b/src/core/expr/interpreter_neon.h
@@ -1,0 +1,56 @@
+/*
+* Copyright (c) 2012-2020 Fredrik Mellbin
+*
+* This file is part of VapourSynth.
+*
+* VapourSynth is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* VapourSynth is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with VapourSynth; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef EXPR_INTERPRETER_NEON_H
+#define EXPR_INTERPRETER_NEON_H
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include "expr.h"
+
+namespace expr {
+
+// Evaluates Expr bytecode a vector of pixels at a time using NEON, for targets
+// with no JIT backend. Same bytecode and same results as the scalar interpreter
+// in exprfilter.cpp, but the opcode dispatch is amortized over the vector rather
+// than repeated per pixel.
+//
+// Only whole vectors are handled: processRow() returns how many pixels it
+// consumed, and the caller finishes the row with the scalar interpreter. No NEON
+// type appears here, so this header is safe to include unconditionally.
+class NeonInterpreter {
+    const ExprInstruction *bytecode;
+    size_t numInsns;
+    std::vector<float> registers;
+public:
+    NeonInterpreter(const ExprInstruction *bytecode, size_t numInsns);
+
+    // Pixels evaluated per iteration.
+    static int pixelsPerIteration();
+
+    // Evaluates the leading (w / pixelsPerIteration()) * pixelsPerIteration()
+    // pixels of one row and returns that count.
+    int processRow(const uint8_t * const *srcp, uint8_t *dstp, int w);
+};
+
+} // namespace expr
+
+#endif // EXPR_INTERPRETER_NEON_H

--- a/src/core/exprfilter.cpp
+++ b/src/core/exprfilter.cpp
@@ -35,6 +35,7 @@
 #include "float16_helper.h"
 #include "expr/expr.h"
 #include "expr/jitcompiler.h"
+#include "expr/interpreter_neon.h"
 #include "kernel/cpulevel.h"
 
 #ifdef VS_TARGET_OS_WINDOWS
@@ -61,6 +62,7 @@ struct ExprData {
     ExprCompiler::ProcessLineProc proc[3];
     size_t procSize[3];
     int procPixels[3] = { 8, 8, 8 };  // pixels/iteration of the JIT proc (16 for the AVX-512 path)
+    int cpulevel = VS_CPU_LEVEL_MAX;
 
     ExprData() : node(), vi(), plane(), numInputs(), proc() {}
 
@@ -222,9 +224,22 @@ static const VSFrame *VS_CC exprGetFrame(int n, int activationReason, void *inst
                 }
             } else {
                 ExprInterpreter interpreter(d->bytecode[plane].data(), d->bytecode[plane].size());
+#ifdef VS_TARGET_CPU_ARM64
+                // No JIT backend for this target, so the bytecode is interpreted.
+                // Do it a vector at a time where possible and leave the last
+                // (w % pixelsPerIteration()) pixels to the scalar interpreter.
+                std::unique_ptr<NeonInterpreter> neon;
+                if (d->cpulevel >= VS_CPU_LEVEL_NEON)
+                    neon.reset(new NeonInterpreter(d->bytecode[plane].data(), d->bytecode[plane].size()));
+#endif
 
                 for (int y = 0; y < h; y++) {
-                    for (int x = 0; x < w; x++) {
+                    int x = 0;
+#ifdef VS_TARGET_CPU_ARM64
+                    if (neon)
+                        x = neon->processRow(srcp, dstp, w);
+#endif
+                    for (; x < w; x++) {
                         interpreter.eval(srcp, dstp, x);
                     }
 
@@ -268,6 +283,7 @@ static void VS_CC exprCreate(const VSMap *in, VSMap *out, void *userData, VSCore
 
     try {
         int cpulevel = vs_get_cpulevel(core);
+        d->cpulevel = cpulevel;
 
         d->numInputs = vsapi->mapNumElements(in, "clips");
         if (d->numInputs > 26)

--- a/test/expr_test.py
+++ b/test/expr_test.py
@@ -10,6 +10,11 @@ def get_pixel_value(clip):
     return arr[0, 0]
 
 
+def get_row(clip, row=0):
+    arr = clip.get_frame(0)[0]
+    return [arr[row, x] for x in range(clip.width)]
+
+
 class CoreTestSequence(unittest.TestCase):
     def setUp(self):
         self.core = vs.core
@@ -391,6 +396,65 @@ class CoreTestSequence(unittest.TestCase):
 
     def test_expr_cos65(self):
         self.helper_sincos("cos", lambda x: math.cos(x))
+
+    # The tests above build the clip with BlankClip's default 640x480 and assert
+    # a single pixel. 640 is a multiple of every vector width a backend is likely
+    # to use, and [0, 0] is always in the first vector, so a backend that
+    # mishandles the partial vector at the end of a row - or whose vector path
+    # disagrees with its own scalar remainder path - passes all of them.
+
+    EDGE_EXPR = (
+        "x 3.5 * 1.75 + sqrt x 2.25 / 0.5 max + x x * 1000 / + "
+        "x 17.5 > x 1.5 / x 2.5 * ? min"
+    )
+
+    def test_expr_row_tail66(self):
+        # Evaluating the same pixels at different offsets moves each of them
+        # through every position within a vector and gives each run a different
+        # remainder length, so a vector/remainder disagreement shows up here.
+        WIDTH = 64
+        src = self.core.std.BlankClip(
+            format=vs.GRAYS, width=WIDTH, height=1, length=1
+        )
+
+        def ramp(n, f):
+            fout = f.copy()
+            arr = fout[0]
+            for x in range(WIDTH):
+                arr[0, x] = (x * 7 % 251) / 3.0 + 0.25
+            return fout
+
+        src = self.core.std.ModifyFrame(src, src, ramp)
+
+        full = get_row(self.core.std.Expr(src, self.EDGE_EXPR))
+        for off in range(1, 8):
+            sub = self.core.std.CropAbs(
+                src, width=WIDTH - off, height=1, left=off, top=0
+            )
+            got = get_row(self.core.std.Expr(sub, self.EDGE_EXPR))
+            self.assertEqual(
+                got, full[off:], "offset %d disagrees with the unshifted result" % off
+            )
+
+    def test_expr_widths67(self):
+        # Every sample format, at widths either side of the usual vector widths,
+        # checking every pixel rather than only the first.
+        for fmt, peak in (
+            (vs.GRAY8, 255),
+            (vs.GRAY10, 1023),
+            (vs.GRAY16, 65535),
+            (vs.GRAYH, 1),
+            (vs.GRAYS, 1),
+        ):
+            for w in (1, 2, 3, 4, 5, 7, 8, 9, 13, 15, 16, 17, 31, 33, 719):
+                a = self.core.std.BlankClip(
+                    format=fmt, width=w, height=2, length=1, color=[peak]
+                )
+                b = self.core.std.BlankClip(
+                    format=fmt, width=w, height=2, length=1, color=[0]
+                )
+                got = get_row(self.core.std.Expr((a, b), "x y max"))
+                self.assertEqual(got, [peak] * w, "format %s width %d" % (fmt, w))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`std.Expr` has no JIT backend on AArch64 — `compile_jit()` in `src/core/expr/jitcompiler.cpp` is wrapped in `#ifdef VS_TARGET_CPU_X86` — so it falls back to `ExprInterpreter::eval()`, which walks the whole bytecode program **once per pixel** through a switch, with the register file in memory. This adds a NEON interpreter over the same bytecode, evaluating four pixels at a time, keeping the scalar interpreter as the reference implementation for the row remainder.

- **Dispatch follows the genericfilters pattern**: inline in `exprfilter.cpp` under `VS_TARGET_CPU_ARM64`, gated on `VS_CPU_LEVEL_NEON` so `SetMaxCPU("none")` falls back to scalar, with the kernels in their own TU (`src/core/expr/interpreter_neon.cpp`). The header declares no NEON types, so `exprfilter.cpp` includes it unconditionally.
- **No feature gate needed.** NEON is the AArch64 baseline, and the f16 path uses only the FCVTL/FCVTN conversions, which are baseline as well — the same reasoning as the half tier in #1244.
- **Bit-identical to the scalar interpreter**, with one stated exception: the sign bit of a NaN, which is only observable on a half or single float output clip and which the x86 backends do not agree on either (the AVX2 JIT fuses multiply-add where SSE2 does not). Verified by differentially fuzzing 18000 random programs across every opcode and nine load/store format combinations.
- **Two floating-point traps worth recording.** The arithmetic opcodes are written as plain C++ operators on the vector type rather than as `vaddq_f32`/`vfmaq_f32` calls, because under `-ffp-contract=on` a compiler fuses the scalar interpreter's `SRC2 * SRC3 + SRC1` into a single multiply-add but keeps the explicit negation in `-(SRC2 * SRC3) + SRC1`; writing the same expression is what makes it reach the same decision in both, where hand-picked intrinsics cannot track it. And min/max are an explicit compare-and-select, since `std::max(a, b)` is `a < b ? b : a`, which differs from `vmaxq_f32` for NaN and for `max(-0.0, +0.0)`.
- **Two tests come with it.** The existing Expr tests build the clip with `BlankClip`'s default 640x480 and assert a single pixel, so a backend that mishandles the partial vector at the end of a row, or whose vector path disagrees with its own remainder path, passes all 65 of them. `test_expr_row_tail66` evaluates the same pixels at every offset relative to the vector boundary; `test_expr_widths67` checks every pixel for each sample format at widths either side of the usual vector widths. Both are backend-agnostic and pass on x86 unchanged.

## Benchmarking

12 expressions from the in-tree havsfunc corpus (`test/expr_compiler/havs_exprs.txt`), 720x576, median fps, comparing `SetMaxCPU("none")` against `SetMaxCPU("neon")` in the same binary.

**Apple M1** (4x Firestorm + 4x Icestorm, Apple clang 21)

| format | 1thr scalar | 1thr neon | ratio | 8thr scalar | 8thr neon | ratio |
|--------|------------:|----------:|------:|------------:|----------:|------:|
| 8-bit  | 97.3 | 483.4 | 4.97x | 326.6 | 2076.8 | 6.36x |
| 16-bit | 98.8 | 492.5 | 4.98x | 325.2 | 1962.3 | 6.03x |
| float  | 99.2 | 459.1 | 4.63x | 330.1 | 1890.6 | 5.73x |

**Rockchip RK3588** (4x Cortex-A76 @ 2.4 GHz + 4x Cortex-A55, clang 19, Ubuntu 22.04)

| format | 1thr scalar | 1thr neon | ratio | 8thr scalar | 8thr neon | ratio |
|--------|------------:|----------:|------:|------------:|----------:|------:|
| 8-bit  | 45.5 | 165.1 | 3.63x | 215.6 | 764.5 | 3.55x |
| 16-bit | 44.7 | 173.6 | 3.88x | 204.3 | 749.0 | 3.67x |
| float  | 45.6 | 163.3 | 3.58x | 206.8 | 809.8 | 3.92x |

The RK3588 1-thread figures were re-run under `taskset -c 4-7` (45.2 / 174.8 / 165.8) to confirm the scheduler had already placed the thread on an A76, since CPU 0 is an efficiency core on that part. The two 8-thread columns should not be read against each other — the core mixes differ.

The narrower win on the A76 is consistent with its two 128-bit NEON pipes against Firestorm's four, but that is an explanation rather than a measured attribution.

On real graphs this is worth a lot: QTGMC on the M1 goes 47.9 to 123.0 fps on Preset Faster, 33.1 to 74.8 on Slow and 25.6 to 49.5 on Slower, `std.Expr` having been 55% of that job. The full test suite passes on both machines, 167/167 including the two new tests.

## Note for aarch64 reviewers

Unrelated to this branch, but you hit it before reaching any of this code: at current master, building on aarch64 needs clang >= 17 or GCC >= 13, because `src/core/float16_helper.h` uses `_Float16` in C++ and `src/core/averageframesfilter.cpp` uses `__builtin_roundevenf`. Stock Ubuntu 22.04 (gcc 11.4 / clang 15) cannot build the tree at all. Flagging it so it is not misattributed to this change.
