### PR TITLE
Migrate cibuildhweel configuration to pyproject.toml 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,9 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - uses: astral-sh/setup-uv@v8.2.0
+    - uses: astral-sh/setup-uv@v10.0.1
 
-    - uses: pypa/cibuildwheel@v4.1.0
+    - uses: pypa/cibuildwheel@v4.2.0
       env:
         CIBW_BUILD: cp314-win_amd64 cp312-*
         CIBW_SKIP: cp312-win*
@@ -124,7 +124,7 @@ jobs:
 
     - name: Publish installer to release
       if: ${{ runner.os == 'Windows' && startsWith(github.ref, 'refs/tags/R') }}
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: installer/Compiled/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,35 +46,13 @@ jobs:
     - uses: astral-sh/setup-uv@v10.0.1
 
     - uses: pypa/cibuildwheel@v4.2.0
-      env:
-        CIBW_BUILD: cp314-win_amd64 cp312-*
-        CIBW_SKIP: cp312-win*
-        CIBW_BUILD_FRONTEND: uv
-        CIBW_CONFIG_SETTINGS_WINDOWS: setup-args=--debug setup-args=--vsenv
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13.3
-        CIBW_ENVIRONMENT_WINDOWS: CC=clang-cl CXX=clang-cl AR=llvm-lib
-        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
       with:
         output-dir: dist
-
-    - name: Fix tag
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        cd dist
-        Get-ChildItem *.whl | ForEach-Object { uvx wheel tags --remove --python-tag cp312 $_.Name }
 
     - uses: actions/upload-artifact@v7
       with:
         name: vapoursynth-${{ matrix.arch }}
         path: dist
-
-    - name: Install and run tests
-      run: |
-        pip install vapoursynth --no-index --find-links dist
-        vapoursynth config
-        vapoursynth register-install
-        vspipe --version
-        python -m unittest discover -s test -p "*test.py"
 
     # The Windows wheel just built is the same one the installer and portable
     # packages ship, so package them here instead of recompiling the wheel in a

--- a/meson.build
+++ b/meson.build
@@ -153,9 +153,10 @@ int main() {
     endif
 endif
 
+threads_dep = dependency('threads')
 deps = [
     dl_dep,
-    dependency('threads'),
+    threads_dep,
     dependency('zimg', version: '>=3.0.5'),
 ]
 
@@ -262,7 +263,7 @@ py.install_sources(
 libvsscript = library('vsscript',
     files('src/vsscript/vsscript.cpp'),
     cpp_args: ['-DPy_NO_LINK_LIB', '-DVS_CORE_EXPORTS'],
-    dependencies: [dl_dep, py_dep],
+    dependencies: [dl_dep, py_dep, threads_dep],
     gnu_symbol_visibility: 'hidden',
     include_directories: incdir,
     install: true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,32 @@ exclude = [
     "*/vsvfw.pdb",
 ]
 
+[tool.cibuildwheel]
+build-frontend = "uv"
+build = ["cp314-win_amd64", "cp312-*"]
+skip = ["cp312-win*", "*-win32"]
+test-sources = ["test"]
+test-command = [
+    "vapoursynth config",
+    "vapoursynth register-install",
+    "vspipe --version",
+    'python -m unittest discover -s test -p "*test.py"',
+]
+
+[tool.cibuildwheel.windows]
+config-settings = { setup-args = ["--debug", "--vsenv"] }
+environment = { CC = "clang-cl", CXX = "clang-cl", AR = "llvm-lib" }
+repair-wheel-command = [
+    "uvx wheel tags --remove --python-tag cp312 {wheel}",
+    'move /y "{wheel}\..\*.whl" "{dest_dir}"',
+]
+
+[tool.cibuildwheel.linux]
+test-command = 'python -m unittest discover -s test -p "*test.py"'
+
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "13.3" }
+
 [tool.ruff]
 extend-exclude = ["vapoursynth.pyi"]
 line-length = 120


### PR DESCRIPTION
- Moved cibuildwheel settings and wheel tests from the GitHub workflow into pyproject.toml (makes running locally much easier).
- Moved Windows wheel tag repair step into cibuildwheel repair-wheel-command.
- Moved tests in cibuildwheel environment
- Skipped `vspipe --version` on Linux since manylinux containers lack libpython.so.
- Explicitly linked threads dependency to libvsscript in Meson for compatibility
  with glibc < 2.34 where libpthread is separate.
- Upgraded GitHub Actions versions
