### PR TITLE
Add support for Python free-threading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,22 +46,8 @@ jobs:
     - uses: astral-sh/setup-uv@v10.0.1
 
     - uses: pypa/cibuildwheel@v4.2.0
-      env:
-        CIBW_BUILD: cp314-win_amd64 cp312-*
-        CIBW_SKIP: cp312-win*
-        CIBW_BUILD_FRONTEND: uv
-        CIBW_CONFIG_SETTINGS_WINDOWS: setup-args=--debug setup-args=--vsenv
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13.3
-        CIBW_ENVIRONMENT_WINDOWS: CC=clang-cl CXX=clang-cl AR=llvm-lib
-        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
       with:
         output-dir: dist
-
-    - name: Fix tag
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        cd dist
-        Get-ChildItem *.whl | ForEach-Object { uvx wheel tags --remove --python-tag cp312 $_.Name }
 
     - uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,12 +55,15 @@ jobs:
         path: dist
 
     - name: Install and run tests
+      env:
+        UV_NO_SYNC: 1
       run: |
-        pip install vapoursynth --no-index --find-links dist
-        vapoursynth config
-        vapoursynth register-install
-        vspipe --version
-        python -m unittest discover -s test -p "*test.py"
+        uv venv --python 3.12
+        uv pip install vapoursynth --no-index --find-links dist
+        uv run vapoursynth config
+        uv run vapoursynth register-install
+        uv run vspipe --version
+        uv run python -m unittest discover -s test -p "*test.py"
 
     # The Windows wheel just built is the same one the installer and portable
     # packages ship, so package them here instead of recompiling the wheel in a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - uses: astral-sh/setup-uv@v8.2.0
+    - uses: astral-sh/setup-uv@v10.0.1
 
-    - uses: pypa/cibuildwheel@v4.1.0
+    - uses: pypa/cibuildwheel@v4.2.0
       env:
         CIBW_BUILD: cp314-win_amd64 cp312-*
         CIBW_SKIP: cp312-win*
@@ -124,7 +124,7 @@ jobs:
 
     - name: Publish installer to release
       if: ${{ runner.os == 'Windows' && startsWith(github.ref, 'refs/tags/R') }}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: installer/Compiled/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,17 +54,6 @@ jobs:
         name: vapoursynth-${{ matrix.arch }}
         path: dist
 
-    - name: Install and run tests
-      env:
-        UV_NO_SYNC: 1
-      run: |
-        uv venv --python 3.12
-        uv pip install vapoursynth --no-index --find-links dist
-        uv run vapoursynth config
-        uv run vapoursynth register-install
-        uv run vspipe --version
-        uv run python -m unittest discover -s test -p "*test.py"
-
     # The Windows wheel just built is the same one the installer and portable
     # packages ship, so package them here instead of recompiling the wheel in a
     # separate job. Everything below only runs on the Windows leg.

--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -407,13 +407,14 @@ Classes and Functions
       The *prefetch* argument is only for debugging purposes and should never need to be changed.
       The *backlog* argument is only for debugging purposes and should never need to be changed.
 
-   .. py:method:: frames([prefetch=None, backlog=None, close=False])
+   .. py:method:: frames([prefetch=None, backlog=None, close=False, collect_garbage=True])
 
       Returns a generator iterator of all VideoFrames in the clip. It will render multiple frames concurrently.
 
       The *prefetch* argument defines how many frames are rendered concurrently. Is only there for debugging purposes and should never need to be changed.
       The *backlog* argument defines how many unconsumed frames (including those that did not finish rendering yet) vapoursynth buffers at most before it stops rendering additional frames. This argument is there to limit the memory this function uses storing frames.
       The *close* argument determines if the frame should be closed after each iteration step. It defaults to false to remain backward compatible.
+      The *collect_garbage* argument determines if gc.collect() should be called after each iteration step. It defaults to true to remain backward compatible.
 
    .. py:method:: clear_cache()
 

--- a/include/cython/vapoursynth_api.h
+++ b/include/cython/vapoursynth_api.h
@@ -7,7 +7,11 @@
 #define MS_WIN64
 #endif
 
+#include "pyconfig.h"
+
+#ifndef Py_GIL_DISABLED
 #define Py_LIMITED_API 0x030C0000
+#endif
 
 #include "Python.h"
 #include "vapoursynth.h"

