### PR TITLE
add `collect_garbage` parameter in RawNode.frames()

### DIFF
--- a/doc/pythonreference.rst
+++ b/doc/pythonreference.rst
@@ -407,13 +407,14 @@ Classes and Functions
       The *prefetch* argument is only for debugging purposes and should never need to be changed.
       The *backlog* argument is only for debugging purposes and should never need to be changed.
 
-   .. py:method:: frames([prefetch=None, backlog=None, close=False])
+   .. py:method:: frames([prefetch=None, backlog=None, close=False, collect_garbage=True])
 
       Returns a generator iterator of all VideoFrames in the clip. It will render multiple frames concurrently.
 
       The *prefetch* argument defines how many frames are rendered concurrently. Is only there for debugging purposes and should never need to be changed.
       The *backlog* argument defines how many unconsumed frames (including those that did not finish rendering yet) vapoursynth buffers at most before it stops rendering additional frames. This argument is there to limit the memory this function uses storing frames.
       The *close* argument determines if the frame should be closed after each iteration step. It defaults to false to remain backward compatible.
+      The *collect_garbage* argument determines if gc.collect() should be called after each iteration step. It defaults to true to remain backward compatible.
 
    .. py:method:: clear_cache()
 

--- a/src/cython/vapoursynth.pyx
+++ b/src/cython/vapoursynth.pyx
@@ -2144,7 +2144,7 @@ cdef class RawNode(object):
             self.funcs.getFrameAsync(n, self.node, frameDoneCallback, <void *>data)
 
 
-    def frames(self, prefetch=None, backlog=None, close=False):
+    def frames(self, prefetch=None, backlog=None, close=False, collect_garbage=True):
         if prefetch is None or prefetch <= 0:
             prefetch = self.core.num_threads
 
@@ -2252,7 +2252,8 @@ cdef class RawNode(object):
 
                 fut.result().close()
 
-            gc.collect()
+            if collect_garbage:
+                gc.collect()
 
     def clear_cache(self):
         self.ensure_valid()

--- a/src/py/vapoursynth.pyi
+++ b/src/py/vapoursynth.pyi
@@ -1039,7 +1039,11 @@ class RawNode:
     def get_frame_async(self, n: int, cb: Callable[[Union[RawFrame, None], Union[Exception, None]], None]) -> None: ...
 
     def frames(
-        self, prefetch: Union[int, None] = None, backlog: Union[int, None] = None, close: bool = False
+        self,
+        prefetch: Union[int, None] = None,
+        backlog: Union[int, None] = None,
+        close: bool = False,
+        collect_garbage: bool = True,
     ) -> Iterator[RawFrame]: ...
 
     def clear_cache(self) -> None: ...
@@ -1120,7 +1124,11 @@ class VideoNode(RawNode):
     def get_frame_async(self, n: int, cb: Callable[[Union[VideoFrame, None], Union[Exception, None]], None]) -> None: ...
 
     def frames(
-        self, prefetch: Union[int, None] = None, backlog: Union[int, None] = None, close: bool = False
+        self,
+        prefetch: Union[int, None] = None,
+        backlog: Union[int, None] = None,
+        close: bool = False,
+        collect_garbage: bool = True,
     ) -> Iterator[VideoFrame]: ...
 
 #include <plugins/bound/VideoNode>
@@ -1151,7 +1159,11 @@ class AudioNode(RawNode):
     def get_frame_async(self, n: int, cb: Callable[[Union[AudioFrame, None], Union[Exception, None]], None]) -> None: ...
 
     def frames(
-        self, prefetch: Union[int, None] = None, backlog: Union[int, None] = None, close: bool = False
+        self,
+        prefetch: Union[int, None] = None,
+        backlog: Union[int, None] = None,
+        close: bool = False,
+        collect_garbage: bool = True,
     ) -> Iterator[AudioFrame]: ...
 
 #include <plugins/bound/AudioNode>


### PR DESCRIPTION
Allow to opt out the stop-the-world gc.collect when the generator exit.