--- a/meson.build
+++ b/meson.build
@@ -153,9 +153,10 @@ int main() {
     endif
 endif
 
+threads_dep = dependency('threads')
 deps = [
     dl_dep,
-    dependency('threads'),
+    threads_dep,
     dependency('zimg', version: '>=3.0.5'),
 ]
 
@@ -266,7 +267,7 @@ py.install_sources(
 libvsscript = library('vsscript',
     files('src/vsscript/vsscript.cpp'),
     cpp_args: ['-DPy_NO_LINK_LIB', '-DVS_CORE_EXPORTS'] + (is_freethreaded ? ['-DPy_GIL_DISABLED=1'] : []),
-    dependencies: [dl_dep, py_dep],
+    dependencies: [dl_dep, py_dep, threads_dep],
     gnu_symbol_visibility: 'hidden',
     include_directories: incdir,
     install: true,

--- a/meson.build
+++ b/meson.build
@@ -237,12 +237,16 @@ vapoursynth_dep = declare_dependency(
     link_with: libvapoursynth,
 )
 
+is_freethreaded = py.get_variable('Py_GIL_DISABLED', 0) == 1 or py.get_variable('ABIFLAGS', '').contains('t')
+py_limited_api = is_freethreaded ? '' : '3.12'
+
 py.extension_module('vapoursynth',
     files('src/common/wave.cpp', 'src/cython/vapoursynth.pyx'),
+    cython_args: ['-X', 'freethreading_compatible=True'],
     dependencies: [py_dep, vapoursynth_dep],
     install: true,
     install_rpath: '$ORIGIN',
-    limited_api: '3.12',
+    limited_api: py_limited_api,
     override_options: 'cython_language=cpp',
     subdir: 'vapoursynth',
 )
@@ -261,7 +265,7 @@ py.install_sources(
 
 libvsscript = library('vsscript',
     files('src/vsscript/vsscript.cpp'),
-    cpp_args: ['-DPy_NO_LINK_LIB', '-DVS_CORE_EXPORTS'],
+    cpp_args: ['-DPy_NO_LINK_LIB', '-DVS_CORE_EXPORTS'] + (is_freethreaded ? ['-DPy_GIL_DISABLED=1'] : []),
     dependencies: [dl_dep, py_dep],
     gnu_symbol_visibility: 'hidden',
     include_directories: incdir,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,13 @@ exclude = [
 build-frontend = "uv"
 build = ["cp314-win_amd64", "cp312-*", "cp315t-*"]
 skip = ["cp312-win*", "*-win32"]
+test-sources = ["test"]
+test-command = [
+    "vapoursynth config",
+    "vapoursynth register-install",
+    "vspipe --version",
+    'python -m unittest discover -s test -p "*test.py"',
+]
 
 [tool.cibuildwheel.windows]
 config-settings = { setup-args = ["--debug", "--vsenv"] }
@@ -68,6 +75,9 @@ repair-wheel-command = [
     "uvx wheel tags --remove --python-tag cp312 {wheel}",
     'move /y "{wheel}\..\*.whl" "{dest_dir}"',
 ]
+
+[tool.cibuildwheel.linux]
+test-command = 'python -m unittest discover -s test -p "*test.py"'
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "13.3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["Cython>=3.1.0", "meson-python"]
+requires = ["Cython>=3.3.0", "meson-python"]
 build-backend = "mesonpy"
 
 [project]
@@ -9,9 +9,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = "LGPL-2.1-or-later"
 license-files = ["COPYING.LESSER"]
-authors = [
-    {name = "Fredrik Mellbin", email = "fredrik.mellbin@gmail.com"},
-]
+authors = [{ name = "Fredrik Mellbin", email = "fredrik.mellbin@gmail.com" }]
 keywords = ["frameserver", "video", "audio"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -57,6 +55,31 @@ exclude = [
     "*/vspipe.pdb",
     "*/vsvfw.pdb",
 ]
+
+[tool.cibuildwheel]
+build-frontend = "uv"
+build = ["cp314-win_amd64", "cp312-*", "cp315t-*"]
+skip = ["cp312-win*", "*-win32"]
+
+[tool.cibuildwheel.windows]
+config-settings = { setup-args = ["--debug", "--vsenv"] }
+environment = { CC = "clang-cl", CXX = "clang-cl", AR = "llvm-lib" }
+repair-wheel-command = [
+    "uvx wheel tags --remove --python-tag cp312 {wheel}",
+    'move /y "{wheel}\..\*.whl" "{dest_dir}"',
+]
+
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "13.3" }
+
+[[tool.cibuildwheel.overrides]]
+select = "cp3??t-*"
+config-settings = { setup-args = ["-Dpython.allow_limited_api=false"] }
+
+[[tool.cibuildwheel.overrides]]
+select = "cp3??t-win*"
+config-settings = { setup-args = ["--debug", "--vsenv", "-Dpython.allow_limited_api=false"] }
+repair-wheel-command = ""
 
 [tool.ruff]
 extend-exclude = ["vapoursynth.pyi"]

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -22,8 +22,7 @@ include 'vsconstants.pxd'
 from vshelper cimport bitblt
 from vsscript_internal cimport VSScript
 from wave cimport WaveHeader, Wave64Header, CreateWave64Header, CreateWaveHeader, PackChannels16to16le, PackChannels32to24le, PackChannels32to32le
-cimport cython.parallel
-from cython cimport view, final
+cimport cython
 from libc.stdlib cimport malloc, free, realloc
 from libc.stdint cimport intptr_t, int16_t, uint16_t, int32_t, uint32_t, uint8_t, uint64_t, int64_t
 from cpython.buffer cimport PyBUF_READ, PyBUF_SIMPLE, PyBuffer_FillInfo, PyBuffer_Release
@@ -34,7 +33,6 @@ from cpython.ref cimport Py_INCREF, Py_DECREF
 import os
 import enum
 import ctypes
-import threading
 import traceback
 import gc
 import sys
@@ -229,7 +227,7 @@ class VapourSynthAPIVersion(typing.NamedTuple):
 __version__ = VapourSynthVersion(VS_CURRENT_RELEASE, 0)
 __api_version__ = VapourSynthAPIVersion(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR)
 
-@final
+@cython.final
 cdef class EnvironmentData(object):
     cdef bint alive
     cdef Core core
@@ -308,7 +306,7 @@ class EnvironmentPolicy(object):
         return env.alive
 
 
-@final
+@cython.final
 cdef class StandaloneEnvironmentPolicy:
     cdef EnvironmentData _environment
     cdef object _api
@@ -391,7 +389,8 @@ cdef void __stdcall _logFree(void* userData) noexcept nogil:
     with gil:
         Py_DECREF(<object>userData)
 
-@final
+
+@cython.final
 cdef class EnvironmentPolicyAPI:
     # This must be a weak-ref to prevent a cyclic dependency that happens if the API
     # is stored within an EnvironmentPolicy-instance.
@@ -622,7 +621,7 @@ def unregister_on_destroy(callback):
     env.on_destroy.remove(callback)
 
 
-@final
+@cython.final
 cdef class _FastManager(object):
     cdef EnvironmentData target
     cdef EnvironmentData previous
@@ -3668,7 +3667,7 @@ cdef void __stdcall publicFunction(const VSMap *inm, VSMap *outm, void *userData
                 vsapi.mapSetError(outm, emsg)
 
 
-@final
+@cython.final
 cdef class VSScriptEnvironmentPolicy:
     cdef dict _env_map
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2287,7 +2287,7 @@ cdef class RawNode(object):
             self.funcs.getFrameAsync(n, self.node, frameDoneCallback, <void *>data)
 
 
-    def frames(self, prefetch=None, backlog=None, close=False):
+    def frames(self, prefetch=None, backlog=None, close=False, collect_garbage=True):
         if prefetch is None or prefetch <= 0:
             prefetch = self.core.num_threads
         if backlog is None or backlog < 0:
@@ -2418,7 +2418,8 @@ cdef class RawNode(object):
                 with contextlib.suppress(BaseException):
                     fut.result().close()
 
-            gc.collect()
+            if collect_garbage:
+                gc.collect()
 
     def clear_cache(self):
         self.ensure_valid()

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -352,7 +352,7 @@ cdef class StandaloneEnvironmentPolicy:
 # Internal holder of the current policy.
 cdef object _policy = None
 
-cdef const VSAPI *_vsapi = NULL
+cdef const VSAPI *_vsapi = getVapourSynthAPI(VAPOURSYNTH_API_VERSION)
 
 
 cdef void _set_logger(EnvironmentData env, VSLogHandler handler, VSLogHandlerFree free, void *userData):
@@ -4038,10 +4038,7 @@ cdef public api VSCore *vpy4_getCore(VSScript *se) nogil:
 cdef public api const VSAPI *vpy4_getVSAPI(int version) nogil:
     return getVapourSynthAPI(version)
 
-cdef const VSAPI *getVSAPIInternal() nogil:
-    global _vsapi
-    if _vsapi == NULL:
-        _vsapi = getVapourSynthAPI(VAPOURSYNTH_API_VERSION)
+cdef inline const VSAPI *getVSAPIInternal() nogil:
     return _vsapi
 
 cdef public api int vpy4_getVariable(VSScript *se, const char *name, VSMap *dst) nogil:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -45,9 +45,9 @@ import functools
 import typing
 import warnings
 import keyword
-from threading import local as ThreadLocal, Lock, RLock
+from threading import local as ThreadLocal, Condition, Event, Lock
 from types import MappingProxyType
-from collections.abc import ItemsView, Iterable, KeysView, MutableMapping, ValuesView
+from collections.abc import ItemsView, Iterable, KeysView, Mapping, MutableMapping, ValuesView
 from concurrent.futures import Future, CancelledError as FutureCancelledError, wait as wait_futures
 from fractions import Fraction
 
@@ -227,15 +227,105 @@ class VapourSynthAPIVersion(typing.NamedTuple):
 __version__ = VapourSynthVersion(VS_CURRENT_RELEASE, 0)
 __api_version__ = VapourSynthAPIVersion(VAPOURSYNTH_API_MAJOR, VAPOURSYNTH_API_MINOR)
 
+
+cdef object _SYNCHRONIZED_SENTINEL
+try:
+    _SYNCHRONIZED_SENTINEL = sentinel("_SYNCHRONIZED_SENTINEL")
+except NameError:
+    _SYNCHRONIZED_SENTINEL = object()
+
+
+@cython.final
+@cython.internal
+cdef class SynchronizedDict:
+    cdef dict data
+    cdef cython.pymutex lock
+
+    def __cinit__(self):
+        self.data = {}
+
+    def __getitem__(self, object key):
+        with self.lock:
+            return self.data[key]
+
+    def __setitem__(self, object key, object value):
+        with self.lock:
+            self.data[key] = value
+
+    def __delitem__(self, object key):
+        with self.lock:
+            del self.data[key]
+
+    def __contains__(self, object key):
+        with self.lock:
+            return key in self.data
+
+    def __len__(self):
+        with self.lock:
+            return len(self.data)
+
+    def __iter__(self):
+        with self.lock:
+            return iter(list(self.data))
+
+    def get(self, object key, object default=None):
+        with self.lock:
+            return self.data.get(key, default)
+
+    def pop(self, object key, object default=_SYNCHRONIZED_SENTINEL):
+        with self.lock:
+            if default is _SYNCHRONIZED_SENTINEL:
+                return self.data.pop(key)
+            return self.data.pop(key, default)
+
+    def clear(self):
+        with self.lock:
+            self.data.clear()
+
+    def keys(self):
+        with self.lock:
+            return list(self.data.keys())
+
+    def values(self):
+        with self.lock:
+            return list(self.data.values())
+
+    def items(self):
+        with self.lock:
+            return list(self.data.items())
+
+    def copy(self):
+        with self.lock:
+            return dict(self.data)
+
+
+class SynchronizedDictView(Mapping):
+    def __init__(self, target):
+        self._target = target
+
+    def __getitem__(self, key):
+        return self._target[key]
+
+    def __iter__(self):
+        return iter(self._target)
+
+    def __len__(self):
+        return len(self._target)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({dict(self._target.items())!r})"
+
+
 @cython.final
 cdef class EnvironmentData(object):
     cdef bint alive
+    cdef bint destroying
     cdef Core core
     cdef object on_destroy
-    cdef dict outputs
-    cdef dict active_exceptions
+    cdef SynchronizedDict outputs
+    cdef SynchronizedDict active_exceptions
     cdef int next_exc_id
-    cdef object exc_lock
+    cdef cython.pymutex lock
 
     cdef int coreCreationFlags
     cdef VSLogHandle* log
@@ -262,24 +352,28 @@ cdef class EnvironmentData(object):
         _unset_logger(self)
 
     cdef int store_exception(self, object e):
-        if self.active_exceptions is None:
+        cdef SynchronizedDict exc = self.active_exceptions
+
+        if exc is None:
             return 0
 
-        with self.exc_lock:
+        with exc.lock:
             self.next_exc_id += 1
-            self.active_exceptions[self.next_exc_id] = e
+            exc.data[self.next_exc_id] = e
 
-            if len(self.active_exceptions) > 1000:
-                self.active_exceptions.pop(next(iter(self.active_exceptions)), None)
+            if len(exc.data) > 1000:
+                exc.data.pop(next(iter(exc.data)), None)
 
             return self.next_exc_id
 
     cdef object retrieve_exception(self, str msg_str):
-        if self.active_exceptions is not None and msg_str.startswith("[VS_PY_EXC_ID:"):
+        cdef SynchronizedDict exc = self.active_exceptions
+
+        if exc is not None and msg_str.startswith("[VS_PY_EXC_ID:"):
             try:
                 parts = msg_str.split("]\n", 1)
                 exc_id = int(parts[0][len("[VS_PY_EXC_ID:"):])
-                return self.active_exceptions.pop(exc_id, None)
+                return exc.pop(exc_id, None)
             except (ValueError, KeyError, IndexError):
                 pass
         return None
@@ -349,8 +443,10 @@ cdef class StandaloneEnvironmentPolicy:
         return environment is self._environment
 
 
-# Internal holder of the current policy.
+# Internal holder of the current policy and lock.
 cdef object _policy = None
+cdef cython.pymutex _policy_lock
+_policy_ready = Event()
 
 cdef const VSAPI *_vsapi = getVapourSynthAPI(VAPOURSYNTH_API_VERSION)
 
@@ -396,7 +492,7 @@ cdef class EnvironmentPolicyAPI:
     # is stored within an EnvironmentPolicy-instance.
     cdef object _target_policy
 
-    cdef object _lock
+    cdef cython.pymutex _lock
     cdef object _known_environments
     # Sadly, weakref has no WeakSet.
     # So we use a counter to fake a WeakSet.
@@ -421,16 +517,16 @@ cdef class EnvironmentPolicyAPI:
         cdef EnvironmentData env = EnvironmentData.__new__(EnvironmentData)
         env.core = None
         env.log = NULL
-        env.outputs = {}
-        env.active_exceptions = {}
+        env.outputs = SynchronizedDict()
+        env.active_exceptions = SynchronizedDict()
         env.next_exc_id = 0
-        env.exc_lock = Lock()
         env.coreCreationFlags = flags
         env.on_destroy = []
         env.env_locals = weakref.WeakKeyDictionary()
         env.known_nodes = weakref.WeakSet()
         env.known_frames = weakref.WeakSet()
         env.active_futures = weakref.WeakSet()
+        env.destroying = False
         env.alive = True
 
         with self._lock:
@@ -454,29 +550,39 @@ cdef class EnvironmentPolicyAPI:
 
     def destroy_environment(self, EnvironmentData env):
         self.ensure_policy_matches()
-        if not env.alive:
-            return
 
-        futs = env.active_futures
-        env.active_futures = None
-        wait_futures(futs)
+        with env.lock:
+            if not env.alive or env.destroying:
+                return
+            env.destroying = True
 
-        callbacks = env.on_destroy
-        env.on_destroy = None
+            futs = env.active_futures
+            env.active_futures = None
 
-        with use_environment(env).use():
-            for callback in callbacks:
-                try:
-                    callback()
-                except Exception as e:
-                    formatted = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
-                    if env.core is not None:
-                        env.core.log_message(MessageType.MESSAGE_TYPE_CRITICAL, formatted)
-                    else:
-                        sys.stderr.write(formatted)
+            callbacks = env.on_destroy
+            env.on_destroy = None
+
+        if futs is not None:
+            wait_futures(futs)
+
+        if callbacks is not None:
+            with use_environment(env).use():
+                for callback in callbacks:
+                    try:
+                        callback()
+                    except Exception as e:
+                        formatted = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
+                        if env.core is not None:
+                            env.core.log_message(MessageType.MESSAGE_TYPE_CRITICAL, formatted)
+                        else:
+                            sys.stderr.write(formatted)
 
         # Invalidate all remaining nodes and frames from this environment
-        for node in list(env.known_nodes):
+        with env.lock:
+            nodes = list(env.known_nodes or [])
+            frames = list(env.known_frames or [])
+
+        for node in nodes:
             if not isinstance(node, RawNode):
                 continue
             rn = <RawNode>node
@@ -486,7 +592,7 @@ cdef class EnvironmentPolicyAPI:
                 rn.node = NULL
                 rn.core = None
 
-        for frame in list(env.known_frames):
+        for frame in frames:
             if not isinstance(frame, RawFrame):
                 continue
             rf = <RawFrame>frame
@@ -506,18 +612,25 @@ cdef class EnvironmentPolicyAPI:
                         c.funcs.freeCore(c.core)
                 c.core = NULL
 
-        env.core = None
-        env.log = NULL
-        env.outputs = {}
-        env.env_locals.clear()
-        env.env_locals = None
-        env.active_exceptions = None
-        env.exc_lock = None
-        env.known_nodes.clear()
-        env.known_nodes = None
-        env.known_frames.clear()
-        env.known_frames = None
-        env.alive = False
+        with env.lock:
+            env.alive = False
+            if env.outputs is not None:
+                env.outputs.clear()
+                env.outputs = None
+            env.core = None
+            env.log = NULL
+            if env.env_locals is not None:
+                env.env_locals.clear()
+                env.env_locals = None
+            if env.active_exceptions is not None:
+                env.active_exceptions.clear()
+                env.active_exceptions = None
+            if env.known_nodes is not None:
+                env.known_nodes.clear()
+                env.known_nodes = None
+            if env.known_frames is not None:
+                env.known_frames.clear()
+                env.known_frames = None
 
     def unregister_policy(self):
         self.ensure_policy_matches()
@@ -535,44 +648,60 @@ cdef class EnvironmentPolicyAPI:
             return f"<EnvironmentPolicyAPI bound to {target!r}>"
 
 
-def register_policy(policy):
+# This function must be invoked with the _policy_lock acquired
+cdef _register_policy_unlocked(object policy):
     global _policy
-    if _policy is not None:
-        raise RuntimeError("There is already a policy registered.")
+    _policy_ready.clear()
     _policy = policy
 
-    # Expose Additional API-calls to the newly registered Environment-policy.
     cdef EnvironmentPolicyAPI _api = EnvironmentPolicyAPI.__new__(EnvironmentPolicyAPI)
     _api._target_policy = weakref.ref(_policy)
-    _api._known_environments = weakref.WeakValueDictionary()
-    _api._lock = threading.Lock()
-    _policy.on_policy_registered(_api)
+    _api._known_environments = weakref.WeakSet()
+    try:
+        _policy.on_policy_registered(_api)
+    except BaseException:
+        _policy = None
+        raise
+    finally:
+        _policy_ready.set()
+
+
+def register_policy(policy):
+    with _policy_lock:
+        if _policy is not None:
+            raise RuntimeError("There is already a policy registered.")
+        _register_policy_unlocked(policy)
 
 
 def _try_enable_introspection(version=None):
-    global _policy
-    if _policy is not None:
-        return False
-
     if version != 0:
         return False
 
-    cdef StandaloneEnvironmentPolicy standalone_policy = StandaloneEnvironmentPolicy.__new__(StandaloneEnvironmentPolicy)
-    standalone_policy._flags = ccfEnableGraphInspection;
-    register_policy(standalone_policy)
+    cdef StandaloneEnvironmentPolicy standalone_policy
 
-    return True
+    with _policy_lock:
+        if _policy is not None:
+            return False
+
+        standalone_policy = StandaloneEnvironmentPolicy.__new__(StandaloneEnvironmentPolicy)
+        standalone_policy._flags = ccfEnableGraphInspection
+        _register_policy_unlocked(standalone_policy)
+        return True
 
 
 ## DO NOT EXPOSE THIS FUNCTION TO PYTHON-LAND!
 cdef get_policy():
     global _policy
+
     cdef StandaloneEnvironmentPolicy standalone_policy
 
-    if _policy is None:
-        standalone_policy = StandaloneEnvironmentPolicy.__new__(StandaloneEnvironmentPolicy)
-        standalone_policy._flags = 0
-        register_policy(standalone_policy)
+    if not _policy_ready.is_set():
+        with _policy_lock:
+            if _policy is None:
+                standalone_policy = StandaloneEnvironmentPolicy.__new__(StandaloneEnvironmentPolicy)
+                standalone_policy._flags = 0
+                _register_policy_unlocked(standalone_policy)
+        _policy_ready.wait()
 
     return _policy
 
@@ -581,16 +710,20 @@ def has_policy():
 
 cdef clear_policy(delay=False):
     global _policy
-    old_policy = _policy
-
-    if not delay:
-        _policy = None
+    cdef object old_policy
+    with _policy_lock:
+        old_policy = _policy
+        if not delay:
+            _policy = None
+            _policy_ready.clear()
 
     if old_policy is not None:
         old_policy.on_policy_cleared()
 
     if delay:
-        _policy = None
+        with _policy_lock:
+            _policy = None
+            _policy_ready.clear()
 
     return old_policy
 
@@ -606,19 +739,23 @@ def register_on_destroy(callback):
     cdef EnvironmentData env = get_policy().get_current_environment()
     if env is None:
         raise RuntimeError("No environment is currently activated.")
-    if env.on_destroy is None:
-        raise ValueError("The environment is already being destroyed.")
 
-    env.on_destroy.append(callback)
+    with env.lock:
+        if env.on_destroy is None:
+            raise ValueError("The environment is already being destroyed.")
+        env.on_destroy.append(callback)
+
 
 def unregister_on_destroy(callback):
     cdef EnvironmentData env = get_policy().get_current_environment()
     if env is None:
         raise RuntimeError("No environment is currently activated.")
-    if env.on_destroy is None:
-        raise ValueError("The environment is already being destroyed.")
 
-    env.on_destroy.remove(callback)
+    with env.lock:
+        if env.on_destroy is None:
+            raise ValueError("The environment is already being destroyed.")
+
+        env.on_destroy.remove(callback)
 
 
 @cython.final
@@ -895,29 +1032,29 @@ class Error(Exception):
     def __repr__(self):
         return repr(self.value)
 
-cdef _get_output_dict(funcname="this function"):
+
+cdef SynchronizedDict _get_output_dict(funcname="this function"):
     cdef EnvironmentData env = _env_current()
     if env is None:
-        raise Error('Internal environment id not set. %s called from a filter callback?'%funcname)
+        raise Error(f'Internal environment id not set. {funcname} called from a filter callback?')
     return env.outputs
 
+
 def clear_output(int index = 0):
-    cdef dict outputs = _get_output_dict("clear_output")
-    try:
-        del outputs[index]
-    except KeyError:
-        pass
+    _get_output_dict("clear_output").pop(index, None)
+
 
 def clear_outputs():
-    cdef dict outputs = _get_output_dict("clear_outputs")
-    outputs.clear()
+    _get_output_dict("clear_outputs").clear()
+
 
 def get_outputs():
-    cdef dict outputs = _get_output_dict("get_outputs")
-    return MappingProxyType(outputs)
+    return SynchronizedDictView(_get_output_dict("get_outputs"))
+
 
 def get_output(int index = 0):
     return _get_output_dict("get_output")[index]
+
 
 cdef class FuncData(object):
     cdef object func
@@ -1010,8 +1147,10 @@ cdef class CallbackData(object):
         # just the future returning form
         self.fut = Future()
         self.fut.set_running_or_notify_cancel()
-        if env is not None and env.active_futures is not None:
-            env.active_futures.add(self.fut)
+        if env is not None:
+            with env.lock:
+                if env.active_futures is not None:
+                    env.active_futures.add(self.fut)
 
 
 cdef createCallbackData(const VSAPI* funcs, RawNode node, object cb):
@@ -1787,8 +1926,10 @@ cdef VideoFrame createConstVideoFrame(const VSFrame *constf, const VSAPI *funcs,
     instance.format = createVideoFormat(funcs.getVideoFrameFormat(constf), funcs, core)
     instance.width = funcs.getFrameWidth(constf, 0)
     instance.height = funcs.getFrameHeight(constf, 0)
-    if env is not None and env.known_frames is not None:
-        env.known_frames.add(instance)
+    if env is not None:
+        with env.lock:
+            if env.known_frames is not None:
+                env.known_frames.add(instance)
     return instance
 
 
@@ -1804,8 +1945,10 @@ cdef VideoFrame createVideoFrame(VSFrame *f, const VSAPI *funcs, VSCore *core):
     instance.format = createVideoFormat(funcs.getVideoFrameFormat(f), funcs, core)
     instance.width = funcs.getFrameWidth(f, 0)
     instance.height = funcs.getFrameHeight(f, 0)
-    if env is not None and env.known_frames is not None:
-        env.known_frames.add(instance)
+    if env is not None:
+        with env.lock:
+            if env.known_frames is not None:
+                env.known_frames.add(instance)
     return instance
 
 
@@ -1995,8 +2138,10 @@ cdef AudioFrame createConstAudioFrame(const VSFrame *constf, const VSAPI *funcs,
     instance.bytes_per_sample = format.bytesPerSample
     instance.channel_layout = format.channelLayout
     instance.num_channels = format.numChannels
-    if env is not None and env.known_frames is not None:
-        env.known_frames.add(instance)
+    if env is not None:
+        with env.lock:
+            if env.known_frames is not None:
+                env.known_frames.add(instance)
     return instance
 
 
@@ -2015,8 +2160,10 @@ cdef AudioFrame createAudioFrame(VSFrame *f, const VSAPI *funcs, VSCore *core):
     instance.bytes_per_sample = format.bytesPerSample
     instance.channel_layout = format.channelLayout
     instance.num_channels = format.numChannels
-    if env is not None and env.known_frames is not None:
-        env.known_frames.add(instance)
+    if env is not None:
+        with env.lock:
+            if env.known_frames is not None:
+                env.known_frames.add(instance)
     return instance
 
 
@@ -2146,11 +2293,9 @@ cdef class RawNode(object):
     def frames(self, prefetch=None, backlog=None, close=False):
         if prefetch is None or prefetch <= 0:
             prefetch = self.core.num_threads
-
         if backlog is None or backlog < 0:
             backlog = prefetch * 3
-        elif backlog < prefetch:
-            backlog = prefetch
+        backlog = max(backlog, prefetch)
 
         def _get_enum_fut():
             get_frame_async = self.get_frame_async
@@ -2167,89 +2312,114 @@ cdef class RawNode(object):
 
         finished = False
         running = 0
-        lock = RLock()
+        refilling = False
+        cond = Condition()
         reorder = {}
-        curr_frames = 0
 
         def _request_next():
-            nonlocal finished, running, curr_frames
+            nonlocal finished, running
 
+            # Must be called with lock held.
             if finished:
                 return
+            try:
+                idx, fut = enum_fut()
+            except StopIteration:
+                finished = True
+                return
+            except BaseException:
+                finished = True
+                cond.notify_all()
+                raise
 
-            with lock:
-                try:
-                    idx, fut = enum_fut()
-                except StopIteration:
-                    finished = True
-                    return
+            reorder[idx] = fut
+            running += 1
 
-                reorder[idx] = fut
-                running += 1
-                curr_frames += 1
-
-                fut.add_done_callback(_finished)
+            fut.add_done_callback(_finished)
 
         def _finished(f):
             nonlocal finished, running
 
-            with lock:
+            with cond:
                 running -= 1
 
                 if finished:
+                    cond.notify_all()
                     return
 
-                if f.exception() is not None:
+                if f.cancelled() or f.exception() is not None:
                     finished = True
+                    cond.notify_all()
                     return
 
-                _refill()
+                if not refilling:
+                    _refill()
+                cond.notify_all()
 
         def _refill():
-            if finished:
+            # Must be called with lock held.
+            nonlocal refilling
+            if finished or refilling:
                 return
 
-            with lock:
+            refilling = True
+            try:
                 # Two rules: 1. Don't exceed the concurrency barrier.
                 #            2. Don't exceed unused-frames-backlog
-                while (not finished) and (running < prefetch) and curr_frames < backlog:
+                while (not finished) and (running < prefetch) and len(reorder) < backlog:
                     _request_next()
-        _refill()
+            finally:
+                refilling = False
+
+        with cond:
+            _refill()
+
+        def has_next_or_done():
+            return sidx in reorder or (finished and not reorder)
 
         sidx = 0
 
         try:
-            while (not finished) or (curr_frames > 0) or running > 0:
-                if sidx not in reorder:
-                    # Spin. Reorder being empty should never happen.
-                    continue
+            while True:
+                with cond:
+                    cond.wait_for(has_next_or_done)
 
-                # Get next requested frame
-                fut = reorder[sidx]
+                    if finished and not reorder:
+                        break
+
+                    # Get next requested frame
+                    fut = reorder.get(sidx, None)
+
+                if fut is None:
+                    continue
 
                 result = fut.result()
 
-                del reorder[sidx]
-
-                curr_frames -= 1
-                _refill()
+                with cond:
+                    reorder.pop(sidx, None)
+                    _refill()
+                    cond.notify_all()
 
                 sidx += 1
 
                 try:
                     yield result
-
                 finally:
                     if close:
                         result.close()
         finally:
-            finished = True
+            with cond:
+                finished = True
+                remaining = list(reorder.values())
+                reorder.clear()
+                cond.notify_all()
 
-            for fut in reorder.copy().values():
-                if fut.exception() is not None:
+            for fut in remaining:
+                if fut.cancelled() or fut.exception() is not None:
                     continue
 
-                fut.result().close()
+                with contextlib.suppress(BaseException):
+                    fut.result().close()
 
             gc.collect()
 
@@ -2401,8 +2571,10 @@ cdef class VideoNode(RawNode):
         # tracked so environment teardown can wait for blocking requests as well
         fut = Future()
         fut.set_running_or_notify_cancel()
-        if env is not None and env.active_futures is not None:
-            env.active_futures.add(fut)
+        if env is not None:
+            with env.lock:
+                if env.active_futures is not None:
+                    env.active_futures.add(fut)
         try:
             with nogil:
                 f = self.funcs.getFrame(n, self.node, errorMsg, 4096)
@@ -2675,8 +2847,10 @@ cdef VideoNode createVideoNode(VSNode *node, const VSAPI *funcs, Core core):
     else:
         instance.fps = Fraction(0, 1)
 
-    if env is not None and env.known_nodes is not None:
-        env.known_nodes.add(instance)
+    if env is not None:
+        with env.lock:
+            if env.known_nodes is not None:
+                env.known_nodes.add(instance)
 
     return instance
 
@@ -2723,8 +2897,10 @@ cdef class AudioNode(RawNode):
         # tracked so environment teardown can wait for blocking requests as well
         fut = Future()
         fut.set_running_or_notify_cancel()
-        if env is not None and env.active_futures is not None:
-            env.active_futures.add(fut)
+        if env is not None:
+            with env.lock:
+                if env.active_futures is not None:
+                    env.active_futures.add(fut)
         try:
             with nogil:
                 f = self.funcs.getFrame(n, self.node, errorMsg, 4096)
@@ -2852,6 +3028,7 @@ cdef class AudioNode(RawNode):
             fileobj.flush()
 
     def set_output(self, int index = 0):
+        self.ensure_valid()
         _get_output_dict("set_output")[index] = self
 
     @property
@@ -2977,8 +3154,10 @@ cdef AudioNode createAudioNode(VSNode *node, const VSAPI *funcs, Core core):
     instance.channel_layout = instance.ai.format.channelLayout
     instance.num_channels = instance.ai.format.numChannels
 
-    if env is not None and env.known_nodes is not None:
-        env.known_nodes.add(instance)
+    if env is not None:
+        with env.lock:
+            if env.known_nodes is not None:
+                env.known_nodes.add(instance)
 
     return instance
 
@@ -3282,9 +3461,15 @@ cdef Core _get_core(threads = None):
     return vsscript_get_core_internal(env)
 
 cdef Core vsscript_get_core_internal(EnvironmentData env):
-    if env.core is None:
-        env.core = createCore(env)
-    return env.core
+    cdef Core core = env.core
+    if core is None:
+        with env.lock:
+            if not env.alive or env.destroying:
+                raise Error('Cannot access or create core on a destroyed environment.')
+            if env.core is None:
+                env.core = createCore(env)
+            core = env.core
+    return core
 
 cdef class _CoreProxy(object):
 
@@ -3605,11 +3790,17 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
             return
 
         s = warnings.formatwarning(message, category, filename, lineno, line)
-        core = vsscript_get_core_internal(env)
-        core.log_message(mtWarning, s)
+        try:
+            core = vsscript_get_core_internal(env)
+            if core is not None:
+                core.log_message(mtWarning, s)
+                return
+        except:
+            pass
+        if _warnings_showwarning is not None:
+            _warnings_showwarning(message, category, filename, lineno, file, line)
 
 class PythonVSScriptLoggingBridge(logging.Handler):
-
     def __init__(self, parent, level=logging.NOTSET):
         super().__init__(level)
         self._parent = parent
@@ -3619,7 +3810,13 @@ class PythonVSScriptLoggingBridge(logging.Handler):
         if env is None:
             self.parent.handle(record)
             return
-        core = vsscript_get_core_internal(env)
+        try:
+            core = vsscript_get_core_internal(env)
+        except Exception:
+            core = None
+        if core is None:
+            self.parent.handle(record)
+            return
 
         message = self.format(record)
 
@@ -3669,10 +3866,9 @@ cdef void __stdcall publicFunction(const VSMap *inm, VSMap *outm, void *userData
 
 @cython.final
 cdef class VSScriptEnvironmentPolicy:
-    cdef dict _env_map
+    cdef SynchronizedDict _env_map
 
     cdef object _stack
-    cdef object _lock
     cdef EnvironmentPolicyAPI _api
 
     cdef object __weakref__
@@ -3685,7 +3881,7 @@ cdef class VSScriptEnvironmentPolicy:
 
         self._stack = ThreadLocal()
         self._api = policy_api
-        self._env_map = {}
+        self._env_map = SynchronizedDict()
 
         # Redirect warnings to the parent application.
         _warnings_showwarning = warnings.showwarning
@@ -3701,7 +3897,9 @@ cdef class VSScriptEnvironmentPolicy:
     def on_policy_cleared(self):
         global _warnings_showwarning
 
-        self._env_map = None
+        if self._env_map is not None:
+            self._env_map.clear()
+            self._env_map = None
         self._stack = None
 
         # Reset the warnings from the parent application
@@ -3719,15 +3917,21 @@ cdef class VSScriptEnvironmentPolicy:
         sys.stdout = sys.__stdout__
 
     cdef EnvironmentData get_environment(self, id):
+        if self._env_map is None:
+            return None
         return self._env_map.get(id, None)
 
     def get_current_environment(self):
+        if self._stack is None:
+            return None
         return getattr(self._stack, "stack", None)
 
     def set_environment(self, environment):
         if not self.is_alive(environment):
             environment = None
 
+        if self._stack is None:
+            return None
         previous = getattr(self._stack, "stack", None)
         self._stack.stack = environment
         return previous
@@ -3739,14 +3943,17 @@ cdef class VSScriptEnvironmentPolicy:
             env.core = createCore2(se.core)
             se.core = NULL # unset the core to indicate it's been used
 
-        self._env_map[script_id] = env
+        if self._env_map is not None:
+            self._env_map[script_id] = env
         return env
 
     cdef has_environment(self, int script_id):
-        return script_id in self._env_map
+        return self._env_map is not None and script_id in self._env_map
 
     cdef _free_environment(self, int script_id):
-        env = self._env_map.pop(script_id, None)
+        cdef EnvironmentData env = None
+        if self._env_map is not None:
+            env = self._env_map.pop(script_id, None)
         if env is not None:
             sys.stdout.flush()
             sys.stderr.flush()
@@ -3764,19 +3971,11 @@ cdef VSScriptEnvironmentPolicy _get_vsscript_policy():
     return <VSScriptEnvironmentPolicy>_policy
 
 
-cdef object _vsscript_use_environment(int id):
-    return use_environment(_get_vsscript_policy().get_environment(id))
-
-
 cdef object _vsscript_use_or_create_environment2(int id, VSScript *se):
     cdef VSScriptEnvironmentPolicy policy = _get_vsscript_policy()
     if not policy.has_environment(id):
         policy._make_environment(id, se)
     return use_environment(policy.get_environment(id))
-
-
-cdef object _vsscript_use_or_create_environment(int id):
-    return _vsscript_use_or_create_environment2(id, NULL)
 
 
 @contextlib.contextmanager
@@ -3831,7 +4030,7 @@ cdef int _vpy_evaluate(VSScript *se, bytes script, str filename):
         with _vsscript_use_or_create_environment2(se.id, se).use():
             exec(code, pyenvdict, pyenvdict)
 
-    except SystemExit, e:
+    except SystemExit as e:
         try:
             se.exitCode = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
         except OverflowError:
@@ -3841,7 +4040,7 @@ cdef int _vpy_evaluate(VSScript *se, bytes script, str filename):
         Py_INCREF(errstr)
         se.errstr = <void *>errstr
         return 3
-    except BaseException, e:
+    except BaseException as e:
         errstr = 'Python exception: ' + str(e) + '\n\n' + traceback.format_exc()
         errstr = errstr.encode('utf-8')
         Py_INCREF(errstr)
@@ -3965,7 +4164,10 @@ cdef public api VSNode *vpy4_getOutput(VSScript *se, int index) nogil:
         pyenvdict = <dict>se.pyenvdict
         node = None
         try:
-            node = _get_vsscript_policy().get_environment(se.id).outputs[index]
+            env = _get_vsscript_policy().get_environment(se.id)
+            if env is None:
+                return NULL
+            node = env.outputs.get(index, None)
         except:
             return NULL
 
@@ -3982,7 +4184,10 @@ cdef public api VSNode *vpy4_getAlphaOutput(VSScript *se, int index) nogil:
         pyenvdict = <dict>se.pyenvdict
         node = None
         try:
-            node = _get_vsscript_policy().get_environment(se.id).outputs[index]
+            env = _get_vsscript_policy().get_environment(se.id)
+            if env is None:
+                return NULL
+            node = env.outputs.get(index, None)
         except:
             return NULL
 
@@ -3997,7 +4202,10 @@ cdef public api int vpy4_getAltOutputMode(VSScript *se, int index) nogil:
         pyenvdict = <dict>se.pyenvdict
         output = None
         try:
-            output = _get_vsscript_policy().get_environment(se.id).outputs[index]
+            env = _get_vsscript_policy().get_environment(se.id)
+            if env is None:
+                return 0
+            output = env.outputs.get(index, None)
         except:
             return 0
 
@@ -4009,26 +4217,32 @@ cdef public api int vpy4_getAvailableOutputNodes(VSScript *se, int size, int *ds
     cdef int dstidx = 0
     with gil:
         pyenvdict = <dict>se.pyenvdict
-        nodes = None
+        keys = None
         try:
-            nodes = _get_vsscript_policy().get_environment(se.id).outputs
+            env = _get_vsscript_policy().get_environment(se.id)
+            if env is None:
+                return 0
+            keys = env.outputs.keys()
         except:
             return 0
 
-        if size > 0:
-            for key in nodes:
+        if size > 0 and keys is not None:
+            for key in keys:
                 dst[dstidx] = key
                 dstidx = dstidx + 1
                 if size - dstidx <= 0:
                     break
 
-        return len(nodes)
+        return len(keys) if keys is not None else 0
 
 cdef public api VSCore *vpy4_getCore(VSScript *se) nogil:
     with gil:
         try:
-            core = vsscript_get_core_internal(_get_vsscript_policy().get_environment(se.id))
-            if core is not None:
+            env = _get_vsscript_policy().get_environment(se.id)
+            if env is None:
+                return NULL
+            core = vsscript_get_core_internal(env)
+            if core is not None and (<Core>core).core != NULL:
                 return (<Core>core).core
             else:
                 return NULL
@@ -4043,26 +4257,30 @@ cdef inline const VSAPI *getVSAPIInternal() nogil:
 
 cdef public api int vpy4_getVariable(VSScript *se, const char *name, VSMap *dst) nogil:
     with gil:
-        with _vsscript_use_environment(se.id).use():
-            pyenvdict = <dict>se.pyenvdict
-            try:
+        try:
+            env = _get_vsscript_policy().get_environment(se.id)
+            with use_environment(env).use():
+                pyenvdict = <dict>se.pyenvdict
                 dname = name.decode('utf-8')
-                read_var = { dname:pyenvdict[dname]}
-                core = vsscript_get_core_internal(_get_vsscript_policy().get_environment(se.id))
-                dictToMap(read_var, dst, core.core, core.funcs)
+                read_var = { dname: pyenvdict[dname] }
+                core = vsscript_get_core_internal(env)
+                if core is None or (<Core>core).core == NULL:
+                    return 1
+                dictToMap(read_var, dst, (<Core>core).core, (<Core>core).funcs)
                 return 0
-            except:
-                return 1
+        except:
+            return 1
 
 cdef public api int vpy4_setVariables(VSScript *se, const VSMap *vars) nogil:
     with gil:
-        with _vsscript_use_environment(se.id).use():
-            pyenvdict = <dict>se.pyenvdict
-            try:
+        try:
+            env = _get_vsscript_policy().get_environment(se.id)
+            with use_environment(env).use():
+                pyenvdict = <dict>se.pyenvdict
                 pyenvdict.update(mapToDict(vars, False))
                 return 0
-            except:
-                return 1
+        except:
+            return 1
 
 cdef public api int vpy4_initVSScript() nogil:
     with gil:

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -494,9 +494,6 @@ cdef class EnvironmentPolicyAPI:
 
     cdef cython.pymutex _lock
     cdef object _known_environments
-    # Sadly, weakref has no WeakSet.
-    # So we use a counter to fake a WeakSet.
-    cdef int _known_environments_counter
 
     def __init__(self):
         raise RuntimeError("Cannot directly instantiate this class.")
@@ -530,9 +527,7 @@ cdef class EnvironmentPolicyAPI:
         env.alive = True
 
         with self._lock:
-            counter = self._known_environments_counter
-            self._known_environments_counter += 1
-            self._known_environments[counter] = env
+            self._known_environments.add(env)
 
         return env
 
@@ -634,7 +629,9 @@ cdef class EnvironmentPolicyAPI:
 
     def unregister_policy(self):
         self.ensure_policy_matches()
-        for environment in self._known_environments.values():
+        with self._lock:
+            environments = list(self._known_environments)
+        for environment in environments:
             self.destroy_environment(environment)
         clear_policy(delay=False)
 

--- a/src/py/vapoursynth.pyi
+++ b/src/py/vapoursynth.pyi
@@ -1039,7 +1039,11 @@ class RawNode:
     def get_frame_async(self, n: int, cb: Callable[[Union[RawFrame, None], Union[Exception, None]], None]) -> None: ...
 
     def frames(
-        self, prefetch: Union[int, None] = None, backlog: Union[int, None] = None, close: bool = False
+        self,
+        prefetch: Union[int, None] = None,
+        backlog: Union[int, None] = None,
+        close: bool = False,
+        collect_garbage: bool = True,
     ) -> Iterator[RawFrame]: ...
 
     def clear_cache(self) -> None: ...
@@ -1120,7 +1124,11 @@ class VideoNode(RawNode):
     def get_frame_async(self, n: int, cb: Callable[[Union[VideoFrame, None], Union[Exception, None]], None]) -> None: ...
 
     def frames(
-        self, prefetch: Union[int, None] = None, backlog: Union[int, None] = None, close: bool = False
+        self,
+        prefetch: Union[int, None] = None,
+        backlog: Union[int, None] = None,
+        close: bool = False,
+        collect_garbage: bool = True,
     ) -> Iterator[VideoFrame]: ...
 
 #include <plugins/bound/VideoNode>
@@ -1151,7 +1159,11 @@ class AudioNode(RawNode):
     def get_frame_async(self, n: int, cb: Callable[[Union[AudioFrame, None], Union[Exception, None]], None]) -> None: ...
 
     def frames(
-        self, prefetch: Union[int, None] = None, backlog: Union[int, None] = None, close: bool = False
+        self,
+        prefetch: Union[int, None] = None,
+        backlog: Union[int, None] = None,
+        close: bool = False,
+        collect_garbage: bool = True,
     ) -> Iterator[AudioFrame]: ...
 
 #include <plugins/bound/AudioNode>


### PR DESCRIPTION
- Configured Meson and headers to support free-threaded builds (`Py_GIL_DISABLED`) without limited API (abi3t isn't supported yet), while keeping abi3 for standard Python. Bumped Cython requirement to >= 3.3.0.
- Added a `SynchronizedDict` helper (`cython.pymutex`) and locked access to environment maps, known nodes, and async frame reordering queues.
- Initialized `_vsapi` at import time to prevent lazy-init race conditions.
- Replaced manual counter / `WeakValueDictionary` with `weakref.WeakSet`.
- Added a `collect_garbage` parameter in `RawNode.frames()`. Allows to opt out of the stop-the-world `gc.collect()` when the generator exits.
- Moved `cibuildwheel` settings and wheel tests from the GitHub workflow into `pyproject.toml` (makes running locally much easier).
- Explicitly linked `threads` dependency in Meson for `libvsscript` and `vspipe` (fixes glibc < 2.34 linking).
- Updated GitHub Actions to latest versions.